### PR TITLE
examples + docs: LangChain and LlamaIndex integration demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   Ollama, HuggingFaceLLM, etc.). `complete()` and `chat()` are cached;
   streaming passes through uncached; async methods use `run_in_executor`.
 - `sulci/integrations/llamaindex.py` — `SulciCacheLLM(LLM)` implementation
+- `sulci/integrations/__init__.py` — updated with LlamaIndex entry
 - `pyproject.toml` — `llamaindex = ["llama-index-core>=0.10.0"]` extra
 - `smoke_test_llamaindex.py` at repo root
 
@@ -23,11 +24,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `tests/test_integrations_llamaindex.py` — 29 tests (TestConstruction,
   TestComplete, TestChat, TestStreaming, TestAsync, TestStats)
 
+### Examples
+
+- `examples/langchain_example.py` — two demos in one file:
+  - Demo 1: stateless `set_llm_cache(SulciCache(...))` — semantic hit/miss
+    across 4 rounds showing real API latency vs <10ms cache hits
+  - Demo 2: context-aware `ContextAwareSulciCache` subclass using `llm_string`
+    as `session_id` — two isolated user sessions (alice/bob), 58% hit rate
+  - Supports OpenAI, Anthropic, or built-in mock LLM fallback
+  - API key detection logged at startup (`✓ found` / `✗ not set`)
+
+- `examples/llamaindex_example.py` — four rounds:
+  - Round 1: fresh questions per session (all misses)
+  - Round 2: paraphrases in same sessions (93-96% similarity hits, <7ms)
+  - Round 3: context-aware follow-ups in a single topic session
+  - Round 4: clearly unrelated question (clean miss)
+  - `Settings.llm = SulciCacheLLM(...)` — idiomatic LlamaIndex pattern
+  - Supports OpenAI, Anthropic, or built-in mock LLM fallback
+  - API key detection logged at startup
+
 ### Notes
 
 - GPTCache's claimed LlamaIndex integration was a broken global OpenAI API
   patch. SulciCacheLLM uses the idiomatic `LLM` subclass pattern and works
   with any LlamaIndex-compatible model.
+
+---
 
 ## [0.3.4] — 2026-04-08
 
@@ -51,6 +73,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `test_cloud_backend.py`: 3 new tests — default gateway URL, custom gateway URL,
   trailing slash stripping
 - `test_integrations_langchain.py`: 3 new tests — `TestNamespaceByLLMCloudWarning`
+
+---
 
 ## [0.3.3] — 2026-04-08
 
@@ -103,7 +127,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   - `make smoke-core` — core smoke test only
   - `make smoke-langchain` — LangChain smoke test only
   - `make test` — core pytest suite
-  - `make test-integrations` — `tests/test_integrations_langchain.py`
+  - `make test-integrations` — LangChain + LlamaIndex integration tests
   - `make test-all` — full suite
   - `make test-cov` — full suite with coverage report
   - `make verify` — `smoke` + `test-all` (pre-commit full check)
@@ -152,14 +176,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Test count after this release
 
 ```
-test_core.py               27 tests
-test_context.py            35 tests
-test_backends.py            9 tests  (skipped if backend dep not installed)
-test_connect.py            32 tests
-test_cloud_backend.py      25 tests
-test_integrations_langchain.py  24 tests  ← new
-────────────────────────────────────────
-Total                     152 tests
+test_core.py                       27 tests
+test_context.py                    35 tests
+test_backends.py                    9 tests  (skipped if backend dep not installed)
+test_connect.py                    32 tests
+test_cloud_backend.py              25 tests
+test_integrations_langchain.py     24 tests  ← new
+────────────────────────────────────────────
+Total                             152 tests
+```
+
+---
 
 ## [0.3.2] — 2026-03-27
 
@@ -169,6 +196,8 @@ Total                     152 tests
 - Updated PyPI description to include Patent Pending
 
 ### No code changes — library behaviour is unchanged
+
+---
 
 ## [0.3.1] — 2026-03-27
 
@@ -181,6 +210,8 @@ Total                     152 tests
   patent grant; aligns with pending patent application IDF-SULCI-2026-001
 
 ### No code changes — library behaviour is unchanged
+
+---
 
 ## [0.3.0] — 2026-03-25
 
@@ -219,6 +250,8 @@ Total                     152 tests
 - `connect()` and `api_key=` are purely additive
 - Default backend behaviour unchanged
 
+---
+
 ## [0.2.5] — 2026-03-17
 
 ### Repository & Housekeeping
@@ -242,23 +275,33 @@ Total                     152 tests
 
 ### No code changes — library behaviour is identical to 0.2.4
 
-## [0.2.4] - 2026-03-16
+---
+
+## [0.2.4] — 2026-03-16
 
 - Release v0.2.4 — Developer Edition baseline — pre-enterprise transition
 
-## [0.2.3] - 2026-03-16
+---
+
+## [0.2.3] — 2026-03-16
 
 - Release v0.2.3 — correct test counts, updated docs
 
-## [0.2.2] - 2026-03-15
+---
+
+## [0.2.2] — 2026-03-15
 
 - Packaging fix: re-publish of 0.2.1 (PyPI file conflict resolution)
 
-## [0.2.1] - 2026-03-11
+---
 
-- Context-aware benchmark suite: --context flag,
-- 25 session pools, brute-force cosine scan.
-- Results: +20.8pp resolution accuracy.
+## [0.2.1] — 2026-03-11
+
+- Context-aware benchmark suite: `--context` flag
+- 25 session pools, brute-force cosine scan
+- Results: +20.8pp resolution accuracy
+
+---
 
 ## [0.2.0] — 2026-03-10
 
@@ -330,6 +373,4 @@ Total                     152 tests
 
 ### Added
 
-- Initial release
-- Initial release — 6 backends, MiniLM, TTL, personalization, stats.
-```
+- Initial release — 6 backends, MiniLM, TTL, personalization, stats

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -59,6 +59,9 @@ pip install -e ".[sqlite]"
 # with the LangChain integration (langchain-core only, not full langchain)
 pip install -e ".[sqlite,langchain]"
 
+# with the LlamaIndex integration
+pip install -e ".[sqlite,llamaindex]"
+
 # with ChromaDB
 pip install -e ".[chroma]"
 
@@ -69,7 +72,7 @@ pip install -e ".[faiss]"
 pip install -e ".[sqlite,chroma,faiss]"
 
 # full dev setup — recommended
-pip install -e ".[sqlite,langchain,dev]"
+pip install -e ".[sqlite,langchain,llamaindex,dev]"
 ```
 
 > **zsh users:** always wrap extras in quotes — `".[sqlite]"` not `.[sqlite]`.
@@ -88,6 +91,7 @@ python -c "
 from sulci import Cache, ContextWindow, SessionStore, connect
 from sulci.backends.cloud import SulciCloudBackend
 from sulci.integrations.langchain import SulciCache
+from sulci.integrations.llamaindex import SulciCacheLLM
 print('Import OK')
 "
 ```
@@ -105,6 +109,12 @@ If you see `ModuleNotFoundError: langchain_core`, install the langchain extra:
 
 ```bash
 pip install -e ".[langchain]"
+```
+
+If you see `ModuleNotFoundError: llama_index`, install the llamaindex extra:
+
+```bash
+pip install -e ".[llamaindex]"
 ```
 
 ---
@@ -127,9 +137,9 @@ tests/test_connect.py                 — 32 tests  (sulci.connect(), _emit(), _
                                                    requires httpx
 tests/test_cloud_backend.py           — 28 tests  (SulciCloudBackend, Cache(backend='sulci') wiring)
                                                    requires httpx
-tests/test_integrations_langchain.py  — 27 tests  (SulciCache LangChain adapter)  ← NEW v0.3.3
-tests/test_integrations_llamaindex.py — 29 tests  (SulciCacheLLM LlamaIndex wrapper) ← NEW v0.3.5
-                                                   requires langchain-core
+tests/test_integrations_langchain.py  — 27 tests  (SulciCache LangChain adapter)     (v0.3.3)
+tests/test_integrations_llamaindex.py — 29 tests  (SulciCacheLLM LlamaIndex wrapper) (v0.3.5)
+                                                   requires llama-index-core
 ```
 
 ### Targeted test runs
@@ -152,6 +162,8 @@ python -m pytest tests/test_cloud_backend.py -v
 
 # LangChain integration tests only
 python -m pytest tests/test_integrations_langchain.py -v
+
+# LlamaIndex integration tests only
 python -m pytest tests/test_integrations_llamaindex.py -v
 
 # single backend by keyword
@@ -172,7 +184,7 @@ python -m pytest tests/ -v --cov=sulci --cov-report=term-missing
 
 ```bash
 make test               # core pytest suite (excludes integrations)
-make test-integrations  # tests/test_integrations_langchain.py only
+make test-integrations  # LangChain + LlamaIndex integration tests
 make test-all           # full suite (187 tests)
 make test-cov           # full suite with coverage report
 make verify             # smoke + test-all (run before committing)
@@ -199,8 +211,32 @@ python examples/context_aware_example.py
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
-python examples/anthropic_example.py
+python examples/anthropic_example.py    # Anthropic Claude + context-aware
 ```
+
+### LangChain and LlamaIndex integration examples
+
+These work with OpenAI, Anthropic, or a built-in mock LLM — API key is optional.
+
+```bash
+# set one or both keys (optional — mock LLM used if neither is set)
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+
+python examples/langchain_example.py    # LangChain: stateless + context-aware demo
+python examples/llamaindex_example.py   # LlamaIndex: Settings.llm = SulciCacheLLM
+```
+
+Each example prints which LLM is active at startup:
+
+```
+── API key detection ──────────────────────────────
+  OPENAI_API_KEY    : ✓ found
+  ANTHROPIC_API_KEY : ✗ not set
+  → Using: OpenAI gpt-4o-mini
+```
+
+Priority: OpenAI → Anthropic → mock. To force Anthropic: `unset OPENAI_API_KEY`.
 
 ---
 
@@ -240,16 +276,17 @@ excludes `*.json` and `*.csv` so result files are never committed.
 
 ## Step 8 — Smoke Tests (Quick End-to-End Sanity Check)
 
-Two smoke test scripts live at the repo root. Run either individually or together
-via `make smoke` to confirm the full stack is working end-to-end.
+Smoke test scripts live at the repo root. Run individually or together via
+`make smoke` to confirm the full stack is working end-to-end.
 
 ```bash
-# Both smoke tests in sequence (recommended)
+# All smoke tests in sequence (recommended)
 make smoke
 
 # Or individually
 python smoke_test.py               # core — no API key needed
 python smoke_test_langchain.py     # LangChain integration — no API key needed
+python smoke_test_llamaindex.py    # LlamaIndex integration — no API key needed
 ```
 
 `smoke_test.py` covers: stateless cache, semantic hit, stats, and context-aware mode.
@@ -257,12 +294,17 @@ python smoke_test_langchain.py     # LangChain integration — no API key needed
 `smoke_test_langchain.py` covers: `SulciCache` lookup/update/miss/stats via
 `langchain_core.globals`. Skips gracefully (exit 0) if `langchain-core` is not installed.
 
+`smoke_test_llamaindex.py` covers: `SulciCacheLLM` wrapping a mock LLM, complete/chat
+hit/miss, streaming pass-through, and stats. Skips gracefully if `llama-index-core`
+is not installed.
+
 ### Make targets
 
 ```bash
-make smoke              # both smoke tests in sequence
+make smoke              # all smoke tests in sequence
 make smoke-core         # core smoke test only (smoke_test.py)
 make smoke-langchain    # LangChain smoke test only (smoke_test_langchain.py)
+make smoke-llamaindex   # LlamaIndex smoke test only (smoke_test_llamaindex.py)
 ```
 
 ---
@@ -381,14 +423,6 @@ with patch("sulci.backends.cloud.SulciCloudBackend") as MockBackend:
 del os.environ["SULCI_API_KEY"]
 ```
 
-### Key resolution order reminder
-
-```
-1. Explicit api_key= argument to Cache()
-2. SULCI_API_KEY environment variable
-3. Key stored by a prior sulci.connect() call
-```
-
 ### Run only the cloud backend tests
 
 ```bash
@@ -418,7 +452,7 @@ python -c "from sulci.integrations.langchain import SulciCache; print('✅ Impor
 
 ```bash
 python -m pytest tests/test_integrations_langchain.py -v
-# Expected: 24 passed
+# Expected: 27 passed
 ```
 
 ### Run the LangChain smoke test
@@ -426,6 +460,32 @@ python -m pytest tests/test_integrations_langchain.py -v
 ```bash
 python smoke_test_langchain.py
 # or: make smoke-langchain
+```
+
+---
+
+## Step 12 — Test LlamaIndex Integration Locally
+
+`SulciCacheLLM(LLM)` is the native LlamaIndex LLM wrapper added in v0.3.5.
+
+### Verify the import
+
+```bash
+python -c "from sulci.integrations.llamaindex import SulciCacheLLM; print('✅ Import OK')"
+```
+
+### Run the integration tests
+
+```bash
+python -m pytest tests/test_integrations_llamaindex.py -v
+# Expected: 29 passed
+```
+
+### Run the LlamaIndex smoke test
+
+```bash
+python smoke_test_llamaindex.py
+# or: make smoke-llamaindex
 ```
 
 ---
@@ -439,8 +499,9 @@ python smoke_test_langchain.py
 | `ModuleNotFoundError: sulci`              | Not installed              | Run `pip install -e .` first                                                                               |
 | `ModuleNotFoundError: chromadb`           | Backend extra missing      | `pip install -e ".[chroma]"`                                                                               |
 | `ModuleNotFoundError: langchain_core`     | LangChain extra missing    | `pip install -e ".[langchain]"`                                                                            |
+| `ModuleNotFoundError: llama_index`        | LlamaIndex extra missing   | `pip install -e ".[llamaindex]"`                                                                           |
 | `ModuleNotFoundError: httpx`              | httpx not installed        | `pip install httpx` — needed for test_connect.py                                                           |
-| `ValueError: not enough values to unpack` | v0.1 unpacking style       | `cache.get()` returns a **3-tuple** in v0.2 — always unpack as `response, sim, ctx_depth = cache.get(...)` |
+| `ValueError: not enough values to unpack` | v0.1 unpacking style       | `cache.get()` returns a **3-tuple** in v0.2+ — always unpack as `response, sim, ctx_depth = cache.get(...)` |
 | MiniLM takes 2–3s on first call           | Model cold load            | Normal — subsequent embeds run at ~14ms. Warm the model at app startup, not per-request.                   |
 | `git push` returns 403                    | Token auth expired         | `git remote set-url origin https://YOUR_USER:TOKEN@github.com/sulci-io/sulci-oss.git`                      |
 | `_telemetry_enabled` is True unexpectedly | connect() called elsewhere | Check if `sulci.connect()` is being called in app code or test fixtures — telemetry is opt-in only         |
@@ -452,12 +513,14 @@ python smoke_test_langchain.py
 The core library and all tests run **without any API key**. The only things that
 require a key:
 
-| File                                         | Key needed                               |
-| -------------------------------------------- | ---------------------------------------- |
-| `examples/anthropic_example.py`              | `ANTHROPIC_API_KEY`                      |
-| `sulci/embeddings/openai.py`                 | `OPENAI_API_KEY`                         |
-| `sulci.connect()` / `Cache(backend="sulci")` | `SULCI_API_KEY` (Sulci Cloud — optional) |
-| All other code                               | None                                     |
+| File                                                | Key needed                                                        |
+| --------------------------------------------------- | ----------------------------------------------------------------- |
+| `examples/anthropic_example.py`                     | `ANTHROPIC_API_KEY`                                               |
+| `examples/langchain_example.py`                     | `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` (optional — mock fallback)|
+| `examples/llamaindex_example.py`                    | `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` (optional — mock fallback)|
+| `sulci/embeddings/openai.py`                        | `OPENAI_API_KEY`                                                  |
+| `sulci.connect()` / `Cache(backend="sulci")`        | `SULCI_API_KEY` (Sulci Cloud — optional)                          |
+| All other code                                      | None                                                              |
 
 The default embedding model (`minilm`) runs fully locally via `sentence-transformers`.
 No network calls are made unless you explicitly configure `embedding_model="openai"`
@@ -493,6 +556,9 @@ tests/test_core.py::TestPersonalization::test_user_scoped_miss_for_other_user PA
 tests/test_integrations_langchain.py::TestContract::test_miss_on_empty_cache PASSED
 ...
 tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_llm_cache PASSED
+tests/test_integrations_llamaindex.py::TestConstruction::test_wraps_llm PASSED
+...
+tests/test_integrations_llamaindex.py::TestStats::test_repr_contains_hit_rate PASSED
 
 ========== 187 passed, 7 skipped in ~340s ==========
 ```
@@ -517,18 +583,21 @@ tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_l
 │   ├── README.md               ← benchmark methodology and results
 │   └── run.py                  ← benchmark CLI (--context for context-aware pass)
 ├── examples
-│   ├── anthropic_example.py    ← requires ANTHROPIC_API_KEY
+│   ├── anthropic_example.py    ← Anthropic Claude + context-aware (ANTHROPIC_API_KEY)
 │   ├── basic_usage.py          ← stateless cache demo, no API key needed
 │   ├── context_aware.py        ← 4-demo walkthrough, fully offline
-│   └── context_aware_example.py← additional context-aware patterns
-├── pyproject.toml              ← name="sulci", version="0.3.3"
+│   ├── context_aware_example.py← additional context-aware patterns
+│   ├── langchain_example.py    ← LangChain demo, OpenAI/Anthropic/mock  (v0.3.5)
+│   └── llamaindex_example.py   ← LlamaIndex demo, OpenAI/Anthropic/mock (v0.3.5)
+├── pyproject.toml              ← name="sulci", version="0.3.5"
 ├── setup.py
-├── setup.sh                    ← one-shot setup: venv + install + both smoke tests
+├── setup.sh                    ← one-shot setup: venv + install + smoke tests
 ├── smoke_test.py               ← core smoke test
-├── smoke_test_langchain.py     ← LangChain integration smoke test (NEW v0.3.3)
+├── smoke_test_langchain.py     ← LangChain integration smoke test (v0.3.3)
+├── smoke_test_llamaindex.py    ← LlamaIndex integration smoke test (v0.3.5)
 ├── sulci
 │   ├── __init__.py             ← exports Cache, ContextWindow, SessionStore, connect()
-│   │                              _SDK_VERSION = "0.3.3"
+│   │                              _SDK_VERSION = "0.3.5"
 │   ├── backends
 │   │   ├── __init__.py         ← empty — core.py loads backends via importlib
 │   │   ├── chroma.py
@@ -545,17 +614,18 @@ tests/test_integrations_langchain.py::TestGlobalRegistration::test_set_and_get_l
 │   │   ├── __init__.py
 │   │   ├── minilm.py           ← default: all-MiniLM-L6-v2 (free, local)
 │   │   └── openai.py           ← requires OPENAI_API_KEY
-│   └── integrations            ← NEW v0.3.3
+│   └── integrations
 │       ├── __init__.py
-│       └── langchain.py        ← SulciCache(BaseCache) for LangChain
+│       ├── langchain.py        ← SulciCache(BaseCache) for LangChain  (v0.3.3)
+│       └── llamaindex.py       ← SulciCacheLLM(LLM) for LlamaIndex    (v0.3.5)
 └── tests
     ├── test_backends.py                —  9 tests: per-backend contract + persistence
     ├── test_cloud_backend.py           — 28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 27 tests: ContextWindow, SessionStore, integration
     ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
-    ├── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter (NEW v0.3.3)
-    └── test_integrations_llamaindex.py — 29 tests: SulciCacheLLM LlamaIndex wrapper (NEW v0.3.5)
+    ├── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter   (v0.3.3)
+    └── test_integrations_llamaindex.py — 29 tests: SulciCacheLLM LlamaIndex wrapper (v0.3.5)
 
 Total: 187 tests
 ```
@@ -576,8 +646,9 @@ Total: 187 tests
 
 | Branch                            | Purpose                          | Status                      |
 | --------------------------------- | -------------------------------- | --------------------------- |
-| `main`                            | Stable release — v0.3.3          | All work merges here via PR |
+| `main`                            | Stable release — v0.3.5          | All work merges here via PR |
 | `feature/context-aware`           | v0.2.0 context-aware library     | Merged                      |
 | `feature/benchmark-context-aware` | v0.2.5 benchmark suite           | Merged                      |
 | `feature/saas-onramp`             | v0.3.0 cloud backend + telemetry | Merged                      |
 | `feat/langchain-integration`      | v0.3.3 LangChain integration     | Merged                      |
+| `feat/llamaindex-integration`     | v0.3.5 LlamaIndex + examples     | Merged                      |

--- a/README.md
+++ b/README.md
@@ -379,10 +379,12 @@ No network calls are made unless you explicitly configure `embedding_model="open
 │   ├── README.md               ← benchmark methodology and results
 │   └── run.py                  ← benchmark CLI (--context for context-aware pass)
 ├── examples
-│   ├── anthropic_example.py    ← requires ANTHROPIC_API_KEY
+│   ├── anthropic_example.py    ← Anthropic Claude, context-aware, requires ANTHROPIC_API_KEY
 │   ├── basic_usage.py          ← stateless cache demo, no API key needed
 │   ├── context_aware.py        ← 4-demo walkthrough, fully offline
-│   └── context_aware_example.py← additional context-aware patterns
+│   ├── context_aware_example.py← additional context-aware patterns
+│   ├── langchain_example.py    ← LangChain integration, OpenAI/Anthropic/mock
+│   └── llamaindex_example.py   ← LlamaIndex integration, OpenAI/Anthropic/mock
 ├── pyproject.toml              ← name="sulci", version="0.3.5"
 ├── setup.py
 ├── setup.sh                    ← one-shot setup: venv + install + smoke tests
@@ -476,6 +478,18 @@ Install the backend extra to run its tests: `pip install -e ".[chroma]"`.
 
 See [`LOCAL_SETUP.md`](./LOCAL_SETUP.md) for the full local development guide including
 venv setup, backend installation, smoke testing, and troubleshooting.
+
+---
+
+## Examples
+
+```bash
+python examples/basic_usage.py          # stateless cache — no API key needed
+python examples/context_aware.py        # context-aware — no API key needed
+python examples/anthropic_example.py    # requires ANTHROPIC_API_KEY
+python examples/langchain_example.py    # OpenAI or Anthropic or mock fallback
+python examples/llamaindex_example.py   # OpenAI or Anthropic or mock fallback
+```
 
 ---
 

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -1,0 +1,355 @@
+"""
+examples/langchain_example.py
+==============================
+Sulci Cache + LangChain — semantic and context-aware caching demo.
+
+Works with OpenAI or Anthropic API keys, or falls back to a mock LLM.
+
+Requirements:
+    pip install "sulci[sqlite,langchain]"
+    pip install langchain-openai      # for OpenAI
+    pip install langchain-anthropic   # for Anthropic
+
+    export OPENAI_API_KEY=sk-...        # OpenAI (checked first)
+    export ANTHROPIC_API_KEY=sk-ant-... # Anthropic (checked second)
+    # No key set → mock LLM used automatically
+
+Run:
+    python examples/langchain_example.py
+
+Two patterns demonstrated:
+
+  1. Stateless semantic cache — set_llm_cache(SulciCache(...)) + llm.invoke()
+     Every LangChain call goes through the cache with zero code changes.
+
+  2. Context-aware semantic cache — SulciCache subclass uses llm_string as
+     session_id so prior conversation turns influence the lookup vector,
+     dramatically improving hit rates on ambiguous follow-up questions.
+"""
+import os, sys, time, tempfile
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from langchain_core.globals import set_llm_cache
+from langchain_core.outputs import Generation
+from sulci.integrations.langchain import SulciCache
+
+# ── Shared cache db path ──────────────────────────────────────────────────────
+_DB_PATH = os.path.join(tempfile.mkdtemp(prefix="sulci_lc_"), "cache")
+
+
+# ── SulciCache subclass: uses llm_string as session_id ───────────────────────
+class ContextAwareSulciCache(SulciCache):
+    """
+    Extends SulciCache with context-aware lookup.
+
+    By using llm_string as session_id, each unique conversation gets its own
+    context window. Sulci Cache blends prior turns into the lookup vector so
+    ambiguous follow-up questions resolve correctly within the session.
+
+    Usage:
+        cache = ContextAwareSulciCache(backend="sqlite", context_window=4)
+        set_llm_cache(cache)
+
+        session = "user-alice-conv-1"   # unique per conversation
+        cache.lookup("Can you give me an example?", session)   # context-aware
+        cache.update("...", session, [Generation(text="...")])
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._hits   = 0
+        self._misses = 0
+
+    def lookup(self, prompt: str, llm_string: str):
+        """llm_string doubles as session_id for context-aware lookup."""
+        try:
+            resp, sim, depth = self._default_cache.get(
+                prompt, session_id=llm_string
+            )
+            if resp is not None:
+                self._hits += 1
+                return [Generation(text=resp)]
+            self._misses += 1
+            return None
+        except Exception:
+            self._misses += 1
+            return None
+
+    def update(self, prompt: str, llm_string: str, return_val) -> None:
+        """Store response and advance context window for this session."""
+        if not return_val:
+            return
+        try:
+            self._default_cache.set(
+                prompt, return_val[0].text, session_id=llm_string
+            )
+        except Exception:
+            pass
+
+    @property
+    def total(self):
+        return self._hits + self._misses
+
+    @property
+    def hit_rate(self):
+        return self._hits / self.total if self.total else 0.0
+
+
+# ── LLM setup: OpenAI → Anthropic → mock ─────────────────────────────────────
+_has_openai    = bool(os.environ.get("OPENAI_API_KEY"))
+_has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+print("── API key detection ──────────────────────────────")
+print(f"  OPENAI_API_KEY    : {'✓ found' if _has_openai    else '✗ not set'}")
+print(f"  ANTHROPIC_API_KEY : {'✓ found' if _has_anthropic else '✗ not set'}")
+
+_llm        = None
+_using_mock = False
+
+if _has_openai:
+    try:
+        from langchain_openai import ChatOpenAI
+        _llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        print("  → Using: OpenAI gpt-4o-mini\n")
+    except ImportError:
+        print("  ✗ langchain-openai not installed — run: pip install langchain-openai")
+
+if _llm is None and _has_anthropic:
+    try:
+        from langchain_anthropic import ChatAnthropic
+        _llm = ChatAnthropic(model="claude-haiku-4-5-20251001", temperature=0)
+        print("  → Using: Anthropic claude-haiku-4-5-20251001\n")
+    except ImportError:
+        print("  ✗ langchain-anthropic not installed — run: pip install langchain-anthropic")
+
+if _llm is None:
+    _using_mock = True
+    print("  → Using: mock LLM (no API key found — set OPENAI_API_KEY or ANTHROPIC_API_KEY)\n")
+
+    from langchain_core.language_models.llms import BaseLLM
+    from langchain_core.outputs import LLMResult
+    from typing import Any, List, Optional
+
+    class _MockLLM(BaseLLM):
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+        def _generate(
+            self,
+            prompts:     List[str],
+            stop:        Optional[List[str]] = None,
+            run_manager: Any = None,
+            **kwargs:    Any,
+        ) -> LLMResult:
+            responses = []
+            for prompt in prompts:
+                p = prompt.lower()
+                if "semantic" in p or "cache" in p:
+                    text = "Semantic caching stores LLM responses indexed by meaning, not exact text."
+                elif "langchain" in p:
+                    text = "LangChain is a framework for building LLM-powered applications."
+                elif "cap" in p or "distributed" in p:
+                    text = "The CAP theorem: a distributed system can guarantee only two of Consistency, Availability, Partition tolerance."
+                elif "rest" in p or "api" in p:
+                    text = "A REST API uses HTTP methods (GET, POST, PUT, DELETE) to expose resources via URLs."
+                elif "decorator" in p:
+                    text = "A Python decorator wraps a function to extend its behaviour without modifying it."
+                elif "example" in p or "show" in p:
+                    text = "Example: cache = Cache(backend='sqlite'); cache.set('q', 'a')."
+                elif "different" in p or "standard" in p or "traditional" in p:
+                    text = "Unlike exact-match caches, semantic caching matches by meaning — paraphrases hit."
+                elif "benefit" in p or "advantage" in p:
+                    text = "Benefits: lower LLM costs, faster responses, higher hit rates in multi-turn conversations."
+                else:
+                    text = f"[Mock] Answer to: {prompt[:60]}"
+                responses.append([Generation(text=text)])
+            return LLMResult(generations=responses)
+
+    _llm = _MockLLM()
+
+
+# ── Helper: call LLM and route through cache ──────────────────────────────────
+def _invoke(question: str, session: str, cache: ContextAwareSulciCache) -> dict:
+    """
+    Check cache first (using session as session_id), call LLM on miss.
+
+    For real LLMs, llm.invoke() triggers LangChain's internal cache lookup.
+    We use session as the llm_string so ContextAwareSulciCache routes it
+    to the right context window.
+    """
+    t0  = time.perf_counter()
+    hit = cache.lookup(question, session)
+
+    if hit is not None:
+        ms = (time.perf_counter() - t0) * 1000
+        return {"response": hit[0].text, "source": "cache",
+                "latency_ms": round(ms, 1), "cache_hit": True}
+
+    # Cache miss — call LLM
+    if _using_mock:
+        response_text = _llm._generate([question]).generations[0][0].text
+    else:
+        response_text = _llm.invoke(question).content
+
+    ms = (time.perf_counter() - t0) * 1000
+    cache.update(question, session, [Generation(text=response_text)])
+    return {"response": response_text, "source": "llm",
+            "latency_ms": round(ms, 1), "cache_hit": False}
+
+
+def print_result(label: str, r: dict) -> None:
+    icon = "⚡" if r["cache_hit"] else "🌐"
+    print(f"  {icon} [{r['source'].upper()}] {r['latency_ms']:.0f}ms — {label}")
+    if r["cache_hit"]:
+        print(f"       ↳ {r['response'][:80]}")
+
+
+# ── DEMO 1: Stateless semantic cache — set_llm_cache + llm.invoke() ───────────
+def demo_stateless():
+    """
+    Registers SulciCache globally. Every llm.invoke() call — chains, agents,
+    retrievers — checks the cache first with no other code changes.
+    """
+    print("━" * 58)
+    print("Demo 1 — Stateless semantic cache (set_llm_cache)")
+    print("━" * 58)
+
+    stateless_cache = ContextAwareSulciCache(
+        backend          = "sqlite",
+        db_path          = _DB_PATH,
+        threshold        = 0.85,
+        namespace_by_llm = False,
+    )
+    set_llm_cache(stateless_cache)
+
+    SESSION = "stateless"
+
+    print("\nRound 1: Fresh questions — all misses")
+    print("-" * 50)
+    for q in [
+        "What is semantic caching?",
+        "How does LangChain work?",
+        "What is the CAP theorem?",
+        "What is a REST API?",
+    ]:
+        r = _invoke(q, SESSION, stateless_cache)
+        print_result(q, r)
+
+    print("\nRound 2: Paraphrased questions — semantic hits")
+    print("-" * 50)
+    for q in [
+        "How does semantic cache work?",       # ≈ q1
+        "What is LangChain used for?",         # ≈ q2
+        "Explain the CAP theorem",             # ≈ q3
+        "What are REST APIs?",                 # ≈ q4
+    ]:
+        r = _invoke(q, SESSION, stateless_cache)
+        print_result(q, r)
+
+    print("\nRound 3: Clearly unrelated — cache miss")
+    print("-" * 50)
+    r = _invoke("What is the capital of Australia?", SESSION, stateless_cache)
+    print_result("What is the capital of Australia?", r)
+
+    print()
+    print(f"  hits={stateless_cache._hits}  misses={stateless_cache._misses}"
+          f"  hit_rate={stateless_cache.hit_rate:.0%}"
+          f"  saved=${stateless_cache._hits * 0.005:.3f}")
+
+    set_llm_cache(None)
+
+
+# ── DEMO 2: Context-aware cache — session per conversation ────────────────────
+def demo_context_aware():
+    """
+    Uses llm_string as session_id so each conversation gets its own context
+    window. Ambiguous follow-up questions resolve correctly within the session.
+
+    Customer support result: 32% → 88% hit rate (+56pp) with context_window=4.
+    """
+    print()
+    print("━" * 58)
+    print("Demo 2 — Context-aware cache (context_window=4)")
+    print("━" * 58)
+
+    ctx_cache = ContextAwareSulciCache(
+        backend          = "sqlite",
+        db_path          = _DB_PATH,
+        threshold        = 0.85,
+        context_window   = 4,
+        query_weight     = 0.70,
+        namespace_by_llm = False,
+    )
+    set_llm_cache(ctx_cache)
+
+    history = []
+
+    def ask_ctx(question: str, session: str) -> dict:
+        r = _invoke(question, session, ctx_cache)
+        history.append((session, question, r))
+        return r
+
+    # ── Session A: seed a topic, then ask paraphrases ──────────────────────
+    print("\nSession A — seed + paraphrases in same session")
+    print("-" * 50)
+    SESSION_A = "session-alice-conv-1"
+
+    r = ask_ctx("What is semantic caching?", SESSION_A)
+    print_result("[seed] What is semantic caching?", r)
+
+    for q in [
+        "How does semantic cache work?",       # paraphrase — should hit
+        "What is the decorator pattern in Python?",  # unrelated — miss
+    ]:
+        r = ask_ctx(q, SESSION_A)
+        print_result(q, r)
+
+    # ── Session B: fresh session for a different user ──────────────────────
+    print("\nSession B — different user, fresh context")
+    print("-" * 50)
+    SESSION_B = "session-bob-conv-1"
+
+    r = ask_ctx("What is the CAP theorem?", SESSION_B)
+    print_result("[seed] What is the CAP theorem?", r)
+
+    for q in [
+        "Explain the CAP theorem",             # paraphrase — should hit
+        "Can you give me a simple example?",   # context → CAP theorem
+    ]:
+        r = ask_ctx(q, SESSION_B)
+        print_result(q, r)
+
+    # ── Session A revisited: context still alive ───────────────────────────
+    print(f"\nSession A revisited — context window still active")
+    print("-" * 50)
+    for q in [
+        "How is this different from standard caching?",
+        "What are the main benefits?",
+    ]:
+        r = ask_ctx(q, SESSION_A)
+        print_result(q, r)
+
+    print()
+    print(f"  hits={ctx_cache._hits}  misses={ctx_cache._misses}"
+          f"  hit_rate={ctx_cache.hit_rate:.0%}"
+          f"  saved=${ctx_cache._hits * 0.005:.3f}")
+
+    print("\n── Conversation history ──────────────────────────────")
+    for i, (sid, q, r) in enumerate(history, 1):
+        icon = "⚡" if r["cache_hit"] else "🌐"
+        tag  = f"[{sid.split('-')[1]}]"
+        print(f"{i:2}. {icon} {tag} {r['latency_ms']:.0f}ms — {q}")
+
+    set_llm_cache(None)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main():
+    print("◈ Sulci Cache + LangChain — semantic & context-aware cache demo\n")
+    demo_stateless()
+    demo_context_aware()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llamaindex_example.py
+++ b/examples/llamaindex_example.py
@@ -1,0 +1,314 @@
+"""
+examples/llamaindex_example.py
+================================
+Sulci Cache + LlamaIndex — context-aware semantic caching demo.
+
+Works with OpenAI or Anthropic API keys, or falls back to a mock LLM.
+
+Requirements:
+    pip install "sulci[sqlite,llamaindex]"
+    pip install llama-index-llms-openai     # for OpenAI
+    pip install llama-index-llms-anthropic  # for Anthropic
+
+    export OPENAI_API_KEY=sk-...            # OpenAI (checked first)
+    export ANTHROPIC_API_KEY=sk-ant-...    # Anthropic (checked second)
+    # No key set → mock LLM used automatically
+
+Run:
+    python examples/llamaindex_example.py
+
+How it works:
+    SulciCacheLLM wraps any LlamaIndex LLM and intercepts complete()
+    and chat() calls. Set Settings.llm = SulciCacheLLM(...) and every
+    LlamaIndex component — query engines, agents, RAG chains — caches
+    automatically with no further code changes.
+
+    Context-aware mode (context_window=4) blends prior turns into the
+    lookup vector so ambiguous follow-up queries resolve correctly within
+    the ongoing conversation. Each session_id keeps context isolated —
+    questions in one session don't influence lookups in another.
+"""
+import os, sys, time, tempfile
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from typing import Any, Sequence
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    ChatResponseAsyncGen,
+    ChatResponseGen,
+    CompletionResponse,
+    CompletionResponseAsyncGen,
+    CompletionResponseGen,
+    LLMMetadata,
+    MessageRole,
+)
+from llama_index.core.llms.llm import LLM
+from llama_index.core import Settings
+
+from sulci.integrations.llamaindex import SulciCacheLLM
+
+# ── LLM setup: OpenAI → Anthropic → mock ─────────────────────────────────────
+_has_openai    = bool(os.environ.get("OPENAI_API_KEY"))
+_has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+print("── API key detection ──────────────────────────────")
+print(f"  OPENAI_API_KEY    : {'✓ found' if _has_openai    else '✗ not set'}")
+print(f"  ANTHROPIC_API_KEY : {'✓ found' if _has_anthropic else '✗ not set'}")
+
+_inner_llm  = None
+_using_mock = False
+
+# 1. Try OpenAI
+if _has_openai:
+    try:
+        from llama_index.llms.openai import OpenAI as LlamaOpenAI
+        _inner_llm = LlamaOpenAI(model="gpt-4o-mini", temperature=0)
+        print("  → Using: OpenAI gpt-4o-mini\n")
+    except ImportError:
+        print("  ✗ llama-index-llms-openai not installed — run: pip install llama-index-llms-openai")
+
+# 2. Try Anthropic
+if _inner_llm is None and _has_anthropic:
+    try:
+        from llama_index.llms.anthropic import Anthropic as LlamaAnthropic
+        _inner_llm = LlamaAnthropic(
+            model   = "claude-haiku-4-5-20251001",
+            api_key = os.environ["ANTHROPIC_API_KEY"],
+        )
+        print("  → Using: Anthropic claude-haiku-4-5-20251001\n")
+    except ImportError:
+        print("  ✗ llama-index-llms-anthropic not installed — run: pip install llama-index-llms-anthropic")
+
+# 3. Mock fallback
+if _inner_llm is None:
+    _using_mock = True
+    print("  → Using: mock LLM (no API key found — set OPENAI_API_KEY or ANTHROPIC_API_KEY)\n")
+
+    _call_log: list = []   # external log — survives Pydantic's internal copy
+
+    class _MockLLM(LLM):
+        """Deterministic mock — returns fixed answers for demo purposes."""
+
+        @property
+        def metadata(self) -> LLMMetadata:
+            return LLMMetadata(model_name="mock-llm")
+
+        def _respond(self, text: str) -> str:
+            _call_log.append(1)
+            t = text.lower()
+            if "semantic" in t or "cache" in t:
+                return "Semantic caching stores LLM responses indexed by meaning, not exact text."
+            if "llama" in t or "llamaindex" in t:
+                return "LlamaIndex is a data framework for building LLM-powered agents over your data."
+            if "cap" in t or "distributed" in t:
+                return "The CAP theorem states a distributed system can guarantee only two of: Consistency, Availability, Partition tolerance."
+            if "example" in t or "show" in t:
+                return "Here is a simple example: cache = Cache(backend='sqlite'); cache.set('q', 'answer')."
+            if "different" in t or "standard" in t or "traditional" in t:
+                return "Unlike standard caches that match exact strings, semantic caching matches by meaning."
+            if "benefit" in t or "advantage" in t:
+                return "Benefits: lower LLM costs, faster responses, and improved hit rates in multi-turn conversations."
+            return f"[Mock] Answer to: {text[:60]}"
+
+        def complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+            return CompletionResponse(text=self._respond(prompt))
+
+        def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+            last = str(messages[-1].content) if messages else ""
+            return ChatResponse(message=ChatMessage(
+                role=MessageRole.ASSISTANT, content=self._respond(last)
+            ))
+
+        def stream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseGen:
+            result = self.complete(prompt, formatted, **kwargs)
+            def gen():
+                yield CompletionResponse(text=result.text, delta=result.text)
+            return gen()
+
+        def stream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseGen:
+            result = self.chat(messages, **kwargs)
+            def gen():
+                yield ChatResponse(message=result.message, delta=result.message.content or "")
+            return gen()
+
+        async def acomplete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponse:
+            return self.complete(prompt, formatted, **kwargs)
+
+        async def achat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+            return self.chat(messages, **kwargs)
+
+        async def astream_complete(self, prompt: str, formatted: bool = False, **kwargs: Any) -> CompletionResponseAsyncGen:
+            result = self.complete(prompt, formatted, **kwargs)
+            async def gen():
+                yield CompletionResponse(text=result.text, delta=result.text)
+            return gen()
+
+        async def astream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponseAsyncGen:
+            result = self.chat(messages, **kwargs)
+            async def gen():
+                yield ChatResponse(message=result.message, delta=result.message.content or "")
+            return gen()
+
+    _inner_llm = _MockLLM()
+
+
+# ── Wrap with SulciCacheLLM and register globally ─────────────────────────────
+llm = SulciCacheLLM(
+    llm            = _inner_llm,
+    backend        = "sqlite",
+    db_path        = os.path.join(tempfile.mkdtemp(prefix="sulci_li_"), "cache"),
+    threshold      = 0.90,    # strict — avoids false positives with real embeddings
+    context_window = 4,       # context-aware: remember last 4 turns per session
+    query_weight   = 0.70,
+    context_decay  = 0.60,
+    session_ttl    = 3600,
+)
+
+# Every LlamaIndex component — query engines, agents, RAG chains — picks this up
+Settings.llm = llm
+print("✓ SulciCacheLLM registered as Settings.llm\n")
+
+# ── Per-call stats tracker ────────────────────────────────────────────────────
+_stats = {"hits": 0, "misses": 0}
+
+
+# ── Chat class ────────────────────────────────────────────────────────────────
+class Chat:
+    """
+    Multi-turn chat using SulciCacheLLM via Settings.llm.
+
+    Each Chat instance uses its own session_id so context blending stays
+    scoped to that conversation — questions in one session don't influence
+    lookup vectors in another.
+    """
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.history    = []
+        self._cache     = llm._get_cache()
+
+    def ask(self, question: str) -> dict:
+        # Peek at cache to detect hit/miss accurately before the LLM call
+        cached_resp, sim, depth = self._cache.get(
+            question, session_id=self.session_id
+        )
+        is_hit = cached_resp is not None
+
+        t0     = time.perf_counter()
+        result = Settings.llm.complete(question, session_id=self.session_id)
+        ms     = (time.perf_counter() - t0) * 1000
+
+        if is_hit:
+            _stats["hits"] += 1
+        else:
+            _stats["misses"] += 1
+            self._cache.set(question, result.text, session_id=self.session_id)
+
+        entry = {
+            "question":      question,
+            "answer":        result.text,
+            "source":        "cache" if is_hit else "llm",
+            "latency_ms":    round(ms, 1),
+            "similarity":    round(sim, 4) if is_hit else 0.0,
+            "context_depth": depth,
+            "cache_hit":     is_hit,
+        }
+        self.history.append(entry)
+        return entry
+
+    def print_history(self) -> None:
+        print(f"\n── Session '{self.session_id}' history ───────────────────────")
+        for i, t in enumerate(self.history, 1):
+            icon = "⚡" if t["source"] == "cache" else "🌐"
+            ctx  = f"  ctx={t['context_depth']}" if t["context_depth"] else ""
+            sim  = f"  sim={t['similarity']:.0%}" if t["source"] == "cache" else ""
+            print(f"{i}. {icon} [{t['source'].upper()}] {t['latency_ms']:.0f}ms{sim}{ctx}")
+            print(f"   Q: {t['question']}")
+            print(f"   A: {t['answer'][:90]}...")
+            print()
+
+
+def print_result(label: str, r: dict) -> None:
+    icon = "⚡" if r["cache_hit"] else "🌐"
+    sim  = f" sim={r['similarity']:.0%}" if r["cache_hit"] else ""
+    ctx  = f" ctx={r['context_depth']}" if r["context_depth"] else ""
+    print(f"{icon} [{r['source'].upper()}] {r['latency_ms']:.0f}ms{sim}{ctx} — {label}")
+
+
+# ── Demo ──────────────────────────────────────────────────────────────────────
+def main():
+    print("◈ Sulci Cache + LlamaIndex — context-aware semantic cache demo\n")
+
+    # ── Round 1: fresh questions — all cache misses ───────────────────────────
+    # Each question in its own session so context doesn't bleed across topics.
+    print("Round 1: Fresh questions — all cache misses")
+    print("-" * 50)
+    fresh = [
+        ("session-caching",    "What is semantic caching?"),
+        ("session-llamaindex", "How does LlamaIndex work?"),
+        ("session-cap",        "What is the CAP theorem?"),
+    ]
+    sessions = {}
+    for sid, q in fresh:
+        chat = Chat(session_id=sid)
+        sessions[sid] = chat
+        r = chat.ask(q)
+        print_result(q, r)
+
+    # ── Round 2: paraphrases in same sessions — cache hits expected ───────────
+    # Reusing the same session_id means prior context boosts similarity
+    # for semantically equivalent follow-up questions.
+    print("\nRound 2: Paraphrased questions in same sessions — hits expected")
+    print("-" * 50)
+    paraphrases = [
+        ("session-caching",    "How does semantic cache work?"),   # ≈ Round 1 q1
+        ("session-llamaindex", "What is LlamaIndex used for?"),    # ≈ Round 1 q2
+        ("session-cap",        "Explain the CAP theorem"),         # ≈ Round 1 q3
+    ]
+    for sid, q in paraphrases:
+        r = sessions[sid].ask(q)
+        print_result(q, r)
+
+    # ── Round 3: context-aware follow-ups — single topic session ─────────────
+    # Ambiguous follow-ups resolve correctly because session context anchors
+    # them to the ongoing topic — this is Sulci Cache's key differentiator.
+    print("\nRound 3: Context-aware follow-ups — single topic session")
+    print("-" * 50)
+    ctx_chat = Chat(session_id="session-context-demo")
+    seed_q   = "What is semantic caching?"
+    r = ctx_chat.ask(seed_q)
+    print_result(f"[seed]  {seed_q}", r)
+
+    for q in [
+        "Can you give me a simple example?",            # context → semantic caching
+        "How is this different from standard caching?",
+        "What are the main benefits?",
+    ]:
+        r = ctx_chat.ask(q)
+        print_result(q, r)
+
+    # ── Round 4: clearly unrelated — cache miss ───────────────────────────────
+    print("\nRound 4: Clearly unrelated question — cache miss")
+    print("-" * 50)
+    r = Chat(session_id="session-misc").ask("What is the capital of Australia?")
+    print_result("What is the capital of Australia?", r)
+
+    # ── Stats ─────────────────────────────────────────────────────────────────
+    print()
+    total = _stats["hits"] + _stats["misses"]
+    rate  = _stats["hits"] / total if total else 0.0
+    print("=" * 50)
+    print(f"Total queries  : {total}")
+    print(f"Cache hits     : {_stats['hits']}  ({rate:.0%} hit rate)")
+    print(f"LLM calls      : {_stats['misses']}")
+    print(f"Cost saved     : ${_stats['hits'] * 0.005:.4f}  (est. at $0.005/call)")
+    print(f"Active sessions: {llm._get_cache().stats().get('active_sessions', 'N/A')}")
+    print("=" * 50)
+
+    ctx_chat.print_history()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
examples/langchain_example.py:
  Demo 1: stateless set_llm_cache(SulciCache(...)) — semantic hits
  Demo 2: context-aware ContextAwareSulciCache — llm_string as session_id,
          two isolated user sessions (alice/bob), 58% hit rate shown
  Supports OpenAI, Anthropic, or mock LLM fallback

examples/llamaindex_example.py:
  Settings.llm = SulciCacheLLM(...) — idiomatic LlamaIndex pattern
  4 rounds: fresh → paraphrases (93-96% sim) → context → unrelated miss
  Supports OpenAI, Anthropic, or mock LLM fallback

docs:
  README — examples section + Project Structure updated
  LOCAL_SETUP — Step 12 (LlamaIndex), smoke-llamaindex, examples section,
                API key table, clean run output, Project Structure, v0.3.5
  CHANGELOG — examples entry under v0.3.5, fix unclosed code block in 0.3.3