### PR TITLE
feat: native LlamaIndex LLM wrapper SulciCacheLLM (v0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.5] — 2026-04-09
+
+### Added
+
+- Native LlamaIndex LLM wrapper `SulciCacheLLM` — first correct LLM-level
+  semantic cache for LlamaIndex. Wraps any `LLM` subclass (OpenAI, Anthropic,
+  Ollama, HuggingFaceLLM, etc.). `complete()` and `chat()` are cached;
+  streaming passes through uncached; async methods use `run_in_executor`.
+- `sulci/integrations/llamaindex.py` — `SulciCacheLLM(LLM)` implementation
+- `pyproject.toml` — `llamaindex = ["llama-index-core>=0.10.0"]` extra
+- `smoke_test_llamaindex.py` at repo root
+
+### Tests
+
+- `tests/test_integrations_llamaindex.py` — 29 tests (TestConstruction,
+  TestComplete, TestChat, TestStreaming, TestAsync, TestStats)
+
+### Notes
+
+- GPTCache's claimed LlamaIndex integration was a broken global OpenAI API
+  patch. SulciCacheLLM uses the idiomatic `LLM` subclass pattern and works
+  with any LlamaIndex-compatible model.
+
 ## [0.3.4] — 2026-04-08
 
 ### Fixed

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,4 +1,4 @@
-# Sulci — Local Setup Guide
+# Sulci Cache — Local Setup Guide
 
 Everything you need to clone the repo, install dependencies, run tests, and verify a working local environment from scratch.
 
@@ -102,6 +102,7 @@ If you see a `ModuleNotFoundError` on a backend (e.g. `chromadb`, `faiss`), that
 extra is not installed. Install it with `pip install -e ".[backend_name]"`.
 
 If you see `ModuleNotFoundError: langchain_core`, install the langchain extra:
+
 ```bash
 pip install -e ".[langchain]"
 ```
@@ -116,7 +117,7 @@ Always use `python -m pytest` rather than bare `pytest` to avoid PATH issues.
 python -m pytest tests/ -v
 ```
 
-All **158 tests** should pass across six test files (7 skipped if optional backend deps not installed):
+All **187 tests** should pass across seven test files (7 skipped if optional backend deps not installed):
 
 ```
 tests/test_core.py                    — 27 tests  (cache.get/set, thresholds, TTL, stats, personalization)
@@ -127,6 +128,7 @@ tests/test_connect.py                 — 32 tests  (sulci.connect(), _emit(), _
 tests/test_cloud_backend.py           — 28 tests  (SulciCloudBackend, Cache(backend='sulci') wiring)
                                                    requires httpx
 tests/test_integrations_langchain.py  — 27 tests  (SulciCache LangChain adapter)  ← NEW v0.3.3
+tests/test_integrations_llamaindex.py — 29 tests  (SulciCacheLLM LlamaIndex wrapper) ← NEW v0.3.5
                                                    requires langchain-core
 ```
 
@@ -150,6 +152,7 @@ python -m pytest tests/test_cloud_backend.py -v
 
 # LangChain integration tests only
 python -m pytest tests/test_integrations_langchain.py -v
+python -m pytest tests/test_integrations_llamaindex.py -v
 
 # single backend by keyword
 python -m pytest tests/test_backends.py -v -k sqlite
@@ -170,7 +173,7 @@ python -m pytest tests/ -v --cov=sulci --cov-report=term-missing
 ```bash
 make test               # core pytest suite (excludes integrations)
 make test-integrations  # tests/test_integrations_langchain.py only
-make test-all           # full suite (158 tests)
+make test-all           # full suite (187 tests)
 make test-cov           # full suite with coverage report
 make verify             # smoke + test-all (run before committing)
 ```
@@ -429,18 +432,18 @@ python smoke_test_langchain.py
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-| ----------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `pytest: command not found` | pytest not on `PATH` | Use `python -m pytest` |
-| `zsh: no matches found: .[sqlite]` | zsh glob expansion | Use quotes: `".[sqlite]"` |
-| `ModuleNotFoundError: sulci` | Not installed | Run `pip install -e .` first |
-| `ModuleNotFoundError: chromadb` | Backend extra missing | `pip install -e ".[chroma]"` |
-| `ModuleNotFoundError: langchain_core` | LangChain extra missing | `pip install -e ".[langchain]"` |
-| `ModuleNotFoundError: httpx` | httpx not installed | `pip install httpx` — needed for test_connect.py |
-| `ValueError: not enough values to unpack` | v0.1 unpacking style | `cache.get()` returns a **3-tuple** in v0.2 — always unpack as `response, sim, ctx_depth = cache.get(...)` |
-| MiniLM takes 2–3s on first call | Model cold load | Normal — subsequent embeds run at ~14ms. Warm the model at app startup, not per-request. |
-| `git push` returns 403 | Token auth expired | `git remote set-url origin https://YOUR_USER:TOKEN@github.com/sulci-io/sulci-oss.git` |
-| `_telemetry_enabled` is True unexpectedly | connect() called elsewhere | Check if `sulci.connect()` is being called in app code or test fixtures — telemetry is opt-in only |
+| Symptom                                   | Cause                      | Fix                                                                                                        |
+| ----------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `pytest: command not found`               | pytest not on `PATH`       | Use `python -m pytest`                                                                                     |
+| `zsh: no matches found: .[sqlite]`        | zsh glob expansion         | Use quotes: `".[sqlite]"`                                                                                  |
+| `ModuleNotFoundError: sulci`              | Not installed              | Run `pip install -e .` first                                                                               |
+| `ModuleNotFoundError: chromadb`           | Backend extra missing      | `pip install -e ".[chroma]"`                                                                               |
+| `ModuleNotFoundError: langchain_core`     | LangChain extra missing    | `pip install -e ".[langchain]"`                                                                            |
+| `ModuleNotFoundError: httpx`              | httpx not installed        | `pip install httpx` — needed for test_connect.py                                                           |
+| `ValueError: not enough values to unpack` | v0.1 unpacking style       | `cache.get()` returns a **3-tuple** in v0.2 — always unpack as `response, sim, ctx_depth = cache.get(...)` |
+| MiniLM takes 2–3s on first call           | Model cold load            | Normal — subsequent embeds run at ~14ms. Warm the model at app startup, not per-request.                   |
+| `git push` returns 403                    | Token auth expired         | `git remote set-url origin https://YOUR_USER:TOKEN@github.com/sulci-io/sulci-oss.git`                      |
+| `_telemetry_enabled` is True unexpectedly | connect() called elsewhere | Check if `sulci.connect()` is being called in app code or test fixtures — telemetry is opt-in only         |
 
 ---
 
@@ -449,12 +452,12 @@ python smoke_test_langchain.py
 The core library and all tests run **without any API key**. The only things that
 require a key:
 
-| File | Key needed |
-| ------------------------------- | ------------------- |
-| `examples/anthropic_example.py` | `ANTHROPIC_API_KEY` |
-| `sulci/embeddings/openai.py` | `OPENAI_API_KEY` |
+| File                                         | Key needed                               |
+| -------------------------------------------- | ---------------------------------------- |
+| `examples/anthropic_example.py`              | `ANTHROPIC_API_KEY`                      |
+| `sulci/embeddings/openai.py`                 | `OPENAI_API_KEY`                         |
 | `sulci.connect()` / `Cache(backend="sulci")` | `SULCI_API_KEY` (Sulci Cloud — optional) |
-| All other code | None |
+| All other code                               | None                                     |
 
 The default embedding model (`minilm`) runs fully locally via `sentence-transformers`.
 No network calls are made unless you explicitly configure `embedding_model="openai"`
@@ -491,7 +494,7 @@ tests/test_integrations_langchain.py::TestContract::test_miss_on_empty_cache PAS
 ...
 tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_llm_cache PASSED
 
-========== 158 passed, 7 skipped in ~300s ==========
+========== 187 passed, 7 skipped in ~340s ==========
 ```
 
 > **Backend tests are skipped — not failed — when the dependency isn't installed.** This is expected.
@@ -551,9 +554,10 @@ tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_l
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 27 tests: ContextWindow, SessionStore, integration
     ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
-    └── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter (NEW v0.3.3)
+    ├── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter (NEW v0.3.3)
+    └── test_integrations_llamaindex.py — 29 tests: SulciCacheLLM LlamaIndex wrapper (NEW v0.3.5)
 
-Total: 158 tests
+Total: 187 tests
 ```
 
 ---
@@ -570,10 +574,10 @@ Total: 158 tests
 
 ## Branch Reference
 
-| Branch | Purpose | Status |
-|---|---|---|
-| `main` | Stable release — v0.3.3 | All work merges here via PR |
-| `feature/context-aware` | v0.2.0 context-aware library | Merged |
-| `feature/benchmark-context-aware` | v0.2.5 benchmark suite | Merged |
-| `feature/saas-onramp` | v0.3.0 cloud backend + telemetry | Merged |
-| `feat/langchain-integration` | v0.3.3 LangChain integration | Merged |
+| Branch                            | Purpose                          | Status                      |
+| --------------------------------- | -------------------------------- | --------------------------- |
+| `main`                            | Stable release — v0.3.3          | All work merges here via PR |
+| `feature/context-aware`           | v0.2.0 context-aware library     | Merged                      |
+| `feature/benchmark-context-aware` | v0.2.5 benchmark suite           | Merged                      |
+| `feature/saas-onramp`             | v0.3.0 cloud backend + telemetry | Merged                      |
+| `feat/langchain-integration`      | v0.3.3 LangChain integration     | Merged                      |

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ smoke:
 	@echo ""
 	@echo "── LangChain integration smoke test ────────────────────────────────"
 	$(PYTHON) smoke_test_langchain.py
+	@echo ""
+	@echo "── LlamaIndex integration smoke test ───────────────────────────────"
+	$(PYTHON) smoke_test_llamaindex.py	
 
 ## Run core smoke test only (no LangChain required)
 smoke-core:
@@ -21,6 +24,11 @@ smoke-core:
 ## Requires: pip install "sulci[sqlite,langchain]"
 smoke-langchain:
 	$(PYTHON) smoke_test_langchain.py
+
+## Run LlamaIndex integration smoke test only
+## Requires: pip install "sulci[sqlite,llamaindex]"
+smoke-llamaindex:
+	$(PYTHON) smoke_test_llamaindex.py	
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -35,7 +43,9 @@ test:
 
 ## Run integration tests (LangChain and any future integrations)
 test-integrations:
-	python -m pytest tests/test_integrations_langchain.py -v --tb=short
+	python -m pytest tests/test_integrations_langchain.py \
+	                tests/test_integrations_llamaindex.py \
+	                -v --tb=short
 
 ## Run all tests (core + all integrations)
 test-all:
@@ -50,6 +60,6 @@ test-cov:
 ## Full local verification: smoke tests + full test suite
 verify: smoke test-all
 
-.PHONY: smoke smoke-core smoke-langchain \
-        test test-langchain test-all test-cov \
+.PHONY: smoke smoke-core smoke-langchain smoke-llamaindex \
+        test test-integrations test-all test-cov \
         verify

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ pip install "sulci[cloud]"     # Sulci Cloud managed backend
 pip install "sulci[sqlite,langchain]"   # + LangChain integration
 ```
 
+**LlamaIndex integration:**
+
+```bash
+pip install "sulci[sqlite,llamaindex]"  # + LlamaIndex native integration
+```
+
 **Step 2 — Install your LLM SDK** (required for `cached_call` with a live model):
 
 ```bash
@@ -65,9 +71,9 @@ pip install openai              # for OpenAI
 
 ## LangChain Integration
 
-Sulci Cache is the only LangChain cache that implements context-aware lookup vector
-blending — blending prior conversation turns into the similarity lookup, not just
-matching the current prompt in isolation.
+Sulci Cache is the only LangChain cache that implements context-aware lookup
+vector blending — blending prior conversation turns into the similarity lookup,
+not just matching the current prompt in isolation.
 
 ```python
 from langchain_core.globals import set_llm_cache
@@ -87,10 +93,42 @@ Install: `pip install "sulci[sqlite,langchain]"`
 
 ---
 
-## LlamaIndex
+## LlamaIndex Integration
 
-Sulci Cache works with LlamaIndex today via the LangChain integration — no
-additional package required.
+`SulciCacheLLM` is a native LLM-level semantic cache for LlamaIndex with
+no LangChain dependency required. It wraps any LlamaIndex-compatible LLM (`OpenAI`, `Anthropic`, `Ollama`, `HuggingFaceLLM`, etc.) — `complete()` and `chat()` are cached, streaming passes through uncached, async methods use `run_in_executor`.
+
+```python
+from llama_index.core import Settings
+from llama_index.llms.openai import OpenAI
+from sulci.integrations.llamaindex import SulciCacheLLM
+
+# Stateless — drop-in for any LlamaIndex LLM
+Settings.llm = SulciCacheLLM(
+    llm       = OpenAI(model="gpt-4o"),
+    backend   = "sqlite",
+    threshold = 0.85,
+)
+
+# Context-aware — RAG chatbot / agent (+56pp hit rate in customer support)
+Settings.llm = SulciCacheLLM(
+    llm            = OpenAI(model="gpt-4o"),
+    backend        = "sqlite",
+    threshold      = 0.75,
+    context_window = 4,
+)
+
+# Managed Sulci Cloud
+Settings.llm = SulciCacheLLM(
+    llm     = OpenAI(model="gpt-4o"),
+    backend = "sulci",
+    api_key = "sk-sulci-...",
+)
+```
+
+Install: `pip install "sulci[sqlite,llamaindex]"`
+
+**Via LangChain (alternative — works today, no extra install):**
 
 ```python
 from langchain_core.globals import set_llm_cache
@@ -98,18 +136,13 @@ from sulci.integrations.langchain import SulciCache
 from llama_index.llms.langchain import LangChainLLM
 from langchain_openai import ChatOpenAI
 
-# Register Sulci Cache as the global LangChain cache
 set_llm_cache(SulciCache(backend="sqlite", context_window=4))
 
-# Use a LangChain LLM inside LlamaIndex — cache is applied transparently
 from llama_index.core import Settings
 Settings.llm = LangChainLLM(llm=ChatOpenAI(model="gpt-4o"))
 ```
 
 Install: `pip install "sulci[sqlite,langchain]" llama-index-llms-langchain langchain-openai`
-
-A native LlamaIndex LLM wrapper (`SulciCacheLLM`) with no LangChain dependency
-is on the roadmap.
 
 ---
 
@@ -350,14 +383,15 @@ No network calls are made unless you explicitly configure `embedding_model="open
 │   ├── basic_usage.py          ← stateless cache demo, no API key needed
 │   ├── context_aware.py        ← 4-demo walkthrough, fully offline
 │   └── context_aware_example.py← additional context-aware patterns
-├── pyproject.toml              ← name="sulci", version="0.3.3"
+├── pyproject.toml              ← name="sulci", version="0.3.5"
 ├── setup.py
-├── setup.sh                    ← one-shot setup: venv + install + both smoke tests
+├── setup.sh                    ← one-shot setup: venv + install + smoke tests
 ├── smoke_test.py               ← core smoke test
 ├── smoke_test_langchain.py     ← LangChain integration smoke test
+├── smoke_test_llamaindex.py    ← LlamaIndex integration smoke test
 ├── sulci
 │   ├── __init__.py             ← exports Cache, ContextWindow, SessionStore, connect()
-│   │                              _SDK_VERSION = "0.3.3"
+│   │                              _SDK_VERSION = "0.3.5"
 │   ├── backends
 │   │   ├── __init__.py         ← empty — core.py loads backends via importlib
 │   │   ├── chroma.py
@@ -374,18 +408,20 @@ No network calls are made unless you explicitly configure `embedding_model="open
 │   │   ├── __init__.py
 │   │   ├── minilm.py           ← default: all-MiniLM-L6-v2 (free, local)
 │   │   └── openai.py           ← requires OPENAI_API_KEY
-│   └── integrations            ← NEW v0.3.3
+│   └── integrations
 │       ├── __init__.py
-│       └── langchain.py        ← SulciCache(BaseCache) for LangChain
+│       ├── langchain.py        ← SulciCache(BaseCache) for LangChain  (v0.3.3)
+│       └── llamaindex.py       ← SulciCacheLLM(LLM) for LlamaIndex    (v0.3.5)
 └── tests
     ├── test_backends.py                —  9 tests: per-backend contract + persistence
     ├── test_cloud_backend.py           — 28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 27 tests: ContextWindow, SessionStore, integration
     ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
-    └── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter
+    ├── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter
+    └── test_integrations_llamaindex.py — 29 tests: SulciCacheLLM LlamaIndex wrapper
 
-8 directories, 33 files
+8 directories, 34 files
 ```
 
 ---
@@ -393,16 +429,17 @@ No network calls are made unless you explicitly configure `embedding_model="open
 ## Running Tests
 
 ```bash
-# full suite — 158 tests total (7 skipped if optional backend deps not installed)
+# full suite — 187 tests total (7 skipped if optional backend deps not installed)
 python -m pytest tests/ -v
 
 # by file
-python -m pytest tests/test_core.py -v                      # 27 tests
-python -m pytest tests/test_context.py -v                   # 27 tests
-python -m pytest tests/test_backends.py -v                  #  9 tests (skipped if dep missing)
-python -m pytest tests/test_connect.py -v                   # 32 tests — sulci.connect() + telemetry
-python -m pytest tests/test_cloud_backend.py -v             # 28 tests — SulciCloudBackend
-python -m pytest tests/test_integrations_langchain.py -v   # 27 tests — LangChain integration
+python -m pytest tests/test_core.py -v                       # 27 tests
+python -m pytest tests/test_context.py -v                    # 27 tests
+python -m pytest tests/test_backends.py -v                   #  9 tests (skipped if dep missing)
+python -m pytest tests/test_connect.py -v                    # 32 tests — sulci.connect() + telemetry
+python -m pytest tests/test_cloud_backend.py -v              # 28 tests — SulciCloudBackend
+python -m pytest tests/test_integrations_langchain.py -v     # 27 tests — LangChain integration
+python -m pytest tests/test_integrations_llamaindex.py -v    # 29 tests — LlamaIndex integration
 
 # single backend only
 python -m pytest tests/test_backends.py -v -k sqlite
@@ -415,12 +452,13 @@ python -m pytest tests/ -v --cov=sulci --cov-report=term-missing
 ### Make targets
 
 ```bash
-make smoke              # both smoke tests (smoke_test.py + smoke_test_langchain.py)
+make smoke              # all smoke tests (core + LangChain + LlamaIndex)
 make smoke-core         # core smoke test only
 make smoke-langchain    # LangChain smoke test only
+make smoke-llamaindex   # LlamaIndex smoke test only
 make test               # core pytest suite
-make test-integrations  # LangChain integration tests only
-make test-all           # full suite (158 tests)
+make test-integrations  # LangChain + LlamaIndex integration tests
+make test-all           # full suite (187 tests)
 make test-cov           # full suite with coverage
 make verify             # smoke + test-all (run before committing)
 ```
@@ -430,6 +468,8 @@ make verify             # smoke + test-all (run before committing)
 `test_cloud_backend.py` (28 tests) — `SulciCloudBackend` construction, `search()`, `upsert()`, `delete_user()`, `clear()`, and `Cache(backend='sulci')` wiring. Requires `httpx`.
 
 `test_integrations_langchain.py` (27 tests) — `SulciCache(BaseCache)` LangChain adapter. Requires `langchain-core`.
+
+`test_integrations_llamaindex.py` (29 tests) — `SulciCacheLLM(LLM)` LlamaIndex wrapper. Requires `llama-index-core`.
 
 Backend tests are **skipped — not failed** when their dependency isn't installed.
 Install the backend extra to run its tests: `pip install -e ".[chroma]"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version         = "0.3.4"
+version         = "0.3.5"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }
@@ -40,6 +40,7 @@ milvus   = ["pymilvus>=2.3.0",     "sentence-transformers>=2.2.0"]
 openai   = ["openai>=1.0.0"]
 cloud    = ["httpx>=0.27.0"]
 langchain = ["langchain-core>=0.1.0"]
+llamaindex = ["llama-index-core>=0.10.0"]
 all      = [
     "chromadb>=0.4.0",
     "qdrant-client>=1.7.0",
@@ -51,6 +52,7 @@ all      = [
     "openai>=1.0.0",
     "httpx>=0.27.0",
     "langchain-core>=0.1.0",
+    "llama-index-core>=0.10.0",
 ]
 dev = [
     "pytest>=7.0",

--- a/smoke_test_llamaindex.py
+++ b/smoke_test_llamaindex.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+smoke_test_llamaindex.py
+─────────────────────────
+Manual smoke test for SulciCacheLLM — no API keys needed.
+
+Run from repo root:
+    python smoke_test_llamaindex.py
+"""
+from typing import Any, Sequence
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+    MessageRole,
+)
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.llms.llm import LLM
+
+from sulci.integrations.llamaindex import SulciCacheLLM
+
+
+# ── Call log — external mutable list, survives Pydantic's internal copy ───────
+
+_call_log: list = []
+
+
+def reset_calls() -> None:
+    _call_log.clear()
+
+
+def call_count() -> int:
+    return len(_call_log)
+
+
+# ── Minimal mock LLM ──────────────────────────────────────────────────────────
+
+class EchoLLM(LLM):
+    """LLM that echoes the prompt and logs calls to the external call log."""
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(model_name="echo-llm")
+
+    def complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+        _call_log.append("complete")
+        return CompletionResponse(text=f"[LLM] {prompt}")
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        _call_log.append("chat")
+        last = messages[-1].content if messages else ""
+        return ChatResponse(message=ChatMessage(role=MessageRole.ASSISTANT, content=f"[LLM] {last}"))
+
+    def stream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseGen:
+        _call_log.append("stream_complete")
+        def gen():
+            yield CompletionResponse(text=f"[LLM stream] {prompt}", delta=f"[LLM stream] {prompt}")
+        return gen()
+
+    def stream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseGen:
+        _call_log.append("stream_chat")
+        def gen():
+            yield ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="[LLM stream]"),
+                delta="[LLM stream]",
+            )
+        return gen()
+
+    async def acomplete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+        return self.complete(prompt, formatted, **kwargs)
+
+    async def achat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        return self.chat(messages, **kwargs)
+
+    async def astream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseAsyncGen:
+        async def gen():
+            yield CompletionResponse(text=f"[LLM astream] {prompt}", delta=f"[LLM astream] {prompt}")
+        return gen()
+
+    async def astream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseAsyncGen:
+        async def gen():
+            yield ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="[LLM astream]"),
+                delta="[LLM astream]",
+            )
+        return gen()
+
+
+# ── Smoke test ────────────────────────────────────────────────────────────────
+
+import tempfile, os
+
+def main():
+    print("=" * 60)
+    print("SulciCacheLLM smoke test")
+    print("=" * 60)
+
+    tmp_dir = tempfile.mkdtemp(prefix="sulci_smoke_")   # ← fresh every run
+    cache = SulciCacheLLM(
+        llm       = EchoLLM(),
+        backend   = "sqlite",
+        db_path   = os.path.join(tmp_dir, "cache"),
+        threshold = 0.85,
+    )
+    
+    print(f"\n{cache!r}")
+
+    # ── Demo 1: complete() ────────────────────────────────────────────────────
+    print("\n── Demo 1: complete() ──────────────────────────────")
+    reset_calls()
+    q  = "What is semantic caching?"
+    r1 = cache.complete(q)
+    print(f"  Miss → {r1.text!r}  (LLM calls: {call_count()})")
+    assert call_count() == 1, f"Expected 1 LLM call on miss, got {call_count()}"
+
+    r2 = cache.complete(q)
+    print(f"  Hit  → {r2.text!r}  (LLM calls: {call_count()})")
+    assert call_count() == 1, f"Expected no extra LLM call on hit, got {call_count()}"
+    assert r1.text == r2.text
+    print("  ✅  complete() hit/miss correct")
+
+    # ── Demo 2: chat() ────────────────────────────────────────────────────────
+    print("\n── Demo 2: chat() ──────────────────────────────────")
+    reset_calls()
+    msg = ChatMessage(role=MessageRole.USER, content="How does context-aware caching work?")
+    c1  = cache.chat([msg])
+    print(f"  Miss → {c1.message.content!r}  (LLM calls: {call_count()})")
+    assert call_count() == 1
+
+    c2 = cache.chat([msg])
+    print(f"  Hit  → {c2.message.content!r}  (LLM calls: {call_count()})")
+    assert call_count() == 1
+    assert c1.message.content == c2.message.content
+    print("  ✅  chat() hit/miss correct")
+
+    # ── Demo 3: stream_complete() passes through ──────────────────────────────
+    print("\n── Demo 3: stream_complete() pass-through ──────────")
+    reset_calls()
+    tokens = list(cache.stream_complete("What is Sulci?"))
+    print(f"  Streamed {len(tokens)} token(s): {tokens[0].text!r}")
+    assert call_count() == 1
+    print("  ✅  stream_complete() pass-through correct")
+
+    # ── Demo 4: stream does NOT populate cache ────────────────────────────────
+    print("\n── Demo 4: stream does not populate cache ──────────")
+    reset_calls()
+    cache.complete("What is Sulci?")   # same prompt as Demo 3 — should be a miss
+    print(f"  complete() after stream_complete — LLM calls: {call_count()}")
+    assert call_count() == 1, "Stream must not write to cache"
+    print("  ✅  stream isolation correct")
+
+    # ── Demo 5: stats ─────────────────────────────────────────────────────────
+    print("\n── Demo 5: stats ───────────────────────────────────")
+    s = cache.stats()
+    print(f"  hits={s['hits']}  misses={s['misses']}  hit_rate={s['hit_rate']:.1%}")
+    print(f"\n{cache!r}")
+
+    print("\n✅  All smoke tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -43,7 +43,7 @@ _api_key:           Optional[str] = None
 _telemetry_enabled: bool          = False
 
 _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
-_SDK_VERSION   = "0.3.4"
+_SDK_VERSION   = "0.3.5"
 _FLUSH_INTERVAL_SECONDS = 30
 
 _event_buffer: list  = []

--- a/sulci/integrations/__init__.py
+++ b/sulci/integrations/__init__.py
@@ -3,13 +3,16 @@
 """
 sulci.integrations
 ──────────────────
-Optional framework adapters for Sulci.
+Optional framework adapters for Sulci Cache.
 
 Each sub-module guards its imports — if the target framework is not
 installed, importing the module raises a clear ImportError with an
 install hint. The core sulci package never depends on any framework.
 
 Available:
-    sulci.integrations.langchain  →  SulciCache(BaseCache) for LangChain
-                                      pip install "sulci[langchain]"
+    sulci.integrations.langchain   →  SulciCache(BaseCache) for LangChain
+                                       pip install "sulci[langchain]"
+
+    sulci.integrations.llamaindex  →  SulciCacheLLM(LLM) for LlamaIndex
+                                       pip install "sulci[llamaindex]"
 """

--- a/sulci/integrations/llamaindex.py
+++ b/sulci/integrations/llamaindex.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci.integrations.llamaindex
+──────────────────────────────
+Context-aware semantic cache adapter for LlamaIndex, backed by Sulci Cache.
+
+This module wraps any LlamaIndex-compatible LLM with a transparent semantic
+cache layer. Unlike the LangChain integration (which uses a global cache
+registry), LlamaIndex caching is implemented by wrapping the LLM itself —
+this is the correct and idiomatic LlamaIndex v0.10+ pattern.
+
+Usage:
+    from llama_index.core import Settings
+    from llama_index.llms.openai import OpenAI
+    from sulci.integrations.llamaindex import SulciCacheLLM
+
+    # Stateless — drop-in for any LlamaIndex LLM
+    Settings.llm = SulciCacheLLM(
+        llm       = OpenAI(model="gpt-4o"),
+        backend   = "sqlite",
+        threshold = 0.85,
+    )
+
+    # Context-aware — chatbot / agent
+    Settings.llm = SulciCacheLLM(
+        llm            = OpenAI(model="gpt-4o"),
+        backend        = "sqlite",
+        threshold      = 0.75,
+        context_window = 4,
+    )
+
+Install:
+    pip install "sulci[sqlite,llamaindex]"
+    # which installs: sulci + llama-index-core
+
+Notes:
+    - complete() and chat() are cached.
+    - stream_complete() and stream_chat() pass through uncached — streaming
+      responses are generators and cannot be reliably stored mid-stream.
+    - Async methods delegate to sync via run_in_executor — event loop never blocked.
+    - All cache errors are swallowed — a cache failure must never crash the app.
+    - Patent pending covers the context-aware blending algorithm.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# llama-index-core is optional — guard the import clearly.
+try:
+    from llama_index.core.base.llms.types import (
+        ChatMessage,
+        ChatResponse,
+        ChatResponseAsyncGen,
+        ChatResponseGen,
+        CompletionResponse,
+        CompletionResponseAsyncGen,
+        CompletionResponseGen,
+        LLMMetadata,
+        MessageRole,
+    )
+    from llama_index.core.bridge.pydantic import Field, PrivateAttr
+    from llama_index.core.llms.llm import LLM
+except ImportError as _li_err:  # pragma: no cover
+    raise ImportError(
+        "llama-index-core is required for sulci.integrations.llamaindex.\n"
+        "Install: pip install \"sulci[llamaindex]\"\n"
+        "or:      pip install llama-index-core"
+    ) from _li_err
+
+# Keys accepted by sulci.Cache — everything else forwarded to the wrapped LLM
+_SULCI_KEYS = frozenset({
+    "backend", "threshold", "embedding_model", "ttl_seconds",
+    "personalized", "db_path", "context_window", "query_weight",
+    "context_decay", "session_ttl", "api_key", "gateway_url", "telemetry",
+})
+
+
+class SulciCacheLLM(LLM):
+    """
+    Context-aware semantic cache wrapper for any LlamaIndex LLM.
+
+    Wraps ``complete()`` and ``chat()`` with a Sulci Cache lookup before
+    forwarding to the underlying LLM on a miss. Streaming calls pass
+    through uncached. All async methods delegate via ``run_in_executor``
+    so the event loop is never blocked.
+
+    Unlike stateless semantic caches, SulciCacheLLM blends prior
+    conversation turns into the similarity lookup vector when
+    ``context_window > 0`` — dramatically improving hit rates in
+    multi-turn RAG and agent workloads:
+
+    - Customer support:  32% → 88% hit rate  (+56 pp)
+    - Developer Q&A:     80% → 96% hit rate  (+16 pp)
+
+    Note: This is the first correct native LLM-level semantic cache for
+    LlamaIndex. GPTCache's claimed integration was a broken global
+    OpenAI API patch; SulciCacheLLM uses the idiomatic ``LLM`` subclass
+    pattern and works with any LlamaIndex-compatible model.
+
+    Args:
+        llm (LLM):
+            The underlying LlamaIndex LLM to wrap. Any LLM subclass works:
+            ``OpenAI``, ``Anthropic``, ``Ollama``, ``HuggingFaceLLM``, etc.
+        backend (str):
+            Sulci backend — ``"sqlite"`` | ``"chroma"`` | ``"qdrant"`` |
+            ``"faiss"`` | ``"redis"`` | ``"milvus"`` | ``"sulci"``
+            (default ``"sqlite"``).
+        threshold (float):
+            Cosine similarity cutoff 0–1 (default ``0.85``).
+        context_window (int):
+            Turns to remember per session; 0 = stateless (default).
+            Set to 4 for context-aware multi-turn caching.
+        api_key (Optional[str]):
+            Sulci Cloud key — required when ``backend="sulci"``.
+        gateway_url (str):
+            Custom gateway for Enterprise VPC deployments
+            (default: ``https://api.sulci.io``).
+
+    Examples:
+        # Stateless — drop-in replacement
+        Settings.llm = SulciCacheLLM(llm=OpenAI(model="gpt-4o"), backend="sqlite")
+
+        # Context-aware — RAG chatbot
+        Settings.llm = SulciCacheLLM(
+            llm=OpenAI(model="gpt-4o"), backend="sqlite",
+            context_window=4, threshold=0.75,
+        )
+
+        # Managed Sulci Cloud
+        Settings.llm = SulciCacheLLM(
+            llm=OpenAI(model="gpt-4o"), backend="sulci", api_key="sk-sulci-...",
+        )
+    """
+
+    # ── Public Pydantic field ─────────────────────────────────────────────────
+    # BaseLLM is Pydantic — fields must be declared with Field().
+    # The wrapped LLM is the only public field; Sulci kwargs are private.
+    llm: Any = Field(description="The underlying LlamaIndex LLM to wrap.")
+
+    # ── Private state (Pydantic PrivateAttr — not serialised) ─────────────────
+    _sulci_kwargs: dict = PrivateAttr(default_factory=dict)
+    _sulci_cache:  Any  = PrivateAttr(default=None)
+
+    def __init__(self, llm: Any, **kwargs: Any) -> None:
+        """
+        Initialise SulciCacheLLM.
+
+        Args:
+            llm:      The LlamaIndex LLM to wrap.
+            **kwargs: Sulci Cache kwargs (backend, threshold, …) plus any
+                      LLM kwargs forwarded to the parent LLM class.
+        """
+        sulci_kwargs = {k: v for k, v in kwargs.items() if k in _SULCI_KEYS}
+        llm_kwargs   = {k: v for k, v in kwargs.items() if k not in _SULCI_KEYS}
+
+        super().__init__(llm=llm, **llm_kwargs)
+
+        # Assign private attrs AFTER super().__init__() so Pydantic is set up
+        self._sulci_kwargs = sulci_kwargs
+        self._sulci_cache  = None
+
+    # ── Cache construction (lazy) ─────────────────────────────────────────────
+
+    def _get_cache(self) -> Any:
+        """Return the sulci.Cache instance, constructing it on first call."""
+        if self._sulci_cache is None:
+            try:
+                from sulci import Cache as _Cache
+            except ImportError as exc:
+                raise ImportError(
+                    "sulci is required for SulciCacheLLM.\n"
+                    "Install: pip install \"sulci[sqlite]\"  # or another backend"
+                ) from exc
+            self._sulci_cache = _Cache(**self._sulci_kwargs)
+        return self._sulci_cache
+
+    # ── LLMMetadata (delegate entirely to wrapped LLM) ────────────────────────
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        """Return the wrapped LLM's metadata unchanged."""
+        return self.llm.metadata
+
+    # ── Cache key helpers ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _last_user_message(messages: Sequence[ChatMessage]) -> str:
+        """
+        Extract the last user message as the cache key for chat calls.
+
+        Using the full message list would mean the key grows every turn
+        (system prompt + history). The last user message is the semantic
+        unit that determines the response.
+        """
+        for msg in reversed(messages):
+            if msg.role == MessageRole.USER:
+                return str(msg.content)
+        # Fallback — join all content if no user message found
+        return " ".join(str(m.content) for m in messages)
+
+    @staticmethod
+    def _pop_session_id(kwargs: dict) -> Optional[str]:
+        """Extract and remove session_id from kwargs if present."""
+        return kwargs.pop("session_id", None)
+
+    # ── Cached sync methods ───────────────────────────────────────────────────
+
+    def complete(
+        self,
+        prompt:    str,
+        formatted: bool = False,
+        **kwargs:  Any,
+    ) -> CompletionResponse:
+        """
+        Check cache first; call underlying LLM on miss.
+
+        Cache errors are swallowed — a failure must never raise to the caller.
+        """
+        session_id = self._pop_session_id(kwargs)
+        try:
+            resp, sim, depth = self._get_cache().get(prompt, session_id=session_id)
+            if resp is not None:
+                logger.debug(
+                    "sulci HIT  sim=%.3f  depth=%d  prompt=%r",
+                    sim, depth, prompt[:60],
+                )
+                return CompletionResponse(text=resp)
+        except Exception:
+            logger.warning("sulci complete() lookup error — cache miss", exc_info=True)
+
+        # Cache miss — call the real LLM
+        result = self.llm.complete(prompt, formatted=formatted, **kwargs)
+
+        try:
+            self._get_cache().set(prompt, result.text, session_id=session_id)
+            logger.debug("sulci SET  prompt=%r", prompt[:60])
+        except Exception:
+            logger.warning("sulci complete() store error — skipping", exc_info=True)
+
+        return result
+
+    def chat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """
+        Check cache first using the last user message as the cache key.
+
+        Cache errors are swallowed.
+        """
+        session_id = self._pop_session_id(kwargs)
+        key        = self._last_user_message(messages)
+
+        try:
+            resp, sim, depth = self._get_cache().get(key, session_id=session_id)
+            if resp is not None:
+                logger.debug(
+                    "sulci HIT  sim=%.3f  depth=%d  key=%r",
+                    sim, depth, key[:60],
+                )
+                return ChatResponse(
+                    message=ChatMessage(
+                        role    = MessageRole.ASSISTANT,
+                        content = resp,
+                    )
+                )
+        except Exception:
+            logger.warning("sulci chat() lookup error — cache miss", exc_info=True)
+
+        # Cache miss — call the real LLM
+        result = self.llm.chat(messages, **kwargs)
+
+        try:
+            text = result.message.content or ""
+            if text:
+                self._get_cache().set(key, text, session_id=session_id)
+                logger.debug("sulci SET  key=%r", key[:60])
+        except Exception:
+            logger.warning("sulci chat() store error — skipping", exc_info=True)
+
+        return result
+
+    # ── Pass-through streaming (uncached) ─────────────────────────────────────
+
+    def stream_complete(
+        self,
+        prompt:    str,
+        formatted: bool = False,
+        **kwargs:  Any,
+    ) -> CompletionResponseGen:
+        """
+        Streaming completion — passes through to underlying LLM uncached.
+
+        Streaming responses are generators that cannot be reliably stored
+        mid-stream. Cache the non-streaming path instead.
+        """
+        return self.llm.stream_complete(prompt, formatted=formatted, **kwargs)
+
+    def stream_chat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponseGen:
+        """Streaming chat — passes through to underlying LLM uncached."""
+        return self.llm.stream_chat(messages, **kwargs)
+
+    # ── Async methods (run_in_executor — event loop never blocked) ────────────
+
+    async def acomplete(
+        self,
+        prompt:    str,
+        formatted: bool = False,
+        **kwargs:  Any,
+    ) -> CompletionResponse:
+        """Async completion — delegates to sync complete() via executor."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, lambda: self.complete(prompt, formatted, **kwargs)
+        )
+
+    async def achat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """Async chat — delegates to sync chat() via executor."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, lambda: self.chat(messages, **kwargs)
+        )
+
+    async def astream_complete(
+        self,
+        prompt:    str,
+        formatted: bool = False,
+        **kwargs:  Any,
+    ) -> CompletionResponseAsyncGen:
+        """Async streaming completion — passes through uncached."""
+        return await self.llm.astream_complete(prompt, formatted=formatted, **kwargs)
+
+    async def astream_chat(
+        self,
+        messages: Sequence[ChatMessage],
+        **kwargs: Any,
+    ) -> ChatResponseAsyncGen:
+        """Async streaming chat — passes through uncached."""
+        return await self.llm.astream_chat(messages, **kwargs)
+
+    # ── Extras ────────────────────────────────────────────────────────────────
+
+    def stats(self) -> dict:
+        """
+        Return Sulci Cache statistics.
+
+        Keys: hits, misses, hit_rate, saved_cost, total_queries,
+              active_sessions.
+        """
+        return self._get_cache().stats()
+
+    def __repr__(self) -> str:
+        s         = self._get_cache().stats()
+        model     = getattr(self.llm.metadata, "model_name", self.llm.__class__.__name__)
+        return (
+            f"SulciCacheLLM("
+            f"llm={model!r}, "
+            f"hit_rate={s.get('hit_rate', 0):.1%}, "
+            f"hits={s.get('hits', 0)}, "
+            f"misses={s.get('misses', 0)})"
+        )

--- a/tests/test_integrations_llamaindex.py
+++ b/tests/test_integrations_llamaindex.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+tests/test_integrations_llamaindex.py
+───────────────────────────────────────
+Tests for sulci.integrations.llamaindex (SulciCacheLLM).
+
+No real LLM API keys required. All tests use a MockLLM and the SQLite
+backend with tmp_path so each test gets a fresh, isolated cache.
+
+Run from repo root (sulci-oss/):
+    python -m pytest tests/test_integrations_llamaindex.py -v
+"""
+from typing import Any, Sequence
+from unittest.mock import patch
+
+import pytest
+
+# Skip the entire module if llama-index-core is not installed.
+llamaindex_core = pytest.importorskip(
+    "llama_index.core",
+    reason="llama-index-core not installed — run: pip install llama-index-core",
+)
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+    MessageRole,
+)
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.llms.llm import LLM
+
+from sulci.integrations.llamaindex import SulciCacheLLM
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# External call log — survives Pydantic's internal copy of the LLM instance.
+# Each test resets it via the `call_log` fixture.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_call_log: list = []
+
+
+@pytest.fixture(autouse=True)
+def call_log():
+    """Reset call log before each test and return it for inspection."""
+    _call_log.clear()
+    yield _call_log
+    _call_log.clear()
+
+
+def n_calls() -> int:
+    return len(_call_log)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MockLLM — no API keys needed
+# ─────────────────────────────────────────────────────────────────────────────
+
+class MockLLM(LLM):
+    """Minimal LLM implementation for tests — returns predictable responses."""
+
+    model_name: str = Field(default="mock-llm")
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(model_name=self.model_name)
+
+    def complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+        _call_log.append("complete")
+        return CompletionResponse(text=f"complete:{prompt}")
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        _call_log.append("chat")
+        last = messages[-1].content if messages else ""
+        return ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content=f"chat:{last}")
+        )
+
+    def stream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseGen:
+        _call_log.append("stream_complete")
+        def gen():
+            yield CompletionResponse(text=f"stream:{prompt}", delta=f"stream:{prompt}")
+        return gen()
+
+    def stream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseGen:
+        _call_log.append("stream_chat")
+        def gen():
+            yield ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="stream_chat"),
+                delta="stream_chat",
+            )
+        return gen()
+
+    async def acomplete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+        return self.complete(prompt, formatted, **kwargs)
+
+    async def achat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        return self.chat(messages, **kwargs)
+
+    async def astream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseAsyncGen:
+        async def gen():
+            yield CompletionResponse(text=f"astream:{prompt}", delta=f"astream:{prompt}")
+        return gen()
+
+    async def astream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseAsyncGen:
+        async def gen():
+            yield ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="astream_chat"),
+                delta="astream_chat",
+            )
+        return gen()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def cache(tmp_path):
+    """SulciCacheLLM backed by SQLite in a fresh temp directory."""
+    return SulciCacheLLM(
+        llm       = MockLLM(),
+        backend   = "sqlite",
+        db_path   = str(tmp_path / "test_cache"),
+        threshold = 0.85,
+    )
+
+
+PROMPT   = "What is semantic caching?"
+RESPONSE = f"complete:{PROMPT}"
+USER_MSG = ChatMessage(role=MessageRole.USER, content=PROMPT)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Construction
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestConstruction:
+
+    def test_wraps_llm(self, cache):
+        assert isinstance(cache.llm, MockLLM)
+
+    def test_metadata_delegates_to_wrapped_llm(self, cache):
+        assert cache.metadata.model_name == "mock-llm"
+
+    def test_sulci_kwargs_separated_from_llm_kwargs(self, tmp_path):
+        c = SulciCacheLLM(
+            llm       = MockLLM(),
+            backend   = "sqlite",
+            db_path   = str(tmp_path / "c2"),
+            threshold = 0.75,
+        )
+        assert c._sulci_kwargs["threshold"] == 0.75
+        assert c._sulci_kwargs["backend"]   == "sqlite"
+
+    def test_cache_is_lazily_constructed(self, cache):
+        assert cache._sulci_cache is None
+
+    def test_get_cache_constructs_on_first_call(self, cache):
+        c = cache._get_cache()
+        assert c is not None
+        assert cache._sulci_cache is c
+
+    def test_get_cache_returns_same_instance(self, cache):
+        assert cache._get_cache() is cache._get_cache()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# complete() — cache hit / miss
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestComplete:
+
+    def test_miss_calls_llm(self, cache):
+        result = cache.complete(PROMPT)
+        assert result.text == RESPONSE
+        assert n_calls() == 1
+
+    def test_hit_skips_llm(self, cache):
+        cache.complete(PROMPT)          # miss — populates cache
+        _call_log.clear()
+        result = cache.complete(PROMPT) # hit — should not call LLM
+        assert result.text == RESPONSE
+        assert n_calls() == 0
+
+    def test_returns_completion_response(self, cache):
+        result = cache.complete(PROMPT)
+        assert isinstance(result, CompletionResponse)
+        assert result.text
+
+    def test_different_prompts_cached_independently(self, cache):
+        p2 = "What is a vector database?"
+        cache.complete(PROMPT)
+        cache.complete(p2)
+        assert n_calls() == 2
+
+    def test_cache_error_falls_through_to_llm(self, cache):
+        with patch.object(cache._get_cache(), "get", side_effect=RuntimeError("db error")):
+            result = cache.complete(PROMPT)
+        assert result.text == RESPONSE
+        assert n_calls() == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# chat() — cache hit / miss
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestChat:
+
+    def test_miss_calls_llm(self, cache):
+        result = cache.chat([USER_MSG])
+        assert n_calls() == 1
+        assert result.message.content == f"chat:{PROMPT}"
+
+    def test_hit_skips_llm(self, cache):
+        cache.chat([USER_MSG])
+        _call_log.clear()
+        result = cache.chat([USER_MSG])
+        assert n_calls() == 0
+        assert result.message.content == f"chat:{PROMPT}"
+
+    def test_returns_chat_response(self, cache):
+        result = cache.chat([USER_MSG])
+        assert isinstance(result, ChatResponse)
+        assert result.message.role == MessageRole.ASSISTANT
+
+    def test_uses_last_user_message_as_key(self, cache):
+        """System message prefix must not create a different cache entry."""
+        sys_msg       = ChatMessage(role=MessageRole.SYSTEM, content="You are helpful.")
+        msgs_with_sys = [sys_msg, USER_MSG]
+        cache.chat([USER_MSG])      # populate cache
+        _call_log.clear()
+        cache.chat(msgs_with_sys)   # same last user message — should hit
+        assert n_calls() == 0
+
+    def test_cache_error_falls_through_to_llm(self, cache):
+        with patch.object(cache._get_cache(), "get", side_effect=RuntimeError("db error")):
+            result = cache.chat([USER_MSG])
+        assert result.message.content == f"chat:{PROMPT}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Streaming — pass-through uncached
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStreaming:
+
+    def test_stream_complete_passes_through(self, cache):
+        gen    = cache.stream_complete(PROMPT)
+        tokens = list(gen)
+        assert len(tokens) > 0
+        assert tokens[0].text == f"stream:{PROMPT}"
+
+    def test_stream_complete_calls_llm(self, cache):
+        list(cache.stream_complete(PROMPT))
+        assert n_calls() == 1
+
+    def test_stream_chat_passes_through(self, cache):
+        gen    = cache.stream_chat([USER_MSG])
+        tokens = list(gen)
+        assert len(tokens) > 0
+
+    def test_stream_does_not_populate_cache(self, cache):
+        """Streaming must not write to cache — subsequent complete() must be a miss."""
+        list(cache.stream_complete(PROMPT))
+        _call_log.clear()
+        cache.complete(PROMPT)   # same prompt — must be a miss (not cached by stream)
+        assert n_calls() == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Async
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAsync:
+
+    @pytest.mark.asyncio
+    async def test_acomplete_miss(self, cache):
+        result = await cache.acomplete(PROMPT)
+        assert result.text == RESPONSE
+        assert n_calls() == 1
+
+    @pytest.mark.asyncio
+    async def test_acomplete_hit(self, cache):
+        await cache.acomplete(PROMPT)
+        _call_log.clear()
+        result = await cache.acomplete(PROMPT)
+        assert n_calls() == 0
+        assert result.text == RESPONSE
+
+    @pytest.mark.asyncio
+    async def test_achat_miss(self, cache):
+        result = await cache.achat([USER_MSG])
+        assert n_calls() == 1
+
+    @pytest.mark.asyncio
+    async def test_astream_complete_passes_through(self, cache):
+        gen    = await cache.astream_complete(PROMPT)
+        tokens = [r async for r in gen]
+        assert len(tokens) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stats and repr
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestStats:
+
+    def test_stats_is_dict(self, cache):
+        assert isinstance(cache.stats(), dict)
+
+    def test_stats_has_required_keys(self, cache):
+        s = cache.stats()
+        for k in ("hits", "misses", "hit_rate", "total_queries", "saved_cost"):
+            assert k in s, f"stats() missing key: {k}"
+
+    def test_repr_contains_class_name(self, cache):
+        assert "SulciCacheLLM" in repr(cache)
+
+    def test_repr_contains_model_name(self, cache):
+        assert "mock-llm" in repr(cache)
+
+    def test_repr_contains_hit_rate(self, cache):
+        assert "hit_rate" in repr(cache)


### PR DESCRIPTION
First published LLM-level semantic cache integration for LlamaIndex. GPTCache's claimed integration was a broken API monkey-patch (confirmed by maintainers in issue #361). SulciCacheLLM uses the correct LLM subclass pattern — works with any LlamaIndex-compatible model.

- sulci/integrations/llamaindex.py — SulciCacheLLM(LLM)
- complete() + chat() cached; streaming uncached; async via run_in_executor
- 29 new tests — 187 total, 7 skipped
- pyproject.toml: llamaindex = [llama-index-core>=0.10.0] extra
- Makefile: smoke-llamaindex + test-integrations updated
- README: LangChain + LlamaIndex sections, Install section updated
- LOCAL_SETUP: 158 → 187, six → seven test files