### PR TITLE
chore: change license from MIT to Apache 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.1] — 2026-03-27
+
+### License
+- Changed from MIT License to Apache License 2.0
+- Added NOTICE file as required by Apache 2.0
+- Updated pyproject.toml classifier to Apache Software License
+- Added SPDX identifiers to all Python source files
+- Rationale: Apache 2.0 includes patent retaliation clause and explicit
+  patent grant; aligns with pending patent application IDF-SULCI-2026-001
+
+### No code changes — library behaviour is unchanged
+
 ## [0.3.0] — 2026-03-25
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,114 @@
-MIT License
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 [sulci.io]
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included
+      in or attached to the work.
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work.
+
+      "Contribution" shall mean any work of authorship submitted to the
+      Licensor for inclusion in the Work.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf
+      of whom a Contribution has been received by the Licensor.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have
+      made, use, offer to sell, sell, import, and otherwise transfer the
+      Work, where such license applies only to those patent claims
+      licensable by such Contributor that are necessarily infringed by
+      their Contribution(s) alone or by combination of their
+      Contributions with the Work.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work; and
+
+      (d) If the Work includes a "NOTICE" text file, you must include
+          a readable copy of the attribution notices contained within
+          that NOTICE file.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution submitted for inclusion in the Work shall be
+      under the terms of this License.
+
+   6. Trademarks. This License does not grant permission to use the
+      trade names, trademarks, service marks, or product names of the
+      Licensor.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work on an "AS IS"
+      BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND.
+
+   8. Limitation of Liability. In no event shall any Contributor be
+      liable to You for damages arising as a result of this License
+      or out of the use or inability to use the Work.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work, You may offer acceptance of support, warranty, indemnity,
+      or other liability obligations consistent with this License.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Kathiravan Sengodan
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,13 @@
-Sulci Library — Open Source Edition
-Copyright (c) 2026 [sulci.io]
+Sulci — Context-Aware Semantic Caching Library
+Copyright 2026 Kathiravan Sengodan
 
-The sulci PyPI package (sulci-oss/ library code) is open source
-and licensed under the MIT License. See LICENSE for full terms.
+This product is licensed under the Apache License, Version 2.0.
+See the LICENSE file for full license terms.
 
-Enterprise platform features, the sulci-platform repository, and
-associated commercial services are proprietary and available under
-a separate commercial license.
+This product includes software developed at sulci.io (https://sulci.io).
 
-Contact: [legal@sulci.io]
+Patent Notice:
+One or more patent applications may cover the context-aware semantic
+caching algorithm implemented in this software (IDF-SULCI-2026-001).
+Apache 2.0 grants recipients a royalty-free patent license for use
+of this code as described in Section 3 of the Apache License.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://github.com/sulci-io/sulci-oss/actions/workflows/tests.yml/badge.svg)](https://github.com/sulci-io/sulci-oss/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/sulci)](https://pypi.org/project/sulci/)
 [![Python](https://img.shields.io/pypi/pyversions/sulci)](https://pypi.org/project/sulci/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 Sulci is a drop-in Python library that caches LLM responses by **semantic meaning**, not exact string match. When a user asks _"How do I deploy to AWS?"_ and someone else later asks _"What's the process for deploying on AWS?"_, Sulci returns the cached answer instead of calling the LLM again — saving cost and latency.
 
@@ -366,7 +366,13 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for branching model, PR process, and 
 
 ## License
 
-MIT — see [`LICENSE`](./LICENSE).
+Apache License 2.0 — see [`LICENSE`](./LICENSE).
+
+Copyright 2026 Kathiravan Sengodan.
+
+This software may be covered by one or more pending patent applications.
+The Apache 2.0 license grants you a royalty-free patent license for your
+use of this code. See Section 3 of the Apache License and the NOTICE file.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version         = "0.3.0"
+version         = "0.3.1"
 description     = "The AI native context-aware semantic cache for LLM apps — stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }
@@ -15,7 +15,7 @@ keywords        = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/__init__.py
 ================

--- a/sulci/backends/__init__.py
+++ b/sulci/backends/__init__.py
@@ -1,2 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 # sulci/backends/__init__.py
 # Backend implementations are loaded dynamically by core.py

--- a/sulci/backends/chroma.py
+++ b/sulci/backends/chroma.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/chroma.py
 ChromaDB backend — recommended for getting started.

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 # sulci/backends/cloud.py
 """
 SulciCloudBackend — routes cache operations to Sulci Cloud via HTTPS.

--- a/sulci/backends/faiss.py
+++ b/sulci/backends/faiss.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/faiss.py
 FAISS backend — fastest local option, MIT license, zero infra.

--- a/sulci/backends/milvus.py
+++ b/sulci/backends/milvus.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/milvus.py
 Milvus Lite backend — embedded vector DB, no server required.

--- a/sulci/backends/qdrant.py
+++ b/sulci/backends/qdrant.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/qdrant.py
 Qdrant backend — best performance for production.

--- a/sulci/backends/redis.py
+++ b/sulci/backends/redis.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/redis.py
 Redis backend — sub-millisecond latency, battle-tested at scale.

--- a/sulci/backends/sqlite.py
+++ b/sulci/backends/sqlite.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/backends/sqlite.py
 SQLite backend — zero infrastructure, embedded database.

--- a/sulci/context.py
+++ b/sulci/context.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/context.py
 ================

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/core.py
 ================

--- a/sulci/embeddings/__init__.py
+++ b/sulci/embeddings/__init__.py
@@ -1,2 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 # sulci/embeddings/__init__.py
 # Embedding models are loaded dynamically by core.py

--- a/sulci/embeddings/minilm.py
+++ b/sulci/embeddings/minilm.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/embeddings/minilm.py
 Local sentence-transformers embeddings — free, no API key, CPU-friendly.

--- a/sulci/embeddings/openai.py
+++ b/sulci/embeddings/openai.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
 """
 sulci/embeddings/openai.py
 OpenAI embeddings — highest quality, requires API key.


### PR DESCRIPTION
Replace MIT license with Apache License 2.0.
Add NOTICE file. Update pyproject.toml classifier. Add SPDX headers to all Python source files.
Bump version to 0.2.6.

Apache 2.0 selected for patent retaliation protection and explicit patent grant. Consistent with patent application IDF-SULCI-2026-001 filing strategy.
Ref: https://www.apache.org/licenses/LICENSE-2.0