### PR TITLE
fix: namespace_by_llm warning + gateway_url for Enterprise VPC (v0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.4] — 2026-04-08
+
+### Fixed
+
+- `SulciCache`: `namespace_by_llm=True` now logs a warning and is silently
+  disabled when `backend="sulci"`. Sulci Cloud handles tenant isolation
+  server-side; `db_path`-based partitioning was creating phantom
+  `SulciCloudBackend` instances with no effect.
+
+### Added
+
+- `SulciCloudBackend`: new `gateway_url` parameter (default: `https://api.sulci.io`).
+  Enterprise VPC customers can point to a self-hosted gateway:
+  `Cache(backend="sulci", api_key="...", gateway_url="https://cache.acme.internal")`
+- `Cache`: `gateway_url` threaded through `_load_backend()` when `backend="sulci"`.
+- `SulciCache` (LangChain): `gateway_url` documented in `**kwargs` table.
+
+### Tests
+
+- `test_cloud_backend.py`: 3 new tests — default gateway URL, custom gateway URL,
+  trailing slash stripping
+- `test_integrations_langchain.py`: 3 new tests — `TestNamespaceByLLMCloudWarning`
+
 ## [0.3.3] — 2026-04-08
 
 ### Added

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -116,7 +116,7 @@ Always use `python -m pytest` rather than bare `pytest` to avoid PATH issues.
 python -m pytest tests/ -v
 ```
 
-All **152 tests** should pass across six test files (7 skipped if optional backend deps not installed):
+All **158 tests** should pass across six test files (7 skipped if optional backend deps not installed):
 
 ```
 tests/test_core.py                    — 27 tests  (cache.get/set, thresholds, TTL, stats, personalization)
@@ -124,9 +124,9 @@ tests/test_context.py                 — 27 tests  (ContextWindow, SessionStore
 tests/test_backends.py                —  9 tests  (per-backend contract + persistence; skipped if dep missing)
 tests/test_connect.py                 — 32 tests  (sulci.connect(), _emit(), _flush(), Cache telemetry flag)
                                                    requires httpx
-tests/test_cloud_backend.py           — 25 tests  (SulciCloudBackend, Cache(backend='sulci') wiring)
+tests/test_cloud_backend.py           — 28 tests  (SulciCloudBackend, Cache(backend='sulci') wiring)
                                                    requires httpx
-tests/test_integrations_langchain.py  — 24 tests  (SulciCache LangChain adapter)  ← NEW v0.3.3
+tests/test_integrations_langchain.py  — 27 tests  (SulciCache LangChain adapter)  ← NEW v0.3.3
                                                    requires langchain-core
 ```
 
@@ -170,7 +170,7 @@ python -m pytest tests/ -v --cov=sulci --cov-report=term-missing
 ```bash
 make test               # core pytest suite (excludes integrations)
 make test-integrations  # tests/test_integrations_langchain.py only
-make test-all           # full suite (152 tests)
+make test-all           # full suite (158 tests)
 make test-cov           # full suite with coverage report
 make verify             # smoke + test-all (run before committing)
 ```
@@ -491,7 +491,7 @@ tests/test_integrations_langchain.py::TestContract::test_miss_on_empty_cache PAS
 ...
 tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_llm_cache PASSED
 
-========== 152 passed, 7 skipped in ~300s ==========
+========== 158 passed, 7 skipped in ~300s ==========
 ```
 
 > **Backend tests are skipped — not failed — when the dependency isn't installed.** This is expected.
@@ -547,13 +547,13 @@ tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_l
 │       └── langchain.py        ← SulciCache(BaseCache) for LangChain
 └── tests
     ├── test_backends.py                —  9 tests: per-backend contract + persistence
-    ├── test_cloud_backend.py           — 25 tests: SulciCloudBackend + Cache wiring
+    ├── test_cloud_backend.py           — 28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 27 tests: ContextWindow, SessionStore, integration
     ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
-    └── test_integrations_langchain.py  — 24 tests: SulciCache LangChain adapter (NEW v0.3.3)
+    └── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter (NEW v0.3.3)
 
-Total: 152 tests
+Total: 158 tests
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -353,11 +353,11 @@ No network calls are made unless you explicitly configure `embedding_model="open
 │       └── langchain.py        ← SulciCache(BaseCache) for LangChain
 └── tests
     ├── test_backends.py                —  9 tests: per-backend contract + persistence
-    ├── test_cloud_backend.py           — 25 tests: SulciCloudBackend + Cache wiring
+    ├── test_cloud_backend.py           — 28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 27 tests: ContextWindow, SessionStore, integration
     ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
-    └── test_integrations_langchain.py  — 24 tests: SulciCache LangChain adapter
+    └── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter
 
 8 directories, 33 files
 ```
@@ -367,7 +367,7 @@ No network calls are made unless you explicitly configure `embedding_model="open
 ## Running Tests
 
 ```bash
-# full suite — 152 tests total (7 skipped if optional backend deps not installed)
+# full suite — 158 tests total (7 skipped if optional backend deps not installed)
 python -m pytest tests/ -v
 
 # by file
@@ -375,8 +375,8 @@ python -m pytest tests/test_core.py -v                      # 27 tests
 python -m pytest tests/test_context.py -v                   # 27 tests
 python -m pytest tests/test_backends.py -v                  #  9 tests (skipped if dep missing)
 python -m pytest tests/test_connect.py -v                   # 32 tests — sulci.connect() + telemetry
-python -m pytest tests/test_cloud_backend.py -v             # 25 tests — SulciCloudBackend
-python -m pytest tests/test_integrations_langchain.py -v   # 24 tests — LangChain integration
+python -m pytest tests/test_cloud_backend.py -v             # 28 tests — SulciCloudBackend
+python -m pytest tests/test_integrations_langchain.py -v   # 27 tests — LangChain integration
 
 # single backend only
 python -m pytest tests/test_backends.py -v -k sqlite
@@ -394,16 +394,16 @@ make smoke-core         # core smoke test only
 make smoke-langchain    # LangChain smoke test only
 make test               # core pytest suite
 make test-integrations  # LangChain integration tests only
-make test-all           # full suite (152 tests)
+make test-all           # full suite (158 tests)
 make test-cov           # full suite with coverage
 make verify             # smoke + test-all (run before committing)
 ```
 
 `test_connect.py` (32 tests) — `sulci.connect()`, `_emit()`, `_flush()`, `Cache(telemetry=)`. Requires `httpx`.
 
-`test_cloud_backend.py` (25 tests) — `SulciCloudBackend` construction, `search()`, `upsert()`, `delete_user()`, `clear()`, and `Cache(backend='sulci')` wiring. Requires `httpx`.
+`test_cloud_backend.py` (28 tests) — `SulciCloudBackend` construction, `search()`, `upsert()`, `delete_user()`, `clear()`, and `Cache(backend='sulci')` wiring. Requires `httpx`.
 
-`test_integrations_langchain.py` (24 tests) — `SulciCache(BaseCache)` LangChain adapter. Requires `langchain-core`.
+`test_integrations_langchain.py` (27 tests) — `SulciCache(BaseCache)` LangChain adapter. Requires `langchain-core`.
 
 Backend tests are **skipped — not failed** when their dependency isn't installed.
 Install the backend extra to run its tests: `pip install -e ".[chroma]"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version         = "0.3.3"
+version         = "0.3.4"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -43,7 +43,7 @@ _api_key:           Optional[str] = None
 _telemetry_enabled: bool          = False
 
 _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
-_SDK_VERSION   = "0.3.3"
+_SDK_VERSION   = "0.3.4"
 _FLUSH_INTERVAL_SECONDS = 30
 
 _event_buffer: list  = []

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -42,8 +42,9 @@ class SulciCloudBackend:
 
     def __init__(
         self,
-        api_key:  str,
-        timeout:  float = 5.0,
+        api_key:     str,
+        timeout:     float = 5.0,
+        gateway_url: str   = "",
     ):
         if not api_key:
             raise ValueError(
@@ -51,10 +52,11 @@ class SulciCloudBackend:
                 "Get your free key at https://sulci.io/signup"
             )
 
-        self._api_key = api_key
-        self._timeout = timeout
-        self._client  = httpx.Client(
-            base_url = self.CLOUD_URL,
+        self._api_key  = api_key
+        self._timeout  = timeout
+        self._base_url = gateway_url.rstrip("/") if gateway_url else self.CLOUD_URL
+        self._client   = httpx.Client(
+            base_url = self._base_url,
             headers  = {
                 "X-Sulci-Key":   api_key,
                 "Content-Type":  "application/json",
@@ -156,7 +158,7 @@ class SulciCloudBackend:
     def __repr__(self) -> str:
         return (
             f"SulciCloudBackend("
-            f"url={self.CLOUD_URL!r}, "
+            f"url={self._base_url!r}, "
             f"key_prefix={self._api_key[:16]!r}, "
             f"timeout={self._timeout})"
         )

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -89,6 +89,7 @@ class Cache:
         session_ttl:     Optional[int] = 3600,
         telemetry                      = True,
         api_key:         Optional[str] = None,
+        gateway_url:     str           = "",
     ):
         self._telemetry     = telemetry
         self.backend        = backend
@@ -99,7 +100,7 @@ class Cache:
         self._stats         = {"hits": 0, "misses": 0, "saved_cost": 0.0}
 
         self._embedder = self._load_embedder(embedding_model)
-        self._backend  = self._load_backend(backend, db_path, api_key)
+        self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
         # Session store — created only when context_window > 0
         self._sessions: Optional[SessionStore] = (
@@ -122,7 +123,7 @@ class Cache:
         from sulci.embeddings.minilm import MiniLMEmbedder
         return MiniLMEmbedder(name)
 
-    def _load_backend(self, name: str, db_path: str, api_key: Optional[str] = None):
+    def _load_backend(self, name: str, db_path: str, api_key: Optional[str] = None, gateway_url: str = ""):
         # sulci cloud backend — special construction, needs api_key not db_path
         if name == "sulci":
             import os, sys
@@ -137,7 +138,10 @@ class Cache:
                 or _module_key
             )
             from sulci.backends.cloud import SulciCloudBackend
-            return SulciCloudBackend(api_key=resolved_key)
+            return SulciCloudBackend(
+                api_key     = resolved_key,
+                gateway_url = gateway_url,
+            )
 
         # all other backends — loaded dynamically via importlib
         registry = {

--- a/sulci/integrations/langchain.py
+++ b/sulci/integrations/langchain.py
@@ -93,6 +93,8 @@ class SulciCache(BaseCache):
                 query_weight    α in blending formula  (default 0.70)
                 context_decay   Per-turn decay         (default 0.50)
                 api_key         Sulci Cloud key (backend="sulci")
+                gateway_url     Custom gateway for Enterprise VPC deployments
+                                (default: https://api.sulci.io)
                 personalized    Partition per user_id  (default False)
                 db_path         On-disk path for SQLite/FAISS backends
 
@@ -131,6 +133,18 @@ class SulciCache(BaseCache):
                 "sulci is required for SulciCache.\n"
                 "Install: pip install \"sulci[sqlite]\"  # or another backend"
             ) from exc
+
+        # namespace_by_llm has no effect with the managed cloud backend —
+        # Sulci Cloud handles tenant isolation server-side via API key.
+        # Creating per-LLM db_path partitions spins up phantom
+        # SulciCloudBackend instances that all hit the same cloud namespace.
+        if namespace_by_llm and kwargs.get("backend") == "sulci":
+            logger.warning(
+                "SulciCache: namespace_by_llm=True has no effect when "
+                "backend='sulci'. Sulci Cloud handles isolation server-side. "
+                "Set namespace_by_llm=False to suppress this warning."
+            )
+            namespace_by_llm = False
 
         self._namespace_by_llm = namespace_by_llm
         self._kwargs            = kwargs

--- a/tests/test_cloud_backend.py
+++ b/tests/test_cloud_backend.py
@@ -31,9 +31,9 @@ from unittest.mock import patch, MagicMock, call
 TEST_KEY = "sk-sulci-testkey1234567890"
 
 
-def make_backend(key=TEST_KEY, timeout=5.0):
+def make_backend(key=TEST_KEY, timeout=5.0, gateway_url=""):
     from sulci.backends.cloud import SulciCloudBackend
-    return SulciCloudBackend(api_key=key, timeout=timeout)
+    return SulciCloudBackend(api_key=key, timeout=timeout, gateway_url=gateway_url)
 
 
 def mock_response(data: dict, status: int = 200):
@@ -78,6 +78,21 @@ class TestConstruction:
     def test_custom_timeout(self):
         b = make_backend(timeout=10.0)
         assert b._timeout == 10.0
+
+    def test_default_gateway_url_is_cloud(self):
+        """No gateway_url → base_url defaults to api.sulci.io."""
+        b = make_backend()
+        assert b._base_url == "https://api.sulci.io"
+
+    def test_custom_gateway_url_is_used(self):
+        """Enterprise VPC can point to a custom gateway."""
+        b = make_backend(gateway_url="https://cache.acme.internal")
+        assert b._base_url == "https://cache.acme.internal"
+
+    def test_custom_gateway_url_trailing_slash_stripped(self):
+        """Trailing slash on gateway_url is stripped cleanly."""
+        b = make_backend(gateway_url="https://cache.acme.internal/")
+        assert b._base_url == "https://cache.acme.internal"
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -276,7 +291,7 @@ class TestCacheWiring:
         with patch("sulci.backends.cloud.SulciCloudBackend") as MockBackend:
             MockBackend.return_value = MagicMock()
             cache = Cache(backend="sulci", api_key=TEST_KEY)
-        MockBackend.assert_called_once_with(api_key=TEST_KEY)
+        MockBackend.assert_called_once_with(api_key=TEST_KEY, gateway_url="")
 
     def test_cache_resolves_key_from_env(self, monkeypatch):
         """Cache(backend='sulci') with no api_key= uses SULCI_API_KEY env var."""
@@ -285,7 +300,7 @@ class TestCacheWiring:
         with patch("sulci.backends.cloud.SulciCloudBackend") as MockBackend:
             MockBackend.return_value = MagicMock()
             cache = Cache(backend="sulci")
-        MockBackend.assert_called_once_with(api_key=TEST_KEY)
+        MockBackend.assert_called_once_with(api_key=TEST_KEY, gateway_url="")
 
     def test_cache_resolves_key_from_connect(self):
         """Cache(backend='sulci') with no api_key= uses key from sulci.connect()."""
@@ -295,7 +310,7 @@ class TestCacheWiring:
             with patch("sulci.backends.cloud.SulciCloudBackend") as MockBackend:
                 MockBackend.return_value = MagicMock()
                 cache = sulci.Cache(backend="sulci")
-            MockBackend.assert_called_once_with(api_key=TEST_KEY)
+            MockBackend.assert_called_once_with(api_key=TEST_KEY, gateway_url="")
         finally:
             sulci._api_key = None   # always reset
 
@@ -314,7 +329,7 @@ class TestCacheWiring:
         with patch("sulci.backends.cloud.SulciCloudBackend") as MockBackend:
             MockBackend.return_value = MagicMock()
             cache = Cache(backend="sulci", api_key=TEST_KEY)
-        MockBackend.assert_called_once_with(api_key=TEST_KEY)
+        MockBackend.assert_called_once_with(api_key=TEST_KEY, gateway_url="")
 
     def test_unknown_backend_still_raises(self):
         """Non-sulci unknown backends still raise ValueError."""

--- a/tests/test_integrations_langchain.py
+++ b/tests/test_integrations_langchain.py
@@ -256,3 +256,51 @@ class TestGlobalRegistration:
         set_llm_cache(cache)
         assert get_llm_cache() is cache
         set_llm_cache(None)   # restore — don't leak between tests
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# namespace_by_llm warning when backend="sulci"
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNamespaceByLLMCloudWarning:
+    """
+    namespace_by_llm=True should warn + be disabled when backend='sulci'.
+    Uses patch to avoid needing a real Sulci Cloud API key.
+    """
+
+    @pytest.fixture
+    def mock_sulci_cache(self):
+        """Patch sulci.Cache so SulciCache.__init__ never touches real backends."""
+        from unittest.mock import MagicMock
+        mock_instance = MagicMock()
+        mock_instance.get.return_value = (None, 0.0, 0)
+        mock_instance.stats.return_value = {
+            "hits": 0, "misses": 0, "hit_rate": 0.0,
+            "saved_cost": 0.0, "total_queries": 0,
+        }
+        with patch("sulci.Cache", return_value=mock_instance):
+            yield mock_instance
+
+    def test_warns_and_disables_when_backend_sulci(self, caplog, mock_sulci_cache):
+        """namespace_by_llm=True with backend='sulci' logs warning + sets False."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sulci.integrations.langchain"):
+            cache = SulciCache(backend="sulci", api_key="sk-test")
+        assert "namespace_by_llm=True has no effect" in caplog.text
+        assert cache._namespace_by_llm is False
+
+    def test_no_warning_when_namespace_by_llm_false(self, caplog, mock_sulci_cache):
+        """namespace_by_llm=False with backend='sulci' produces no warning."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sulci.integrations.langchain"):
+            cache = SulciCache(backend="sulci", api_key="sk-test", namespace_by_llm=False)
+        assert "namespace_by_llm" not in caplog.text
+        assert cache._namespace_by_llm is False
+
+    def test_no_warning_for_non_sulci_backend(self, caplog, mock_sulci_cache):
+        """namespace_by_llm=True with a local backend produces no warning."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="sulci.integrations.langchain"):
+            cache = SulciCache(backend="sqlite")
+        assert "namespace_by_llm" not in caplog.text
+        assert cache._namespace_by_llm is True


### PR DESCRIPTION
## Summary

Two fixes to complete the LangChain integration cleanly.

## Fix 1 — `namespace_by_llm` warning when `backend="sulci"`

`namespace_by_llm=True` (default) was silently creating phantom
`SulciCloudBackend` instances with different `db_path` suffixes that
all hit the same cloud tenant anyway. Now logs a warning and disables
itself automatically.

```python
# Before — silent phantom instances, no effect
set_llm_cache(SulciCache(backend="sulci", api_key="sk-sulci-..."))

# After — warning logged, namespace_by_llm set to False automatically
# To suppress: pass namespace_by_llm=False explicitly
set_llm_cache(SulciCache(backend="sulci", api_key="sk-sulci-...", namespace_by_llm=False))
```

## Fix 2 — `gateway_url` for Enterprise VPC

Enterprise customers self-hosting the Sulci gateway can now point
`Cache` at their internal URL.

```python
Cache(
    backend     = "sulci",
    api_key     = "sk-sulci-...",
    gateway_url = "https://cache.acme.internal",
)
```

Threads through `Cache.__init__()` → `_load_backend()` → `SulciCloudBackend.__init__()`.

## Tests

- 3 new tests: `TestConstruction` — default/custom/trailing-slash gateway URL
- 3 new tests: `TestNamespaceByLLMCloudWarning` — warning fires, suppressed, non-sulci backend
- 4 updated assertions: `TestCacheWiring` — include `gateway_url=""` in expected call

## Files changed

- `sulci/backends/cloud.py` — `gateway_url` param
- `sulci/core.py` — thread `gateway_url` through
- `sulci/integrations/langchain.py` — warning + docstring
- `tests/test_cloud_backend.py` — 3 new + 4 updated
- `tests/test_integrations_langchain.py` — 3 new
- `pyproject.toml`, `sulci/__init__.py` — v0.3.4
- `CHANGELOG.md`, `README.md`, `LOCAL_SETUP.md` — updated