### PR TITLE
v0.4.0: Backend/Embedder protocols + tenant_id isolation + dev tooling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install
-        run: pip install ".[sqlite]" pytest pytest-cov httpx pytest-asyncio==0.21.1
+        run: pip install ".[sqlite]" qdrant-client pytest pytest-cov httpx pytest-asyncio==0.21.1
+
+      - name: Test Qdrant tenant isolation
+        run: pytest tests/test_qdrant_tenant_isolation.py -v --tb=short
+
+      - name: Conformance suite
+        run: pytest tests/compat/ -v --tb=short
 
       - name: Test core
         run: pytest tests/test_core.py -v --tb=short --cov=sulci --cov-report=term-missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,119 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.4.0] — 2026-04-26
+
+### Added
+
+- **Public Backend protocol** (`sulci/backends/protocol.py`) — formalizes the
+  shape every vector-cache backend must satisfy. `runtime_checkable` Protocol
+  with `store()`, `search()`, `clear()` methods. New `tenant_id` keyword-only
+  parameter for multi-tenant partition isolation. STABLE API per ADR 0005.
+- **Public Embedder protocol** (`sulci/embeddings/protocol.py`) — formalizes
+  the shape MiniLMEmbedder and OpenAIEmbedder already had: `dimension`
+  property, `embed(text)`, `embed_batch(texts)`. L2-normalization required.
+- **`tenant_id` partition isolation** — first-class kwarg on `Cache.get()`,
+  `Cache.set()`, and `Cache.cached_call()`. Forwarded to backend's `store`/
+  `search` calls. Tenant isolation is a hard boundary — entries from other
+  tenants must not be returned even when similarity exceeds threshold.
+- **Keyword-only enforcement** (`*,` separator) on `Cache.get()`, `set()`,
+  `cached_call()` — locks down `tenant_id`, `user_id`, `session_id`, and
+  `metadata` as keyword-only to prevent positional misuse.
+- **`ENFORCES_TENANT_ISOLATION` class attribute** on every backend, declaring
+  whether `search()` filters by tenant_id. QdrantBackend = True (uses payload
+  Filter); other shipped backends accept tenant_id as a label only.
+- **Conformance test suite** (`tests/compat/`) — parametrized tests verifying
+  that any class claiming to implement Backend or Embedder protocol satisfies
+  the contract. Three groups: TestStructural (signature checks, runs always),
+  TestRoundTrip (behavioral, runs when backend is constructable),
+  TestTenantIsolation (runs only on backends with ENFORCES_TENANT_ISOLATION).
+- **Qdrant tenant isolation tests** (`tests/test_qdrant_tenant_isolation.py`)
+  — 11 tests across 8 customer-support scenarios (HelpDesk AI / Acme /
+  Globex / Initech) verifying isolation guarantees end-to-end against an
+  embedded Qdrant. Test names framed as product scenarios so failures
+  describe user-impacting breakage.
+- **`docs/protocols.md`** — Backend and Embedder protocol reference for
+  developers extending sulci with custom backends or embedders.
+- **`docs/multi_tenancy_and_isolation.md`** — OSS-layer trust and partition
+  model. Generic customer scenarios, what's enforced where, FAQ on hashing,
+  rotation, GDPR, encryption-at-rest.
+- **`examples/extending_sulci/custom_backend.py`** — InMemoryBackend
+  reference implementation. ~150 lines, in-memory dict-based, satisfies the
+  full Backend protocol with self-test.
+- **Developer tooling** (`scripts/`):
+  - `run_tests_per_file.py` — runs pytest test files in fresh subprocesses
+    (avoids MPS deadlock on Apple Silicon)
+  - `run_examples.py` — runs every example + smoke test with timeout
+  - `verify_integration_examples.py` — 8-scenario LLM provider matrix for
+    langchain/llamaindex examples
+  - `verify_benchmark.py` — runs canonical benchmark and verifies headline
+    numbers haven't drifted from `benchmark/baseline.json`
+- **`benchmark/baseline.json`** — canonical TF-IDF benchmark numbers from
+  pre-v040-baseline. Used by verify_benchmark.py for regression detection.
+
+### Changed
+
+- **`__version__`** is now derived dynamically from `pyproject.toml` via
+  `importlib.metadata.version("sulci")`. Previously hardcoded in three
+  places (pyproject.toml, _SDK_VERSION, USER_AGENT) which had drifted.
+- **`_SDK_VERSION`** still exists (telemetry payload field name unchanged
+  on the wire) but now equals `__version__`. Marked as deprecated alias.
+- **`SulciCloudBackend.USER_AGENT`** now `f"sulci/{__version__}"` (was
+  hardcoded "sulci/0.3.0", drifted by two minor releases).
+- **`SulciCloudBackend.store()`** added (was missing — `cloud.py` only had
+  `upsert()` while `core.py` always called `self._backend.store()`. Latent
+  AttributeError on `Cache(backend='sulci').set()` is now fixed).
+
+### Fixed
+
+- **qdrant-client 1.x compatibility**: `QdrantBackend.search()` migrated
+  from `client.search()` (removed) to `client.query_points()` with
+  `.points` iteration. `QdrantBackend.clear()` now deletes points (preserves
+  collection schema) instead of `delete_collection()` which broke subsequent
+  operations on qdrant-client 1.x.
+- **Cross-tenant data leak in `tenant_id=None` read path**: stores wrote
+  `tenant_id="global"` for None, but searches with `tenant_id=None` added
+  no filter, so unscoped reads silently returned named-tenant entries.
+  Fixed by always filtering to "global" when None is passed. Caught by
+  `test_named_tenant_entry_does_not_match_global_search`.
+- **`examples/anthropic_example.py`** previously hardcoded `backend="chroma"`
+  and documented `pip install "sulci[chroma]" anthropic` install line, but
+  the README's quickstart recommends `sulci[sqlite]`. Mismatch caused
+  ImportError on first run for users following the README. Switched to
+  `backend="sqlite"` (functionally equivalent for this demo) and added
+  graceful mock-LLM fallback when `ANTHROPIC_API_KEY` is unset.
+- **`benchmark/.gitignore`** had a typo (`iresults/*.json`) that left
+  benchmark output untracked-but-visible in `git status`. Fixed.
+
+### CI
+
+- `qdrant-client` added to `.github/workflows/tests.yml` install step.
+- New CI steps: "Test Qdrant tenant isolation" and "Conformance suite" run
+  early in the matrix to fail-fast on isolation regressions.
+
+### Makefile
+
+- New targets: `test-per-file`, `test-per-file-fast`, `examples`,
+  `verify-integration-examples`, `benchmark-verify`, `checkin`. The
+  `checkin` target chains smoke + tests + examples + benchmark-verify
+  as a comprehensive pre-PR check (~7 min wall-clock).
+
+### Notes
+
+- `tenant_id` is honored ungated when passed (no `personalized` flag
+  required). `user_id` continues to be gated by `personalized=True` for
+  backwards compatibility with v0.3.x users; this asymmetry will be
+  reconciled in v0.5.0+.
+- After a version bump, run `pip install -e . --no-deps` in editable
+  installs to refresh `importlib.metadata`'s cached dist-info.
+- Built-in TF-IDF benchmark numbers verified byte-stable across the
+  v0.3.x line and pre-v040-baseline (CI runs #26 through #36).
+- Verified end-to-end via `make checkin`: 290 pytest tests pass, 12/12
+  examples pass (including real OpenAI + Anthropic API calls), all 17
+  benchmark metrics within tolerance vs baseline.
+
+---
+
 ## [0.3.7] — 2026-04-11
 
 ### Added

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -321,6 +321,92 @@ make smoke-async        # AsyncCache smoke test only (smoke_test_async.py)
 
 ---
 
+## Step 8.5 — Pre-PR Verification with Runner Scripts
+
+When you're about to open a PR, the `scripts/` directory provides three
+runners that wrap the most common pre-commit verification flows. Each one
+runs sequentially across many files in fresh subprocesses, captures
+pass/fail per file, and prints a summary table at the end. Failure logs
+are saved to `/tmp/sulci-*-runner/` for later inspection.
+
+### Why these scripts exist
+
+Several integration tests construct multiple `MiniLMEmbedder` instances
+in one process. On Apple Silicon (MPS), this occasionally deadlocks at
+`embeddings.cpu()` under memory pressure. The runner scripts launch each
+test file (or example) in its own Python subprocess, giving each a clean
+MiniLM cold-start and avoiding the deadlock. Trade-off: each subprocess
+pays its own ~30-40s warmup, so wall-clock is longer than a single
+`pytest tests/` invocation. CI doesn't need this — it runs on Linux
+without MPS — but local development on M-series Macs benefits.
+
+### Make targets
+
+```bash
+make test-per-file              # all test files in fresh subprocesses (~10-15 min)
+make test-per-file-fast         # skip the slowest 4 files (~3-5 min, faster iteration)
+make examples                   # all examples + smoke tests with timeout (~10-15 min)
+make verify-integration-examples  # full 4-scenario LLM-provider matrix for langchain
+                                  # + llamaindex (~10-15 min, requires both API keys,
+                                  # ~$0.10-0.20 in real LLM calls per run)
+make benchmark-verify           # run TF-IDF benchmark, verify against baseline.json (~15s)
+make checkin                    # smoke + test-per-file + examples + benchmark-verify (pre-PR check)
+```
+
+### When to use which
+
+| If you changed... | Run |
+|---|---|
+| `sulci/` source code | `make test-per-file` |
+| `examples/*.py` or `smoke_test*.py` | `make examples` |
+| `examples/langchain_example.py` or `examples/llamaindex_example.py` | `make verify-integration-examples` |
+| `benchmark/` files or anything that touches headline numbers | `make benchmark-verify` |
+| Anything before opening a PR | `make checkin` |
+
+### Direct script invocation
+
+The runners support direct invocation if you want to override defaults
+like timeout or filter to specific files:
+
+```bash
+python scripts/run_tests_per_file.py --help
+python scripts/run_examples.py --help
+python scripts/verify_integration_examples.py --help
+```
+
+For example, to run only the four fast test files with a tight
+60-second timeout:
+
+```bash
+python scripts/run_tests_per_file.py \
+    --files tests/test_backends.py tests/test_cloud_backend.py \
+            tests/test_connect.py tests/compat/ \
+    --timeout 60
+```
+
+### What `make checkin` produces
+
+A successful run prints a summary like
+`TOTAL: 285 passed, 0 failed, 0 errors, 38 skipped`, then the examples
+summary `TOTAL: 12/12 passed`, then a final banner. If anything fails,
+the failure log path is printed in the per-file summary table so you
+can `cat` the relevant log rather than re-running with extra flags.
+
+### Adding new runner scripts
+
+If you add a new dev-tooling script:
+
+1. Make it a `#!/usr/bin/env python3` script in `scripts/` with `chmod +x`
+2. Use `argparse` with a `--help` that explains preconditions and exit codes
+3. Use `subprocess.run(timeout=...)` rather than the GNU `timeout` command
+   (macOS doesn't ship `timeout` by default; `subprocess.run` is portable)
+4. Save per-target logs to `/tmp/<runner-name>/`
+5. Add a Makefile target so contributors don't have to remember the
+   invocation
+6. Update `scripts/README.md` and this section
+
+---
+
 ## Step 9 — Test sulci.connect() Locally
 
 `sulci.connect()` is the opt-in telemetry gate. The default state

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -713,7 +713,7 @@ tests/test_integrations_llamaindex.py::TestStats::test_repr_contains_hit_rate PA
 │   ├── context_aware_example.py← additional context-aware patterns
 │   ├── langchain_example.py    ← LangChain demo, OpenAI/Anthropic/mock  (v0.3.5)
 │   └── llamaindex_example.py   ← LlamaIndex demo, OpenAI/Anthropic/mock (v0.3.5)
-├── pyproject.toml              ← name="sulci", version="0.3.7"
+├── pyproject.toml              ← name="sulci", version="0.4.0"
 ├── setup.py
 ├── setup.sh                    ← one-shot setup: venv + install + smoke tests
 ├── smoke_test.py               ← core smoke test
@@ -721,7 +721,7 @@ tests/test_integrations_llamaindex.py::TestStats::test_repr_contains_hit_rate PA
 ├── smoke_test_llamaindex.py    ← LlamaIndex integration smoke test          (v0.3.5)
 ├── sulci
 │   ├── __init__.py             ← exports Cache, ContextWindow, SessionStore, connect()
-│   │                              _SDK_VERSION = "0.3.7"
+│   │                              _SDK_VERSION = __version__   # derived from pyproject.toml
 │   ├── backends
 │   │   ├── __init__.py         ← empty — core.py loads backends via importlib
 │   │   ├── chroma.py
@@ -771,7 +771,7 @@ Total: 212 tests
 
 | Branch                            | Purpose                          | Status                      |
 | --------------------------------- | -------------------------------- | --------------------------- |
-| `main`                            | Stable release — v0.3.7          | All work merges here via PR |
+| `main`                            | Stable release — v0.4.0          | All work merges here via PR |
 | `feature/context-aware`           | v0.2.0 context-aware library     | Merged                      |
 | `feature/benchmark-context-aware` | v0.2.5 benchmark suite           | Merged                      |
 | `feature/saas-onramp`             | v0.3.0 cloud backend + telemetry | Merged                      |

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,45 @@ test-cov:
 ## Full local verification: smoke tests + full test suite
 verify: smoke test-all
 
+# ── Developer tooling (scripts/) ──────────────────────────────────────────────
+
+## Run pytest test files one at a time, in fresh subprocesses (see scripts/README.md)
+test-per-file:
+	$(PYTHON) scripts/run_tests_per_file.py
+
+## Run pytest one at a time, skipping the slowest 4 files (faster local iteration)
+test-per-file-fast:
+	$(PYTHON) scripts/run_tests_per_file.py --skip-slow
+
+## Run every example + smoke test with timeout, capture pass/fail
+## Mock LLM fallback if no API keys; real LLMs if OPENAI/ANTHROPIC keys are set
+examples:
+	$(PYTHON) scripts/run_examples.py
+
+## Verify framework-integration examples (langchain + llamaindex) by
+## exercising every LLM-credential configuration: no keys / OpenAI only /
+## Anthropic only / both keys. Requires both OPENAI_API_KEY and
+## ANTHROPIC_API_KEY in env (uses real API calls; ~$0.10-0.20 per run).
+verify-integration-examples:
+	$(PYTHON) scripts/verify_integration_examples.py
+
+## Verify the canonical TF-IDF benchmark numbers haven't regressed
+## against benchmark/baseline.json (~15s wall-clock, no network/API).
+benchmark-verify:
+	$(PYTHON) scripts/verify_benchmark.py
+
+## Comprehensive pre-PR check: smoke + tests-per-file + examples
+## Add 'matrix' manually if you want to also verify provider detection
+checkin: smoke test-per-file examples benchmark-verify
+	@echo ""
+	@echo "════════════════════════════════════════════════════════════════════"
+	@echo " ✓ checkin verification complete"
+	@echo "   For provider-detection coverage too: make verify-integration-examples"
+	@echo "════════════════════════════════════════════════════════════════════"
+
+# ── PHONY ─────────────────────────────────────────────────────────────────────
+
 .PHONY: smoke smoke-core smoke-langchain smoke-llamaindex smoke-async \
         test test-async test-integrations test-all test-cov \
+        test-per-file test-per-file-fast examples verify-integration-examples benchmark-verify checkin \
         verify

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ response, sim, depth = cache.get("Tell me more about it", session_id="s1")
 
 ### Drop-in with `cached_call`
 
-> **Requires:** `pip install "sulci[chroma]" anthropic`
+> **Requires:** `pip install "sulci[sqlite]" anthropic`
 >
 > ```bash
 > export ANTHROPIC_API_KEY=sk-ant-...
@@ -577,7 +577,7 @@ Or use a clean venv (avoids conda transitive dependency conflicts entirely):
 ```bash
 python -m venv .venv
 source .venv/bin/activate        # Windows: .venv\Scripts\activate
-pip install "sulci[chroma]" anthropic
+pip install "sulci[sqlite]" anthropic
 python your_script.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Sulci Cache is a drop-in Python library that caches LLM responses by **semantic 
 | 1–3 second response time     | Cache hits return in <10ms                               |
 | No memory across sessions    | Context-aware: understands conversation history          |
 
-**Benchmark results (v0.3.3, 5,000 queries):**
+**Benchmark results (v0.4.0, 5,000 queries):**
 
 - Overall hit rate: **85.9%**
 - Hit latency p50: **0.74ms** (vs ~1,840ms for a live LLM call)
@@ -343,9 +343,9 @@ cache = Cache(
 
 | Method                                                                                 | Returns                   | Description                                                        |
 | -------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------ |
-| `cache.get(query, user_id=None, session_id=None)`                                      | `(str\|None, float, int)` | response, similarity, context_depth                                |
-| `cache.set(query, response, user_id=None, session_id=None)`                            | `None`                    | Store entry, advance context window                                |
-| `cache.cached_call(query, llm_fn, session_id=None, user_id=None, cost_per_call=0.005)` | `dict`                    | response, source, similarity, latency_ms, cache_hit, context_depth |
+| `cache.get(query, *, tenant_id=None, user_id=None, session_id=None)`                   | `(str\|None, float, int)` | response, similarity, context_depth (tenant_id added in v0.4.0)    |
+| `cache.set(query, response, *, tenant_id=None, user_id=None, session_id=None, metadata=None)` | `None`                    | Store entry, advance context window                                |
+| `cache.cached_call(query, llm_fn, *, tenant_id=None, user_id=None, session_id=None, cost_per_call=0.005)` | `dict`        | response, source, similarity, latency_ms, cache_hit, context_depth |
 | `cache.get_context(session_id)`                                                        | `ContextWindow`           | Return session's context window                                    |
 | `cache.clear_context(session_id)`                                                      | `None`                    | Reset session history                                              |
 | `cache.context_summary(session_id=None)`                                               | `dict`                    | Snapshot of one or all sessions                                    |

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,5 +1,6 @@
-iresults/*.json
+results/*.json
 results/*.csv
 results/*.txt
+results/*_db/
 # Keep the placeholder
 !results/.gitkeep

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -72,7 +72,7 @@ python benchmark/run.py --use-sulci --use-claude --fresh \
 
 ---
 
-## Results (v0.2.1)
+## Results (v0.4.0)
 
 All results produced with `--use-sulci --use-claude --fresh --queries 1000 --no-sweep --claude-max-calls 1000`.
 

--- a/benchmark/baseline.json
+++ b/benchmark/baseline.json
@@ -1,0 +1,35 @@
+{
+  "_meta": {
+    "description": "Canonical TF-IDF benchmark numbers. The verifier (scripts/verify_benchmark.py) compares fresh run output against these.",
+    "source": "GitHub Actions benchmark.yml run #36 (commit 35a0c86, pre-v040-baseline)",
+    "verified_stable_across_releases": ["v0.3.4 (run #26)", "v0.3.7 (implicit)", "pre-v040-baseline (run #36)"],
+    "tolerance_notes": "Counts may drift by ±2 across platforms (Linux vs macOS) due to dict-iteration tie-breaks. Headline percentages match exactly. Latency varies by machine; not part of regression check."
+  },
+  "stateless": {
+    "threshold": 0.85,
+    "total_queries": 5000,
+    "cache_hits": 4294,
+    "hit_rate": 0.8588,
+    "false_positives": 1336,
+    "false_positive_rate": 0.3111,
+    "saved_cost_usd": 21.47,
+    "cost_reduction_pct": 85.88
+  },
+  "context_aware": {
+    "context_window": 4,
+    "total_followup_queries": 125,
+    "stateless_hit_rate": 0.64,
+    "stateless_resolution_accuracy": 0.568,
+    "context_hit_rate": 0.816,
+    "context_resolution_accuracy": 0.776,
+    "accuracy_delta_pct": 20.8,
+    "hit_rate_delta": 0.176
+  },
+  "domain_breakdown_context_aware": [
+    {"domain": "customer_support",     "stateless_accuracy": 0.32, "context_accuracy": 0.88, "improvement": 0.56},
+    {"domain": "developer_qa",         "stateless_accuracy": 0.80, "context_accuracy": 0.96, "improvement": 0.16},
+    {"domain": "product_faq",          "stateless_accuracy": 0.72, "context_accuracy": 0.76, "improvement": 0.04},
+    {"domain": "medical_information",  "stateless_accuracy": 0.40, "context_accuracy": 0.60, "improvement": 0.20},
+    {"domain": "general_knowledge",    "stateless_accuracy": 0.60, "context_accuracy": 0.68, "improvement": 0.08}
+  ]
+}

--- a/docs/multi_tenancy_and_isolation.md
+++ b/docs/multi_tenancy_and_isolation.md
@@ -1,0 +1,430 @@
+# Multi-Tenancy and Data Isolation in Sulci
+
+> How sulci enforces partition boundaries between tenants and users,
+> what guarantees the OSS library makes, and how to wire it into your
+> application correctly.
+
+This document covers the *why* and *how* of sulci's tenant isolation
+model. For the strict protocol reference (method signatures, the
+conformance test contract, kwarg semantics), see
+[docs/protocols.md](protocols.md). For the customer-support test
+scenarios that pin behavior at the implementation level, see
+[tests/test_qdrant_tenant_isolation.py](../tests/test_qdrant_tenant_isolation.py).
+
+---
+
+## Why this matters
+
+A semantic cache sits between an LLM application and the LLM provider.
+When a query comes in, the cache asks: *"have I already seen something
+semantically similar?"* If yes, return the cached response and skip the
+LLM call. This saves cost and latency.
+
+The semantic part is also the dangerous part.
+
+Consider a SaaS support chatbot company — call it HelpDesk AI — that
+sells the same chatbot to multiple customers. Acme Corp uses it for
+warranty questions. Globex Health uses it for patient billing
+(HIPAA-regulated). Initech Software uses it for technical support.
+
+If HelpDesk AI runs all three customers' caches against the same
+embedding space *without partition isolation*, then a Globex agent's
+question about a patient's billing history could be returned to an
+Initech caller asking a semantically-similar question. Globex's
+patient PHI ends up in Initech's response. That's a HIPAA breach,
+a lawsuit, and probably the end of HelpDesk AI as a company.
+
+The fix is partition isolation: every cached entry is tagged with
+the tenant it belongs to, and searches are restricted to entries
+matching the caller's tenant. Sulci's `Backend` protocol takes this
+as a hard requirement — entries from other tenants MUST NOT be
+returned, even when their similarity exceeds threshold. Threshold
+is a quality knob; tenant filtering is a security boundary.
+
+This document explains how that boundary works in the OSS library,
+what its limits are, and how to wire it into your application.
+
+---
+
+## The two axes of isolation
+
+There are two independent ways one customer's data can be kept apart
+from another's. They are often conflated in conversations about
+"multi-tenancy" but they're conceptually distinct:
+
+### Axis 1 — Logical isolation (within a single deployment)
+
+How does *one running cache cluster* keep tenant A's data away from
+tenant B's data? This is what `tenant_id` in the protocol enforces.
+
+It's a property of the code: every `store()` and `search()` call
+filters by tenant, and the protocol's behavioral requirements pin
+that filtering as mandatory. Logical isolation runs on every
+request, lives forever, doesn't depend on deployment topology.
+
+### Axis 2 — Physical isolation (across deployments)
+
+Does tenant A's data physically sit on the same hardware/network/
+cluster as tenant B's? Or are they in entirely separate processes,
+machines, or networks?
+
+This is a property of the *infrastructure*, decided at procurement
+time. It's outside the scope of the OSS library — the OSS library
+runs wherever you put it. Some customers are happy with shared
+infrastructure where logical isolation is the only boundary. Others
+require dedicated infrastructure for regulatory reasons (HIPAA,
+FedRAMP, SOC 2). The Sulci Cloud product offers both shared and
+dedicated options; see [sulci.io/enterprise](https://sulci.io/enterprise)
+for the deployment options Sulci offers commercially.
+
+This document focuses on Axis 1 — the logical isolation that the
+OSS library enforces in code. Axis 2 is a deployment decision the
+operator makes, not a protocol concern.
+
+---
+
+## The OSS trust model
+
+Sulci OSS is a Python library that runs *inside* the user's
+application. Its trust assumptions:
+
+- **The calling code is trusted.** The application embedding sulci
+  is responsible for authenticating its users and deciding what
+  `tenant_id`/`user_id` to pass on each request. If the application
+  passes the wrong tenant_id, sulci will dutifully return entries
+  for the wrong tenant. The library cannot validate a tenant_id
+  against an external authentication source — that's not its job.
+- **The backend is trusted.** Whichever vector store sulci is
+  configured to use (Qdrant, Chroma, etc.) is in the trust path.
+  A compromised backend can return any data it wants. Sulci's
+  filter logic is a defense against accidental leakage from
+  application bugs, not a defense against a malicious backend.
+- **The protocol's filter is the last line of defense.** Above sulci,
+  there might be a gateway, a load balancer, a service mesh, an
+  auth layer — those are *your* concerns, not the library's. Below
+  sulci, the backend's data files. The Backend protocol's `tenant_id`
+  filter is the boundary the library is responsible for. If that
+  filter has a bug, no upstream care can fix it; if it works, no
+  downstream chaos can bypass it from within the same process.
+
+This is what makes the conformance suite (`tests/compat/`) and the
+customer-scenario tests (`tests/test_qdrant_tenant_isolation.py`)
+matter so much. They verify the library's one job is done correctly.
+
+---
+
+## What's enforced where
+
+The OSS library's filter logic is implemented in each Backend's
+`search()` method. The protocol prescribes the contract; each
+implementation honors it (or doesn't, declared via the
+`ENFORCES_TENANT_ISOLATION` class attribute).
+
+| Backend | Enforces tenant isolation? | How |
+|---|---|---|
+| QdrantBackend | Yes | Qdrant payload `Filter(must=[FieldCondition(...)])` applied at query time |
+| ChromaBackend | No (label-only) | `tenant_id` stored in metadata; not filtered on read |
+| SQLiteBackend | No | `tenant_id` accepted but currently dropped (schema migration deferred) |
+| RedisBackend | No | Same as SQLite |
+| FAISSBackend | No | Same |
+| MilvusBackend | No | Same |
+| SulciCloudBackend | (gateway-side) | Cloud gateway enforces via API key → tenant mapping; OSS conformance opts out because there's no local gateway to verify against |
+
+Backends with `ENFORCES_TENANT_ISOLATION = False` accept the
+`tenant_id` kwarg without raising — they're protocol-conformant — but
+their `search()` doesn't filter on it. Those backends are appropriate
+for single-tenant deployments where the application has no concept of
+multiple tenants. **Don't use them for multi-tenant SaaS.**
+
+The conformance test suite (`tests/compat/`) automatically runs the
+`TestTenantIsolation` group only against backends declaring
+`ENFORCES_TENANT_ISOLATION = True`. Custom backends that handle
+multiple tenants should declare `True` and pass that group's tests.
+
+---
+
+## Customer scenarios
+
+Concrete walkthroughs of how the model behaves in real situations.
+These are also the names of test methods in
+`tests/test_qdrant_tenant_isolation.py` — when one of those tests
+fails, the failure tells you which user-impacting scenario is broken.
+
+### Scenario 1 — Acme agents share each other's cache (the value prop)
+
+> **Acme agent #1:** "What's the warranty on the Acme P500 pump?"
+
+The cache misses, the LLM is called, the response gets stored:
+
+```pythoncache.set(
+query    = "What's the warranty on the Acme P500 pump?",
+response = "The Acme P500 has a 5-year limited warranty.",
+tenant_id = "acme_corp",
+user_id   = "agent_001",
+)
+
+> **Acme agent #2 (different agent, same company):** "How long is
+> the P500 covered under warranty?"
+
+The cache **hits** — same tenant, semantically-similar query. The
+response is returned without calling the LLM. This is sulci's
+core value: cache hits within a tenant save cost and latency.
+
+```pythoncache.get(
+query     = "How long is the P500 covered under warranty?",
+tenant_id = "acme_corp",
+user_id   = "agent_002",
+)
+→ returns ("The Acme P500 has a 5-year limited warranty.", 0.92, 0)
+
+**What could go wrong:** if the application forgets to pass
+`tenant_id`, all entries land in the `"global"` partition. That works
+fine for single-tenant apps but breaks the cross-tenant isolation
+guarantee the moment the app starts handling multiple tenants. Always
+pass `tenant_id` in multi-tenant deployments.
+
+### Scenario 2 — Globex PHI must not leak to Initech
+
+> **Globex agent:** "What's the bill code for John Smith's surgery
+> on March 15?"
+
+```pythoncache.set(
+query     = "Bill code for John Smith's surgery on March 15?",
+response  = "Patient John Smith MRN 4471823, code 49505. Balance $1,247.83.",
+tenant_id = "globex_health",
+)
+
+> **Initech caller (different company, semantically-similar query):**
+> "What's the policy for billing the patient surgery on March 15?"
+
+The vector similarity between these two queries is ~0.85. Without
+tenant isolation, this would match — and Initech would receive PHI
+for a Globex patient.
+
+With tenant isolation:
+
+```pythonresp, sim, depth = cache.get(
+query     = "What's the policy for billing the patient surgery on March 15?",
+tenant_id = "initech_software",
+)
+→ returns (None, 0.0, 0)   ← clean miss
+
+The Globex entry is filtered out before similarity is even
+considered. The result is a clean miss; Initech's LLM is called
+fresh with their (very different) actual context.
+
+**What could go wrong:** an asymmetry between the store path's
+sentinel handling and the search path's filter logic. If `store()`
+writes `tenant_id="global"` for `None` but `search()` with
+`tenant_id=None` doesn't filter, the unscoped read would silently
+return entries from named tenants. This was a real bug in v0.4.0
+phase 1.4, caught by
+`test_named_tenant_entry_does_not_match_global_search`. The fix is
+documented in the [protocols reference](protocols.md#search).
+
+### Scenario 3 — Within-tenant user partitioning
+
+Same company, two agents with different access permissions.
+
+> **Acme enterprise-sales agent (agent_001):** "What pricing tier
+> does Northrop Industries get?"
+
+```pythoncache.set(
+query     = "What pricing tier does Northrop Industries get?",
+response  = "Northrop is Tier-3 enterprise: 22% discount, net-60 terms.",
+tenant_id = "acme_corp",
+user_id   = "agent_001_enterprise",
+)
+
+> **Acme residential-sales agent (agent_002):** "What pricing does
+> Northrop get?"
+
+```pythonresp, sim, depth = cache.get(
+query     = "What pricing does Northrop get?",
+tenant_id = "acme_corp",
+user_id   = "agent_002_residential",
+)
+→ returns (None, 0.0, 0)
+
+agent_002 doesn't have enterprise-customer access in their CRM.
+They miss the cache and the LLM is called fresh, producing an
+answer based on agent_002's own permissions (likely "I don't have
+access to Northrop's pricing details"). The privileged response
+that agent_001 saw never leaks to agent_002.
+
+**Whether to set `user_id`** is a deployment decision. Some
+applications have role-based access controls where different users
+must see different responses to the same query — those should pass
+`user_id`. Others have shared knowledge bases where all users in a
+tenant should hit the same cache — those can leave `user_id`
+unset. Sulci's protocol supports both.
+
+### Scenario 4 — Solo-developer single-tenant deployment
+
+> **Solo dev:** "How do I deploy a Python app to AWS Lambda?"
+
+```pythoncache.set(
+query    = "How do I deploy a Python app to AWS Lambda?",
+response = "Package code as a .zip, upload via aws lambda create-function.",
+# No tenant_id, no user_id
+)
+
+> **Solo dev later:** "What's the process for getting a Python app
+> onto Lambda?"
+
+```pythonresp, sim, depth = cache.get(
+query = "What's the process for getting a Python app onto Lambda?",
+# No tenant_id, no user_id
+)
+→ returns ("Package code as a .zip, upload via aws lambda create-function.", 0.94, 0)
+
+This is the simplest deployment. No tenants, no users. Everything
+goes into the `"global"` partition (sulci's internal sentinel for
+"un-scoped"). The cache works exactly as it did before v0.4.0
+introduced tenant_id; backwards-compatible by design.
+
+**Most OSS users start here.** The library is approachable because
+multi-tenancy is opt-in, not required.
+
+---
+
+## For implementers: wiring tenant_id and user_id from your application
+
+The library doesn't dictate where these values come from. They're
+yours to set on each call. Here are common patterns.
+
+### From a JWT / session token
+
+```pythonfrom sulci import Cache
+import jwtcache = Cache(backend="qdrant")def handle_chat_request(request, http_headers):
+token  = http_headers.get("Authorization", "").removeprefix("Bearer ")
+claims = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])# Derive partition keys from authenticated identity.
+tenant_id = claims["org_id"]      # the customer's organization
+user_id   = claims["sub"]          # the individual end-userresponse, sim, _ = cache.get(
+    query     = request.query,
+    tenant_id = tenant_id,
+    user_id   = user_id,
+)
+if response is None:
+    response = call_llm(request.query, system_prompt_for(tenant_id))
+    cache.set(
+        query     = request.query,
+        response  = response,
+        tenant_id = tenant_id,
+        user_id   = user_id,
+    )
+return response
+
+The principle: **`tenant_id` and `user_id` come from authenticated
+identity, never from request body.** Letting a caller pass their own
+`tenant_id` in a request payload would let any caller spoof another
+tenant's cache. Always derive from a token your app issued.
+
+### From an API key map
+
+```pythonTENANT_FROM_API_KEY = {
+"sk_acme_xxxxxxxxxxxx":   "acme_corp",
+"sk_globex_yyyyyyyyyy":   "globex_health",
+"sk_initech_zzzzzzzzz":   "initech_software",
+}def handle_request(request, headers):
+api_key   = headers["Authorization"].removeprefix("Bearer ")
+tenant_id = TENANT_FROM_API_KEY.get(api_key)
+if tenant_id is None:
+raise Unauthorized()user_id = headers.get("X-Customer-User-Id")  # optional, customer-suppliedresponse, sim, _ = cache.get(
+    query     = request.query,
+    tenant_id = tenant_id,
+    user_id   = user_id,
+)
+
+The API key is the source of truth for `tenant_id`. The customer's
+own user identifier (which they pass through in a header) becomes
+`user_id`, but only as a partition label — sulci doesn't validate
+those values, that's the customer's concern within their own tenant.
+
+### From an LLM framework integration (LangChain, LlamaIndex)
+
+Sulci's LangChain and LlamaIndex integrations forward cache kwargs
+through their respective adapter classes. The `Cache` constructor
+accepts the same `tenant_id`/`user_id` parameters; consult those
+integrations' docstrings for framework-specific patterns.
+
+---
+
+## FAQ
+
+### Does sulci hash tenant_id before storing it?
+
+No. The `tenant_id` value you pass is stored verbatim in the
+backend's metadata or payload field. If you're concerned about
+tenant identifiers being readable by anyone with backend access,
+hash them in your application before passing to sulci.
+
+### Can I rotate tenant_ids?
+
+The protocol doesn't have a rename-or-merge primitive. To rotate a
+tenant_id from `old_id` to `new_id`, you'd need to clear (or
+selectively delete) entries under `old_id` and let new entries land
+under `new_id`. Cache loss during rotation is acceptable for most
+use cases — sulci is a cache, not a system of record.
+
+### Can a tenant see how many entries another tenant has?
+
+The OSS library's `cache.stats()` returns aggregate counts for the
+entire backend, not per-tenant. There's no protocol method that
+exposes per-tenant counts to a tenant. If you need per-tenant
+metrics for billing or capacity planning, that's an operator-side
+concern (you can query the backend directly), not a tenant-facing
+API.
+
+### What happens if I pass an empty string as tenant_id?
+
+`tenant_id=""` is treated as a literal empty-string partition key.
+It's distinct from `tenant_id=None` (which becomes `"global"`).
+Behavior is pinned by `test_empty_string_does_not_match_none` in
+`tests/test_qdrant_tenant_isolation.py`. We recommend you don't pass
+empty strings — pick `None` or a real tenant identifier.
+
+### What about deletion? GDPR / CCPA right-to-erasure?
+
+The OSS protocol's `clear()` removes everything. Per-user or
+per-tenant deletion is not in the v0.4.0 OSS protocol surface. For
+deployments with regulatory deletion requirements, this is an
+enterprise-tier concern; see
+[sulci.io/enterprise](https://sulci.io/enterprise) for what the
+managed product offers, or contact us if you need help building it
+into a custom backend.
+
+### Is tenant_id encrypted at rest?
+
+That depends entirely on which backend you're using. Sulci doesn't
+add encryption — it stores `tenant_id` as a normal field in your
+chosen backend's storage. If your backend (Qdrant, Postgres-backed
+SQLite, encrypted Redis, etc.) provides at-rest encryption, the
+field is encrypted. If not, it isn't. Check your backend's
+documentation.
+
+### Can I use sulci OSS without ever thinking about tenant_id?
+
+Yes. If your application has one tenant — or no concept of tenants
+at all — never pass `tenant_id`. Everything goes into the `"global"`
+partition automatically. The library works exactly as it did before
+v0.4.0. The kwarg is optional precisely so single-tenant
+deployments don't pay any complexity tax.
+
+---
+
+## See also
+
+- [docs/protocols.md](protocols.md) — strict technical reference
+  for the Backend and Embedder protocols
+- [examples/extending_sulci/custom_backend.py](../examples/extending_sulci/custom_backend.py) —
+  a worked reference implementation showing how to build a custom
+  backend that satisfies the tenant isolation contract
+- [tests/test_qdrant_tenant_isolation.py](../tests/test_qdrant_tenant_isolation.py) —
+  the customer-scenario tests that pin behavior at the
+  implementation level
+- [tests/compat/](../tests/compat/) — the conformance test suite
+  that validates any custom backend against the protocol
+- [sulci.io/enterprise](https://sulci.io/enterprise) — for
+  deployment options beyond the OSS library (managed cloud, VPC,
+  air-gapped enterprise installations)

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,341 @@
+# Sulci Protocols Reference
+
+> Public extension points for sulci-cache. Introduced in v0.4.0.
+
+This document describes the two public protocols that govern how
+sulci's pluggable components are shaped: the **Backend** protocol
+(for vector storage drivers) and the **Embedder** protocol (for
+text-embedding models).
+
+If you want to plug a new vector store, embedding model, or storage
+medium into sulci, this is the contract you implement.
+
+---
+
+## Why protocols?
+
+Sulci ships seven backends (sqlite, chroma, qdrant, faiss, redis, milvus, sulci-cloud)
+and two embedders (minilm, openai). Each implementation predates v0.4.0
+and was working in production. The protocols introduced in v0.4.0 do not
+change those implementations — they formalize the surface they already
+expose, so that:
+
+1. **Custom implementations** can satisfy a stable, documented contract
+2. **A conformance test suite** can validate any implementation against
+   the contract programmatically
+3. **Multi-tenant isolation** can be guaranteed at the protocol level,
+   not as an opt-in feature
+
+Both protocols are `typing.Protocol` definitions decorated with
+`@runtime_checkable`, so `isinstance(my_backend, Backend)` returns
+`True` if your class has the required methods. The conformance suite
+(`tests/compat/`) goes further — it checks parameter names, kinds,
+defaults, and behavioral round-trip semantics.
+
+---
+
+## Backend protocol
+
+Defined in `sulci/backends/protocol.py`. Three methods every backend
+must implement, plus one class-level annotation.
+
+### `store()`
+
+```python
+def store(
+    self,
+    key: str,
+    query: str,
+    response: str,
+    embedding: list[float],
+    *,
+    tenant_id: Optional[str] = None,
+    user_id:   Optional[str] = None,
+    expires:   Optional[float] = None,
+    metadata:  Optional[dict] = None,
+) -> None:
+```
+
+Insert or replace one cache entry.
+
+| Parameter | Semantics |
+|---|---|
+| `key` | Deterministic identifier (typically a hash of tenant + user + query). Used for upsert. |
+| `query` | Original query text. Stored for debugging only — not used in retrieval. |
+| `response` | The LLM response text being cached. |
+| `embedding` | L2-normalized vector representation of `query`. Length must match the embedder's `dimension`. |
+| `tenant_id` | Optional partition key. `None` is stored as the literal sentinel `"global"`. See *Multi-tenancy* below. |
+| `user_id` | Optional within-tenant partition key. Same `None` → `"global"` semantics as `tenant_id`. |
+| `expires` | Unix timestamp after which this entry is stale. `None` means no expiry. |
+| `metadata` | Arbitrary application-defined fields, stored alongside the entry. |
+
+The kwargs after `*` are **keyword-only**. Calling code must use
+`store(..., tenant_id=...)`, never positional. This is enforced at
+the protocol level so callers can't accidentally swap arguments.
+
+**Behavioral requirements:**
+
+- MUST upsert by `key` — calling `store` twice with the same `key`
+  replaces the existing entry rather than creating duplicates.
+- MUST normalize `tenant_id=None` and `user_id=None` to `"global"`
+  before storage, so that subsequent searches with `None` find them.
+- SHOULD log, not raise, on transient backend errors. A failed write
+  should never crash the calling application.
+
+### `search()`
+
+```python
+def search(
+    self,
+    embedding: list[float],
+    threshold: float,
+    *,
+    tenant_id: Optional[str] = None,
+    user_id:   Optional[str] = None,
+    now:       Optional[float] = None,
+) -> tuple[Optional[str], float]:
+```
+
+Approximate nearest-neighbor search by cosine similarity, restricted
+by tenant and user partition.
+
+Returns `(response, similarity)` if a hit at or above `threshold`,
+otherwise `(None, 0.0)`.
+
+| Parameter | Semantics |
+|---|---|
+| `embedding` | The L2-normalized query vector. |
+| `threshold` | Minimum cosine similarity (0.0–1.0) to count as a hit. |
+| `tenant_id` | Optional partition filter. `None` matches the `"global"` partition only — never other named tenants. |
+| `user_id` | Optional within-tenant filter. Same partition semantics as `tenant_id`. |
+| `now` | Unix timestamp for TTL comparison. Defaults to `time.time()`. Provided for test determinism. |
+
+**Behavioral requirements:**
+
+- MUST honor tenant isolation as a hard boundary. Entries from a
+  different `tenant_id` MUST NOT be returned, even when their
+  similarity exceeds `threshold`. This is the protocol's strongest
+  guarantee. See `tests/test_qdrant_tenant_isolation.py` for the
+  scenarios that pin this behavior.
+- MUST honor `user_id` partitioning the same way, layered within
+  tenant. Different-tenant + same-user_id MUST miss.
+- MUST treat `None` and `"global"` symmetrically on the read path.
+  This pairs with `store()`'s sentinel normalization. Any asymmetry
+  here is a cross-tenant data leak (caught and fixed in v0.4.0
+  phase 1.4).
+- MUST NOT raise on connectivity errors. Return `(None, 0.0)` and
+  log instead. A broken cache must degrade to "no cache" silently —
+  the user's application must never crash because of cache trouble.
+- MUST exclude expired entries (entries with `expires` set and
+  `expires < now`).
+
+### `clear()`
+
+```python
+def clear(self) -> None:
+```
+
+Remove all entries. Destructive, idempotent.
+
+Typically used in tests; production should prefer TTL-based expiry
+or per-user/per-tenant deletion (which is *not* part of the v0.4.0
+protocol — it's an enterprise-tier concern).
+
+For backends like Qdrant where `clear` could either delete the
+underlying schema or just the data: the protocol semantics are
+"empty the cache" — implementations should preserve the underlying
+storage structure (collections, indexes, etc.) so subsequent
+operations work without rebuilding.
+
+### `ENFORCES_TENANT_ISOLATION` class attribute
+
+```python
+class MyBackend:
+    ENFORCES_TENANT_ISOLATION: bool = True
+```
+
+A class-level boolean declaring whether this backend honors the
+tenant isolation contract on the read path.
+
+- `True` — `search()` filters out entries from other tenants. The
+  conformance suite runs `TestTenantIsolation` against this backend.
+- `False` — backend accepts `tenant_id` as a labeling field but does
+  not filter on it. The conformance suite skips isolation tests.
+  This is acceptable for backends where multi-tenant isolation is a
+  non-goal (e.g., embedded SQLite for solo developers).
+
+The shipped backends declare:
+
+| Backend | `ENFORCES_TENANT_ISOLATION` |
+|---|---|
+| QdrantBackend | `True` |
+| ChromaBackend | `False` (tenant_id stored as label, not filtered) |
+| SQLiteBackend, RedisBackend, FAISSBackend, MilvusBackend | `False` |
+| SulciCloudBackend | `False` (enforced server-side; OSS conformance can't reach the gateway) |
+
+Custom backends must declare this attribute. Conformance fails if it's missing.
+
+---
+
+## Embedder protocol
+
+Defined in `sulci/embeddings/protocol.py`. Three members.
+
+### `dimension` property
+
+```python
+@property
+def dimension(self) -> int:
+```
+
+Vector dimensionality. MUST be:
+
+- A positive integer
+- Stable for the lifetime of the embedder instance
+- Exposed as a `@property` (not a plain attribute, not a method)
+
+The `Cache` uses this at construction time to size backend collections.
+
+### `embed()`
+
+```python
+def embed(self, text: str) -> list[float]:
+```
+
+Embed a single text string. Returns a list of `dimension` floats,
+**L2-normalized** (i.e. `||v|| ≈ 1.0`).
+
+The L2 normalization requirement is critical. Sulci backends use
+cosine similarity assuming unit-length vectors. An unnormalized
+embedder produces incorrect similarity scores and silently breaks
+cache-hit semantics.
+
+### `embed_batch()`
+
+```python
+def embed_batch(self, texts: list[str]) -> list[list[float]]:
+```
+
+Embed a list of texts. Returns a list of `dimension`-length vectors
+in the same order as the inputs, each L2-normalized.
+
+This is the hot path for benchmark workloads and bulk imports.
+Implementations should batch internally where the underlying model
+supports it (e.g. sentence-transformers' `batch_size` argument).
+
+---
+
+## Verifying conformance
+
+Sulci ships a public conformance test suite at `tests/compat/`. It
+parametrizes across every class in two registries:
+`BACKEND_CLASSES` and `EMBEDDER_CLASSES`. Both are defined in
+`tests/compat/conftest.py`.
+
+### Adding your class to the registry
+
+```python
+# tests/compat/conftest.py
+
+from my_package.backends import MyCustomBackend
+
+BACKEND_CLASSES = [
+    cls for cls in [
+        # ... existing backends ...
+        MyCustomBackend,
+    ]
+    if cls is not None
+]
+```
+
+Add a corresponding clause to `_try_construct_backend` so the suite
+knows how to build a live instance for behavioral tests:
+
+```python
+if name == "MyCustomBackend":
+    try:
+        return cls(my_required_arg="...")
+    except Exception:
+        return None  # behavioral tests will skip; structural still run
+```
+
+### What the suite checks
+
+Three test groups, each with different infrastructure requirements:
+
+| Group | Checks | Runs when |
+|---|---|---|
+| `TestStructural` | `isinstance(b, Backend)`, parameter names + kinds + defaults via `inspect.signature`, presence of `ENFORCES_TENANT_ISOLATION` | Always |
+| `TestRoundTrip` | `store()` + `search()` returns the stored response; `clear()` empties the backend | When `_try_construct_backend` returns a live instance |
+| `TestTenantIsolation` | Cross-tenant search misses; same-tenant search hits | When `ENFORCES_TENANT_ISOLATION = True` AND backend is constructable |
+
+### Run
+
+```bash
+pytest tests/compat/ -v
+```
+
+Structural tests are fast (sub-second per backend) and will catch
+signature mismatches immediately. Behavioral tests are slower and
+require infrastructure for backends like Qdrant, Redis, Milvus.
+
+---
+
+## Where this fits in the architecture
+
+The Backend and Embedder protocols are the OSS extension surface.
+They define the contract between Sulci's `Cache` class and any
+storage/embedding driver — that's their full scope. Two important
+boundaries to be aware of:
+
+**Calling code is responsible for `tenant_id` and `user_id`.** The
+protocol exposes both as kwargs on `store()` and `search()`, and
+makes no assumption about where they come from. A solo developer
+using sulci as a personal cache passes neither. A multi-tenant SaaS
+embedding sulci passes both, derived from whatever identity layer
+the application uses.
+
+**Sulci Cloud (the managed product) sits one layer above.** If
+you're using `Cache(backend="sulci")`, the gateway derives
+`tenant_id` from your API key before the request reaches a backend
+driver. End-user application code in that case never touches
+`tenant_id` directly. This is platform behavior, not protocol
+behavior — see [Multi-Tenancy and Data Isolation](multi_tenancy_and_isolation.md)
+for the OSS-layer trust model.
+
+---
+
+## Stability and versioning
+
+Both protocols are declared **STABLE API** in their respective
+source files (`sulci/backends/protocol.py`,
+`sulci/embeddings/protocol.py`). This means:
+
+- Removing a method or kwarg is a **breaking change**. Custom
+  implementations would no longer satisfy the contract.
+- Adding a new optional kwarg is **backwards-compatible** if the
+  default preserves existing behavior. Existing implementations
+  satisfying the old contract still satisfy the new one.
+- Changing the *semantics* of an existing method (e.g. what
+  `tenant_id=None` means on the read path) is a breaking change
+  even if the signature is unchanged. v0.4.0 phase 1.4 was this kind
+  of change, and it landed in a minor release because there were
+  no shipped consumers of v0.4.0's behavior yet.
+
+Per ADR 0005, future protocol modifications require a superseding
+ADR before merge.
+
+---
+
+## See also
+
+- **`examples/extending_sulci/custom_backend.py`** — A worked
+  reference implementation. ~150 lines, in-memory dict-based,
+  satisfies the protocol fully. Run it directly to see a self-test
+  pass.
+- **`docs/multi_tenancy_and_isolation.md`** — The customer-facing
+  scenarios and trust model that motivate the protocol's tenant
+  isolation requirements.
+- **`tests/compat/`** — The conformance test suite itself.
+- **`tests/test_qdrant_tenant_isolation.py`** — End-to-end isolation
+  scenarios, framed as customer-support product cases.

--- a/examples/anthropic_example.py
+++ b/examples/anthropic_example.py
@@ -4,7 +4,7 @@ examples/anthropic_example.py
 Production-ready Sulci + Anthropic Claude integration with context awareness.
 
 Requirements:
-    pip install "sulci[chroma]" anthropic
+    pip install "sulci[sqlite]" anthropic
     export ANTHROPIC_API_KEY=sk-ant-...
 
 Run:
@@ -17,7 +17,7 @@ from sulci import Cache
 
 # ── Cache configuration ───────────────────────────────────────────────────
 cache = Cache(
-    backend         = "chroma",
+    backend         = "sqlite",   # default-available; works with `pip install "sulci[sqlite]"`
     threshold       = 0.85,
     embedding_model = "minilm",
     ttl_seconds     = 86400,
@@ -30,25 +30,35 @@ cache = Cache(
 )
 
 # ── Anthropic client ──────────────────────────────────────────────────────
-try:
-    import anthropic
-    _client = anthropic.Anthropic()
-
-    def call_claude(query: str, model: str = "claude-sonnet-4-20250514") -> str:
-        msg = _client.messages.create(
-            model      = model,
-            max_tokens = 1024,
-            messages   = [{"role": "user", "content": query}],
-        )
-        return msg.content[0].text
-
-    print("✓ Anthropic client ready\n")
-
-except ImportError:
-    print("⚠  anthropic not installed — using mock LLM\n")
-
+def _make_mock_call_claude():
     def call_claude(query: str, **_) -> str:
         return f"[Mock] Answer to: {query}"
+    return call_claude
+
+try:
+    import anthropic
+except ImportError:
+    print("⚠  anthropic SDK not installed — using mock LLM")
+    print("   To run with real Claude: pip install anthropic\n")
+    call_claude = _make_mock_call_claude()
+else:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("⚠  ANTHROPIC_API_KEY not set — using mock LLM")
+        print("   To run with real Claude: export ANTHROPIC_API_KEY=sk-ant-...")
+        print("   Get a key at https://console.anthropic.com/\n")
+        call_claude = _make_mock_call_claude()
+    else:
+        _client = anthropic.Anthropic()
+
+        def call_claude(query: str, model: str = "claude-sonnet-4-20250514") -> str:
+            msg = _client.messages.create(
+                model      = model,
+                max_tokens = 1024,
+                messages   = [{"role": "user", "content": query}],
+            )
+            return msg.content[0].text
+
+        print("✓ Anthropic client ready\n")
 
 
 # ── Context-aware chat wrapper ────────────────────────────────────────────

--- a/examples/extending_sulci/README.md
+++ b/examples/extending_sulci/README.md
@@ -1,0 +1,30 @@
+# Extending Sulci
+
+This directory contains **reference implementations** of sulci's public protocols.
+
+These files are different in purpose from the other examples in `examples/`:
+
+- `examples/*.py` — *usage* examples ("how do I use sulci in my LangChain app?")
+- `examples/extending_sulci/*.py` — *extension* examples ("how do I write my own backend?")
+
+If you want to implement a custom backend or embedder for sulci, start here. Each
+file is a worked example you can copy into your own codebase, adapt to your
+infrastructure, and verify against sulci's conformance test suite.
+
+## What's here
+
+- **`custom_backend.py`** — In-memory dict-based backend that satisfies the full
+  Backend protocol. Run it directly to see it pass a self-test, or load
+  `InMemoryBackend` into your own conformance suite to validate your environment.
+
+## Verifying your custom implementation
+
+1. Implement your class against the protocol surface in
+   `sulci/backends/protocol.py` (or `sulci/embeddings/protocol.py`).
+2. Add your class to `BACKEND_CLASSES` (or `EMBEDDER_CLASSES`) in
+   `tests/compat/conftest.py`.
+3. Run `pytest tests/compat/` and confirm the conformance suite passes.
+
+See `docs/protocols.md` for the full protocol contract, and
+`docs/multi_tenancy_and_isolation.md` for the tenant isolation guarantees
+your backend must satisfy if it sets `ENFORCES_TENANT_ISOLATION = True`.

--- a/examples/extending_sulci/custom_backend.py
+++ b/examples/extending_sulci/custom_backend.py
@@ -1,0 +1,226 @@
+"""
+examples/extending_sulci/custom_backend.py
+==========================================
+A worked example showing how to implement a custom Backend that conforms
+to the sulci v0.4.0+ Backend protocol.
+
+This implementation is **deliberately simple** — an in-memory dict with
+linear-scan cosine similarity. Real backends (Qdrant, Chroma, FAISS,
+etc.) use specialized vector indexes; this example trades performance
+for clarity so the protocol contract is the only thing on screen.
+
+Run this file directly to see the backend in action:
+
+    python examples/extending_sulci/custom_backend.py
+
+Validate conformance with the public test suite:
+
+    # In your project's tests/ directory:
+    from examples.extending_sulci.custom_backend import InMemoryBackend
+    # Then add InMemoryBackend to BACKEND_CLASSES in tests/compat/conftest.py
+    # and run: pytest tests/compat/
+
+The protocol is documented in docs/protocols.md. Multi-tenancy semantics
+are documented in docs/multi_tenancy_and_isolation.md.
+"""
+from __future__ import annotations
+import math
+import time
+from typing import Optional
+
+
+class InMemoryBackend:
+    """
+    Reference implementation of the Backend protocol.
+
+    Stores entries in a Python list. Every search() does a linear cosine
+    scan — O(N) per query. Don't ship this for production; ship Qdrant,
+    Chroma, or FAISS. This exists to show the contract.
+    """
+
+    #: This backend treats tenant_id as a real partition key — entries
+    #: written under one tenant_id are never returned to a search under
+    #: a different tenant_id, even when their similarity is high.
+    ENFORCES_TENANT_ISOLATION: bool = True
+
+    def __init__(self):
+        # Each entry is a dict with: key, query, response, embedding,
+        # tenant_id, user_id, expires, metadata. Stored as a list so
+        # iteration order is stable for tests.
+        self._entries: list[dict] = []
+
+    # ---- Backend protocol methods -------------------------------------------
+
+    def store(
+        self,
+        key: str,
+        query: str,
+        response: str,
+        embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        expires: Optional[float] = None,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        """
+        Insert or replace a cache entry.
+
+        The protocol stores tenant_id=None and user_id=None as the literal
+        sentinel "global" so that searches with None pass through the
+        same partition rather than returning anything-and-everything.
+        See docs/multi_tenancy_and_isolation.md "operational migration"
+        section for why this matters.
+        """
+        # Normalize sentinels at the storage boundary so search-time
+        # filtering can compare against canonical values.
+        entry = {
+            "key":       key,
+            "query":     query,
+            "response":  response,
+            "embedding": embedding,
+            "tenant_id": tenant_id if tenant_id is not None else "global",
+            "user_id":   user_id   if user_id   is not None else "global",
+            "expires":   expires,
+            "metadata":  metadata or {},
+        }
+
+        # Upsert by key — replace existing entry with same key, otherwise append.
+        for i, existing in enumerate(self._entries):
+            if existing["key"] == key:
+                self._entries[i] = entry
+                return
+        self._entries.append(entry)
+
+    def search(
+        self,
+        embedding: list[float],
+        threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> tuple[Optional[str], float]:
+        """
+        Linear-scan cosine search with tenant + user partition filtering.
+
+        Returns (response, similarity) on hit, (None, 0.0) on miss.
+        Never raises — a backend that fails a search must degrade
+        gracefully to "no cache" rather than crashing the caller.
+        """
+        # Normalize search-time sentinels to match the storage boundary.
+        # Without this, tenant_id=None on read would not match tenant_id="global"
+        # on write — a real cross-tenant data leak we caught in v0.4.0 phase 1.4.
+        target_tenant = tenant_id if tenant_id is not None else "global"
+        target_user   = user_id   if user_id   is not None else "global"
+        now = now if now is not None else time.time()
+
+        try:
+            best_sim:  float = 0.0
+            best_resp: Optional[str] = None
+
+            for entry in self._entries:
+                # Tenant isolation: hard filter, applied before similarity.
+                if entry["tenant_id"] != target_tenant:
+                    continue
+                if entry["user_id"] != target_user:
+                    continue
+
+                # TTL filter: skip expired entries silently.
+                if entry["expires"] is not None and now > entry["expires"]:
+                    continue
+
+                sim = _cosine_similarity(embedding, entry["embedding"])
+                if sim >= threshold and sim > best_sim:
+                    best_sim  = sim
+                    best_resp = entry["response"]
+
+            return (best_resp, best_sim) if best_resp is not None else (None, 0.0)
+        except Exception:
+            # Backend connectivity errors must not propagate — return a
+            # clean miss instead. This is a core sulci invariant: a
+            # broken cache degrades to "no cache" quietly.
+            return (None, 0.0)
+
+    def clear(self) -> None:
+        """Remove all entries. Destructive, idempotent."""
+        self._entries.clear()
+
+
+# -----------------------------------------------------------------------------
+# Helpers — not part of the protocol, just used by this example's search().
+# -----------------------------------------------------------------------------
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """
+    Cosine similarity between two vectors. Assumes inputs are
+    already L2-normalized (which sulci embedders guarantee), in which
+    case cosine similarity is just the dot product.
+    """
+    if len(a) != len(b):
+        return 0.0
+    return sum(x * y for x, y in zip(a, b))
+
+
+# -----------------------------------------------------------------------------
+# Self-test — run this file directly.
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("InMemoryBackend self-test")
+    print("=" * 50)
+
+    backend = InMemoryBackend()
+
+    # Two L2-normalized vectors. v1 and v2 are nearly identical (high sim);
+    # v3 is orthogonal (zero sim).
+    v1 = [1.0, 0.0, 0.0]
+    v2 = [0.99, 0.14, 0.0]   # ~99% similar to v1
+    v3 = [0.0, 0.0, 1.0]     # orthogonal to v1
+
+    # 1. Empty search returns miss
+    resp, sim = backend.search(v1, threshold=0.5)
+    print(f"\n1. Empty search:           resp={resp!r}  sim={sim:.3f}")
+    assert resp is None and sim == 0.0
+
+    # 2. Store and retrieve
+    backend.store(
+        key="k1", query="hello", response="world",
+        embedding=v1, tenant_id="acme",
+    )
+    resp, sim = backend.search(v1, threshold=0.5, tenant_id="acme")
+    print(f"2. Same-tenant exact hit:  resp={resp!r}  sim={sim:.3f}")
+    assert resp == "world" and sim > 0.99
+
+    # 3. Cross-tenant must miss (tenant isolation guarantee)
+    resp, sim = backend.search(v1, threshold=0.5, tenant_id="globex")
+    print(f"3. Cross-tenant search:    resp={resp!r}  sim={sim:.3f}")
+    assert resp is None and sim == 0.0, "Tenant isolation breach!"
+
+    # 4. Paraphrased query (high sim) within tenant — hits
+    resp, sim = backend.search(v2, threshold=0.85, tenant_id="acme")
+    print(f"4. Paraphrase same tenant: resp={resp!r}  sim={sim:.3f}")
+    assert resp == "world"
+
+    # 5. Different topic (orthogonal vec) — misses even within tenant
+    resp, sim = backend.search(v3, threshold=0.85, tenant_id="acme")
+    print(f"5. Different topic:        resp={resp!r}  sim={sim:.3f}")
+    assert resp is None
+
+    # 6. Solo-developer mode (no tenant_id) round-trips correctly
+    backend.store(
+        key="solo", query="aws", response="lambda answer",
+        embedding=v1,
+    )
+    resp, sim = backend.search(v1, threshold=0.5)
+    print(f"6. Solo (no tenant):       resp={resp!r}  sim={sim:.3f}")
+    assert resp == "lambda answer"
+
+    # 7. clear() empties the backend
+    backend.clear()
+    resp, sim = backend.search(v1, threshold=0.5, tenant_id="acme")
+    print(f"7. After clear():          resp={resp!r}  sim={sim:.3f}")
+    assert resp is None
+
+    print("\n" + "=" * 50)
+    print("All assertions passed. InMemoryBackend conforms to the protocol.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version         = "0.3.7"
+version         = "0.4.0"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,62 @@
+# scripts/
+
+Developer tooling for sulci-oss. These scripts are not part of the published
+package — they exist to help contributors run pre-commit / pre-release
+verification more reliably than ad-hoc shell loops.
+
+## What's here
+
+| Script | Purpose | Typical wall-clock | API cost |
+|---|---|---|---|
+| `run_tests_per_file.py` | Run pytest test files one at a time, in fresh subprocesses | 10-15 min full sweep on M-series Mac | none |
+| `run_examples.py` | Run every example + smoke test with timeout, capture pass/fail | 10-15 min full sweep on M-series Mac | none with mock fallback; small $ if API keys are set |
+| `verify_integration_examples.py` | Verify langchain & llamaindex examples select the right LLM provider across 4 credential scenarios | 10-15 min for full 8-run matrix | $0.10-0.20 |
+| `verify_benchmark.py` | Run the canonical TF-IDF benchmark and verify headline numbers (hit rate, +20.8pp delta, $21.47 saved) match `benchmark/baseline.json` within tolerance | ~15s | none |
+
+## Why per-file pytest invocations?
+
+The `run_tests_per_file.py` script doesn't run `pytest tests/` as one command —
+it runs each file in its own subprocess. This is deliberate: several
+integration tests construct multiple `MiniLMEmbedder` instances in one process,
+which on Apple Silicon (MPS) occasionally deadlocks at `embeddings.cpu()`
+under memory pressure. Running each test file in a fresh Python process gives
+each one a clean MiniLM cold-start and avoids the deadlock.
+
+Trade-off: every subprocess pays its own MiniLM cold-load cost (~30-40s on
+M-series Macs, much less on CPU-only Linux runners). Wall-clock is longer
+than a single pytest invocation. CI doesn't need this — it uses a single
+pytest invocation on a clean Linux runner where MPS is irrelevant.
+
+## When to use which
+
+Picking by what you changed:
+
+| If you changed... | Run |
+|---|---|
+| `sulci/` source code | `make test-per-file` |
+| `examples/*.py` or `smoke_test*.py` | `make examples` |
+| `examples/langchain_example.py` or `examples/llamaindex_example.py` (and you have API keys) | `make verify-integration-examples` |
+| `benchmark/` files or anything that affects benchmark numbers | `make benchmark-verify` |
+| Anything before opening a PR | `make checkin` |
+
+## Output and logs
+
+All three scripts save per-target log files to `/tmp/sulci-*-runner/`. On
+failure, the summary table prints the path of the failing log so you can
+inspect what actually went wrong rather than re-running with `-v`.
+
+Override the log directory with `--log-dir <path>` on any script.
+
+## Adding new scripts
+
+If you add a new runner here:
+
+1. Make it a `#!/usr/bin/env python3` script with `chmod +x`
+2. Use `argparse` with a `--help` that explains preconditions and exit codes
+3. Use `subprocess.run(timeout=...)` rather than the GNU `timeout` command
+   (macOS doesn't ship `timeout` by default; `subprocess.run` is portable)
+4. Save per-target logs to `/tmp/<runner-name>/` so failure diagnosis
+   doesn't require re-running the whole sweep
+5. Add a Makefile target so other contributors don't have to remember
+   the exact invocation
+6. Update this README with a new row in the "What's here" table

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+scripts/run_examples.py
+========================
+Run every example and smoke test in this repository, report pass/fail/timeout
+per file, and produce a summary table.
+
+What it covers:
+    * examples/*.py              — usage examples (basic_usage, context_aware,
+                                   anthropic, langchain, llamaindex, async)
+    * examples/extending_sulci/  — protocol-implementation reference impls
+    * smoke_test*.py             — end-to-end smoke tests at repo root
+
+What it doesn't cover:
+    * The pytest test suite — use scripts/run_tests_per_file.py for that
+    * The provider-detection matrix — use scripts/verify_integration_examples.py
+
+API key behavior:
+    Examples that integrate with LLM providers (anthropic, langchain,
+    llamaindex, async_example) detect ANTHROPIC_API_KEY / OPENAI_API_KEY
+    and fall back to a mock LLM if neither is set. This script does NOT
+    set or clear keys — it runs each example with whatever's in the
+    environment, so by default mock fallback is exercised.
+
+Default behavior:
+    On Apple Silicon MPS, first MiniLM load is ~30-40s. Each example
+    runs in its own Python subprocess paying its own cold-start. Default
+    per-example timeout is 120s, override with --timeout.
+
+Usage:
+    python scripts/run_examples.py
+    python scripts/run_examples.py --timeout 180
+    python scripts/run_examples.py --filter examples/basic_usage.py
+
+Exit codes:
+    0   all selected examples completed (exit 0 in their own process)
+    1   at least one example failed or timed out
+    2   harness error (no examples found, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Default discovery: examples/, examples/extending_sulci/, and smoke_test*.py.
+# Order chosen to surface fast/standalone failures first; LLM-using examples
+# come later because they're slowest (real or mock LLM calls).
+DEFAULT_FILES = [
+    # Quick, no LLM
+    "examples/basic_usage.py",
+    "examples/extending_sulci/custom_backend.py",
+
+    # Smoke tests (also fast, run once per Python process)
+    "smoke_test.py",
+    "smoke_test_async.py",
+    "smoke_test_langchain.py",
+    "smoke_test_llamaindex.py",
+
+    # Context-aware examples (no LLM, ~30-90s with MiniLM warmup)
+    "examples/context_aware.py",
+    "examples/context_aware_example.py",
+
+    # LLM-using examples (mock fallback if no keys, real if keys are set)
+    "examples/async_example.py",
+    "examples/anthropic_example.py",
+    "examples/langchain_example.py",
+    "examples/llamaindex_example.py",
+]
+
+
+def run_one(target: str, timeout_sec: int, log_dir: Path) -> dict:
+    """Run a single example/script and capture its outcome."""
+    log_path = log_dir / (target.replace("/", "_") + ".log")
+    cmd = [sys.executable, target]
+
+    print(f"  running: {target} ... ", end="", flush=True)
+    t0 = time.time()
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           timeout=timeout_sec, cwd=REPO_ROOT)
+        wallclock = time.time() - t0
+        log_path.write_text(
+            "=== STDOUT ===\n" + r.stdout +
+            "\n=== STDERR ===\n" + r.stderr +
+            f"\n=== exit: {r.returncode}, wallclock: {wallclock:.1f}s ===\n"
+        )
+        if r.returncode == 0:
+            print(f"PASS    {wallclock:.1f}s")
+            return {"target": target, "ok": True, "status": "PASS",
+                    "wallclock": wallclock, "exit_code": 0,
+                    "log": str(log_path)}
+        else:
+            print(f"FAIL    exit={r.returncode}  {wallclock:.1f}s")
+            return {"target": target, "ok": False, "status": "FAIL",
+                    "wallclock": wallclock, "exit_code": r.returncode,
+                    "log": str(log_path)}
+    except subprocess.TimeoutExpired as e:
+        wallclock = time.time() - t0
+        # Capture whatever was written before kill, for diagnosis.
+        stdout_partial = (e.stdout.decode() if e.stdout else "") if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr_partial = (e.stderr.decode() if e.stderr else "") if isinstance(e.stderr, bytes) else (e.stderr or "")
+        log_path.write_text(
+            "=== TIMEOUT ===\n"
+            f"Killed after {wallclock:.1f}s (limit {timeout_sec}s)\n\n"
+            "=== STDOUT (partial) ===\n" + stdout_partial +
+            "\n=== STDERR (partial) ===\n" + stderr_partial
+        )
+        print(f"TIMEOUT  {wallclock:.1f}s (limit {timeout_sec}s)")
+        return {"target": target, "ok": False, "status": "TIMEOUT",
+                "wallclock": wallclock, "exit_code": -1,
+                "log": str(log_path)}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--timeout", type=int, default=120,
+                   help="per-example wall-clock timeout in seconds (default: 120). "
+                        "Cold MiniLM load ~30-40s on Apple Silicon MPS, plus example "
+                        "work, plus real LLM calls if keys are set.")
+    p.add_argument("--files", nargs="+", default=None,
+                   help="specific files to run (default: all examples + smoke tests)")
+    p.add_argument("--filter", default=None,
+                   help="run only files containing this substring in their path")
+    p.add_argument("--log-dir", default="/tmp/sulci-examples-runner",
+                   help="where to save per-file log output")
+    args = p.parse_args()
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    targets = args.files if args.files else DEFAULT_FILES
+    if args.filter:
+        targets = [t for t in targets if args.filter in t]
+
+    missing = [t for t in targets if not (REPO_ROOT / t).exists()]
+    if missing:
+        print(f"ERROR: missing target paths: {missing}", file=sys.stderr)
+        return 2
+    if not targets:
+        print("ERROR: no targets selected", file=sys.stderr)
+        return 2
+
+    # Detect which API keys are set, just for an informational header.
+    keys = []
+    if os.environ.get("OPENAI_API_KEY"):    keys.append("OPENAI_API_KEY")
+    if os.environ.get("ANTHROPIC_API_KEY"): keys.append("ANTHROPIC_API_KEY")
+    keys_label = ", ".join(keys) if keys else "none (mock fallback for LLM examples)"
+
+    print("=" * 70)
+    print(" Sulci examples + smoke-test runner")
+    print(f" timeout-per-file: {args.timeout}s   targets: {len(targets)}")
+    print(f" API keys in env:  {keys_label}")
+    print(f" logs: {log_dir}")
+    print("=" * 70)
+
+    results = []
+    overall_t0 = time.time()
+    for target in targets:
+        results.append(run_one(target, args.timeout, log_dir))
+    total = time.time() - overall_t0
+
+    # Summary
+    print("\n" + "=" * 70)
+    print(f" SUMMARY ({total:.1f}s total wall-clock)")
+    print("=" * 70)
+    print(f"  {'Target':<48} {'Status':<8}  {'time':>7}")
+    print(f"  {'-'*48} {'-'*8}  {'-'*7}")
+    for r in results:
+        print(f"  {r['target']:<48} {r['status']:<8}  {r['wallclock']:>6.1f}s")
+
+    passed = sum(1 for r in results if r["ok"])
+    total_count = len(results)
+    failing = [r for r in results if not r["ok"]]
+
+    print(f"\n  TOTAL: {passed}/{total_count} passed")
+    if failing:
+        print(f"\n  Failing targets (logs in {log_dir}):")
+        for r in failing:
+            print(f"    - {r['target']}  →  {r['log']}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_tests_per_file.py
+++ b/scripts/run_tests_per_file.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+scripts/run_tests_per_file.py
+==============================
+Run each test file in tests/ in its own pytest invocation, sequentially.
+
+Why one file at a time:
+    Several integration tests (langchain, llamaindex) construct multiple
+    MiniLMEmbedder instances in one process. On Apple Silicon (MPS), this
+    occasionally deadlocks at embeddings.cpu() under memory pressure.
+    Running each test file in a fresh Python process avoids that and gives
+    each file a clean MiniLM cold-start.
+
+Trade-off:
+    Wall-clock time is longer than a single 'pytest tests/' because every
+    test file pays the MiniLM warm-up cost (~10s on M-series Macs).
+    On a CPU-only Linux runner the difference is much smaller.
+
+Usage:
+    python scripts/run_tests_per_file.py
+    python scripts/run_tests_per_file.py --timeout 90
+    python scripts/run_tests_per_file.py --files tests/test_core.py tests/test_context.py
+    python scripts/run_tests_per_file.py --skip-slow
+
+Exit codes:
+    0   all selected files passed (zero failures, zero errors)
+    1   at least one file failed or errored
+    2   harness error (bad arguments, missing files, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+# Default order matches the per-file sweeps used during v0.4.0 verification.
+# Fast files first so failures fail loud and early; slowest last.
+DEFAULT_FILES = [
+    "tests/test_backends.py",
+    "tests/test_cloud_backend.py",
+    "tests/test_connect.py",
+    "tests/test_context.py",
+    "tests/test_core.py",
+    "tests/test_async_cache.py",
+    "tests/test_qdrant_tenant_isolation.py",
+    "tests/test_integrations_langchain.py",
+    "tests/test_integrations_llamaindex.py",
+    "tests/compat/",
+]
+
+# Files that are typically slow (>1 min). Used by --skip-slow.
+SLOW_FILES = {
+    "tests/test_integrations_langchain.py",
+    "tests/test_integrations_llamaindex.py",
+    "tests/test_async_cache.py",
+    "tests/test_core.py",
+}
+
+# Pytest summary tokens can appear in any order: "1 failed, 27 passed in 73s"
+# or "28 passed in 55s" or "5 passed, 3 skipped in 12s" etc.
+# Each count gets its own regex; we look at the final summary line.
+COUNT_PATTERNS = {
+    "passed":  re.compile(r"(\d+)\s+passed"),
+    "failed":  re.compile(r"(\d+)\s+failed"),
+    "errors":  re.compile(r"(\d+)\s+error"),  # matches "error" and "errors"
+    "skipped": re.compile(r"(\d+)\s+skipped"),
+}
+RUNTIME_PATTERN = re.compile(r"in\s+([\d.]+)s")
+
+
+def parse_summary(stdout: str) -> Tuple[int, int, int, int, float]:
+    """Extract (passed, failed, errors, skipped, runtime_sec) from pytest output."""
+    # Find the last "=== ... ===" summary line that mentions any test outcome.
+    last_summary = None
+    for line in stdout.splitlines():
+        if (line.startswith("=") and
+                any(k in line for k in ("passed", "failed", "error", "skipped"))):
+            last_summary = line
+    if not last_summary:
+        return (0, 0, 0, 0, 0.0)
+
+    def _extract(pat: re.Pattern) -> int:
+        m = pat.search(last_summary)
+        return int(m.group(1)) if m else 0
+
+    passed  = _extract(COUNT_PATTERNS["passed"])
+    failed  = _extract(COUNT_PATTERNS["failed"])
+    errors  = _extract(COUNT_PATTERNS["errors"])
+    skipped = _extract(COUNT_PATTERNS["skipped"])
+
+    rm = RUNTIME_PATTERN.search(last_summary)
+    runtime = float(rm.group(1)) if rm else 0.0
+    return (passed, failed, errors, skipped, runtime)
+
+
+def run_one(target: str, timeout_sec: int, log_dir: Path) -> dict:
+    """Run pytest against a single target and return a result dict."""
+    log_path = log_dir / (target.replace("/", "_").rstrip("_") + ".log")
+    cmd = [sys.executable, "-m", "pytest", target, "-v",
+           f"--timeout={timeout_sec}", "--tb=short"]
+
+    print(f"  running: {target} ... ", end="", flush=True)
+    t0 = time.time()
+    try:
+        # Wall-clock budget for the whole subprocess: enough for many tests
+        # to run, each with timeout_sec individually. Cap minimum at 10 min.
+        wall_budget = max(timeout_sec * 30, 600)
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           timeout=wall_budget, cwd=REPO_ROOT)
+        wallclock = time.time() - t0
+        log_path.write_text(
+            "=== STDOUT ===\n" + r.stdout +
+            "\n=== STDERR ===\n" + r.stderr +
+            f"\n=== exit: {r.returncode}, wallclock: {wallclock:.1f}s ===\n"
+        )
+        passed, failed, errors, skipped, _ = parse_summary(r.stdout)
+        ok = (r.returncode == 0 and failed == 0 and errors == 0)
+        status = "PASS" if ok else "FAIL"
+        print(f"{status:5} ({passed}p, {failed}f, {errors}e, {skipped}s) {wallclock:.1f}s")
+        return {
+            "target": target, "passed": passed, "failed": failed,
+            "errors": errors, "skipped": skipped, "wallclock": wallclock,
+            "exit_code": r.returncode, "ok": ok, "log": str(log_path),
+        }
+    except subprocess.TimeoutExpired:
+        wallclock = time.time() - t0
+        log_path.write_text(f"TIMEOUT after {wallclock:.1f}s\n")
+        print(f"TIMEOUT {wallclock:.1f}s")
+        return {
+            "target": target, "passed": 0, "failed": 0, "errors": 1,
+            "skipped": 0, "wallclock": wallclock, "exit_code": -1,
+            "ok": False, "log": str(log_path),
+        }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--timeout", type=int, default=120,
+                   help="per-test pytest --timeout value in seconds (default: 120). "
+                        "Each subprocess pays its own MiniLM cold-start (~30s on "
+                        "Apple Silicon MPS), so 60s often trips on the first "
+                        "test of a freshly-spawned subprocess.")
+    p.add_argument("--files", nargs="+", default=None,
+                   help="specific test files/dirs to run (default: all)")
+    p.add_argument("--skip-slow", action="store_true",
+                   help="skip the slowest test files (langchain, llamaindex, async, core)")
+    p.add_argument("--log-dir", default="/tmp/sulci-test-runner",
+                   help="where to save per-file log output")
+    args = p.parse_args()
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    targets = args.files if args.files else DEFAULT_FILES
+    if args.skip_slow:
+        targets = [t for t in targets if t not in SLOW_FILES]
+
+    # Validate targets exist relative to repo root
+    missing = [t for t in targets if not (REPO_ROOT / t.rstrip("/")).exists()]
+    if missing:
+        print(f"ERROR: missing test paths: {missing}", file=sys.stderr)
+        return 2
+
+    print("=" * 70)
+    print(" Sulci per-file test runner")
+    print(f" timeout-per-file: {args.timeout}s   targets: {len(targets)}   logs: {log_dir}")
+    print("=" * 70)
+
+    results = []
+    overall_t0 = time.time()
+    for target in targets:
+        results.append(run_one(target, args.timeout, log_dir))
+    total_runtime = time.time() - overall_t0
+
+    # Summary table
+    print("\n" + "=" * 70)
+    print(f" SUMMARY ({total_runtime:.1f}s total wall-clock)")
+    print("=" * 70)
+    print(f"  {'Target':<48} {'Result':<6}  {'p':>4} {'f':>3} {'e':>3} {'s':>4} {'time':>7}")
+    print(f"  {'-'*48} {'-'*6}  {'-'*4} {'-'*3} {'-'*3} {'-'*4} {'-'*7}")
+    for r in results:
+        marker = "PASS" if r["ok"] else "FAIL"
+        print(f"  {r['target']:<48} {marker:<6}  "
+              f"{r['passed']:>4} {r['failed']:>3} {r['errors']:>3} "
+              f"{r['skipped']:>4} {r['wallclock']:>6.1f}s")
+
+    total_passed  = sum(r["passed"] for r in results)
+    total_failed  = sum(r["failed"] for r in results)
+    total_errors  = sum(r["errors"] for r in results)
+    total_skipped = sum(r["skipped"] for r in results)
+    failing       = [r for r in results if not r["ok"]]
+
+    print(f"\n  TOTAL: {total_passed} passed, {total_failed} failed, "
+          f"{total_errors} errors, {total_skipped} skipped")
+    if failing:
+        print(f"\n  Failing files (logs in {log_dir}):")
+        for r in failing:
+            print(f"    - {r['target']}  →  {r['log']}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_benchmark.py
+++ b/scripts/verify_benchmark.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+scripts/verify_benchmark.py
+============================
+Run the canonical TF-IDF benchmark and verify results against the committed
+baseline (benchmark/baseline.json). Fails if any non-latency metric drifts
+beyond tolerance.
+
+Why this exists:
+    The headline numbers on sulci.io and in benchmark/README.md (85.88% hit
+    rate, +20.8pp resolution accuracy, $21.47 saved per 5000 queries) come
+    from this benchmark. Any regression here is website-visible breakage.
+    'make checkin' should catch it before a PR lands.
+
+Tolerance:
+    Percentages: ±1.0 percentage point absolute
+    Counts:      ±2 absolute (dict-iteration tie-breaks differ across
+                 Linux/macOS; we observed exactly one such off-by-one)
+    Latency:     not checked (machine-dependent, varies 100x between
+                 a fast Linux runner and a power-saving laptop)
+
+Usage:
+    python scripts/verify_benchmark.py
+    python scripts/verify_benchmark.py --baseline path/to/other.json
+
+Exit codes:
+    0   all metrics within tolerance
+    1   one or more metrics drifted beyond tolerance
+    2   harness error (benchmark didn't run, JSON missing, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESULTS_DIR = REPO_ROOT / "benchmark" / "results"
+
+# Tolerances
+PCT_TOL    = 1.0   # 1.0 percentage point on rates
+COUNT_TOL  = 2     # 2 absolute on integer counts
+COST_TOL   = 0.50  # 50 cents on cost (5000-query budget is $25 baseline)
+
+
+def run_benchmark(timeout_sec: int) -> int:
+    print("Running canonical benchmark: python benchmark/run.py --no-sweep --context")
+    print("(expected wall-clock: 10-20 seconds; TF-IDF engine, no MPS / network)")
+    print()
+    try:
+        r = subprocess.run(
+            [sys.executable, "benchmark/run.py", "--no-sweep", "--context"],
+            cwd=REPO_ROOT,
+            timeout=timeout_sec,
+            capture_output=False,  # let it print to console for visibility
+        )
+        if r.returncode != 0:
+            print(f"\nERROR: benchmark/run.py exited with code {r.returncode}",
+                  file=sys.stderr)
+            return r.returncode
+        return 0
+    except subprocess.TimeoutExpired:
+        print(f"\nERROR: benchmark/run.py exceeded {timeout_sec}s timeout",
+              file=sys.stderr)
+        return -1
+
+
+def load_results() -> tuple[dict, dict]:
+    summary = RESULTS_DIR / "summary.json"
+    context = RESULTS_DIR / "context_summary.json"
+    if not summary.exists():
+        print(f"ERROR: {summary} not found (benchmark didn't produce stateless results)",
+              file=sys.stderr)
+        sys.exit(2)
+    if not context.exists():
+        print(f"ERROR: {context} not found (benchmark didn't produce context-aware results)",
+              file=sys.stderr)
+        sys.exit(2)
+    return (json.loads(summary.read_text()),
+            json.loads(context.read_text()))
+
+
+def compare(label: str, baseline_val, measured_val, tol, kind: str) -> tuple[bool, str]:
+    """
+    Compare a single metric. Returns (ok, formatted_diff_string).
+
+    kind is "pct" (percentage in 0-100), "rate" (rate in 0-1),
+            "count" (integer), or "money" (USD float).
+    """
+    delta = measured_val - baseline_val
+    abs_delta = abs(delta)
+    if kind == "pct":
+        formatted = f"{baseline_val:>7.2f} → {measured_val:>7.2f}  Δ={delta:+.2f}pp"
+        ok = abs_delta <= tol
+    elif kind == "rate":
+        formatted = f"{baseline_val:>7.4f} → {measured_val:>7.4f}  Δ={delta:+.4f}"
+        ok = abs_delta * 100 <= tol  # tol is in pp; rate is 0-1
+    elif kind == "count":
+        formatted = f"{baseline_val:>7d} → {measured_val:>7d}  Δ={delta:+d}"
+        ok = abs_delta <= tol
+    elif kind == "money":
+        formatted = f"${baseline_val:>6.2f} → ${measured_val:>6.2f}  Δ=${delta:+.2f}"
+        ok = abs_delta <= tol
+    else:
+        raise ValueError(f"unknown kind: {kind}")
+
+    marker = "OK" if ok else "DRIFT"
+    return ok, f"  [{marker:5}]  {label:<46} {formatted}"
+
+
+def verify_against_baseline(measured_summary: dict, measured_context: dict,
+                            baseline: dict) -> bool:
+    print("\n" + "=" * 72)
+    print(" Verifying benchmark output against baseline")
+    print(f" baseline: {baseline['_meta']['source']}")
+    print(f" tolerances: rates ±{PCT_TOL}pp, counts ±{COUNT_TOL}, money ±${COST_TOL:.2f}")
+    print("=" * 72)
+
+    all_ok = True
+
+    # Stateless headline
+    print("\n  Stateless (5000-query):")
+    bs = baseline["stateless"]
+    for label, key, kind, tol in [
+        ("hit_rate",            "hit_rate",            "rate",  PCT_TOL),
+        ("cache_hits",          "cache_hits",          "count", COUNT_TOL),
+        ("false_positives",     "false_positives",     "count", COUNT_TOL),
+        ("false_positive_rate", "false_positive_rate", "rate",  PCT_TOL),
+        ("saved_cost_usd",      "saved_cost_usd",      "money", COST_TOL),
+        ("cost_reduction_pct",  "cost_reduction_pct",  "pct",   PCT_TOL),
+    ]:
+        if key not in measured_summary:
+            print(f"  [MISS ]  {label:<46} not present in measured output")
+            all_ok = False
+            continue
+        ok, line = compare(label, bs[key], measured_summary[key], tol, kind)
+        print(line)
+        if not ok:
+            all_ok = False
+
+    # Context-aware headline
+    print("\n  Context-aware (125-followup):")
+    bc = baseline["context_aware"]
+    msl = measured_context.get("stateless", {})
+    mca = measured_context.get("context_aware", {})
+    mim = measured_context.get("improvement", {})
+
+    pairs = [
+        ("stateless_hit_rate",            bc["stateless_hit_rate"],
+            msl.get("hit_rate"),                "rate", PCT_TOL),
+        ("stateless_resolution_accuracy", bc["stateless_resolution_accuracy"],
+            msl.get("resolution_accuracy"),     "rate", PCT_TOL),
+        ("context_hit_rate",              bc["context_hit_rate"],
+            mca.get("hit_rate"),                "rate", PCT_TOL),
+        ("context_resolution_accuracy",   bc["context_resolution_accuracy"],
+            mca.get("resolution_accuracy"),     "rate", PCT_TOL),
+        ("accuracy_delta_pct",            bc["accuracy_delta_pct"],
+            mim.get("accuracy_delta_pct"),      "pct",  PCT_TOL),
+        ("hit_rate_delta",                bc["hit_rate_delta"],
+            mim.get("hit_rate_delta"),          "rate", PCT_TOL),
+    ]
+    for label, baseline_val, measured_val, kind, tol in pairs:
+        if measured_val is None:
+            print(f"  [MISS ]  {label:<46} not present in measured output")
+            all_ok = False
+            continue
+        ok, line = compare(label, baseline_val, measured_val, tol, kind)
+        print(line)
+        if not ok:
+            all_ok = False
+
+    # Domain breakdown — accuracy improvement per domain
+    print("\n  Per-domain accuracy improvement (context vs stateless):")
+    measured_domains = {d["domain"]: d
+                        for d in measured_context.get("domain_breakdown", [])}
+    for entry in baseline["domain_breakdown_context_aware"]:
+        d = entry["domain"]
+        baseline_imp = entry["improvement"]
+        if d not in measured_domains:
+            print(f"  [MISS ]  domain {d:<32} not in measured output")
+            all_ok = False
+            continue
+        measured_imp = measured_domains[d].get("accuracy_improvement", 0.0)
+        ok, line = compare(f"{d} improvement", baseline_imp, measured_imp,
+                           PCT_TOL, "rate")
+        print(line)
+        if not ok:
+            all_ok = False
+
+    print("\n" + "=" * 72)
+    return all_ok
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--baseline", default="benchmark/baseline.json",
+                   help="path to baseline JSON (default: benchmark/baseline.json)")
+    p.add_argument("--timeout", type=int, default=120,
+                   help="seconds to allow for benchmark/run.py (default: 120)")
+    p.add_argument("--skip-run", action="store_true",
+                   help="skip running the benchmark; verify against existing "
+                        "benchmark/results/*.json (useful for re-checking)")
+    args = p.parse_args()
+
+    baseline_path = REPO_ROOT / args.baseline
+    if not baseline_path.exists():
+        print(f"ERROR: baseline not found at {baseline_path}", file=sys.stderr)
+        return 2
+    baseline = json.loads(baseline_path.read_text())
+
+    if not args.skip_run:
+        rc = run_benchmark(args.timeout)
+        if rc != 0:
+            return 2
+
+    measured_summary, measured_context = load_results()
+    ok = verify_against_baseline(measured_summary, measured_context, baseline)
+
+    if ok:
+        print("\n  ALL METRICS WITHIN TOLERANCE — no regression")
+        print("=" * 72)
+        return 0
+    else:
+        print("\n  ONE OR MORE METRICS DRIFTED — investigate before merging")
+        print(f"  Baseline: {baseline_path}")
+        print("=" * 72)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_integration_examples.py
+++ b/scripts/verify_integration_examples.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+scripts/verify_integration_examples.py
+================================
+Verify that LLM-using examples (langchain_example.py, llamaindex_example.py)
+correctly select their LLM provider across all credential configurations.
+
+Cross product of:
+    * examples: langchain_example.py, llamaindex_example.py
+    * scenarios: no keys / OpenAI only / Anthropic only / both keys
+
+→ 8 runs total. For each run, we override the API-key env vars in the
+subprocess (your shell environment is never modified), execute the example
+end-to-end, and parse its '→ Using: <provider>' output line to confirm the
+expected provider was selected.
+
+Why this matters:
+    Both example files claim to detect available API keys and fall back to
+    a mock LLM when neither is set. The matrix exercises the actual code
+    path for every combination, including real-API end-to-end on whichever
+    provider is selected. This is the kind of thing CI doesn't check
+    (because CI doesn't have real keys), so it's a manual pre-release task.
+
+Preconditions:
+    * Both OPENAI_API_KEY and ANTHROPIC_API_KEY must be set in the shell
+      env. The script bails with a clear error if either is missing.
+    * The corresponding SDKs must be importable. Failures here surface as
+      ImportError fallbacks within the example.
+
+Cost:
+    Real LLM calls are made for the OpenAI-only, Anthropic-only, and
+    both-keys scenarios. Per scenario, a typical demo run is 10-30
+    completions on small queries, costing on the order of $0.01-0.05.
+    Full matrix: roughly $0.10-0.20 of total provider spend per run.
+
+Usage:
+    python scripts/verify_integration_examples.py
+    python scripts/verify_integration_examples.py --timeout 240
+    python scripts/verify_integration_examples.py --scenarios "no keys" "Anthropic only"
+
+Exit codes:
+    0   all 8 scenarios produced the expected provider and exited 0
+    1   at least one scenario mismatch or non-zero exit
+    2   harness error (missing keys, missing SDKs, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+EXAMPLES = [
+    ("langchain_example.py",  "examples/langchain_example.py"),
+    ("llamaindex_example.py", "examples/llamaindex_example.py"),
+]
+
+# (label, openai_value, anthropic_value, expected_provider)
+# Empty string in the value column means "explicitly unset for this run".
+def build_scenarios(real_openai: str, real_anthropic: str) -> List[Tuple[str, str, str, str]]:
+    return [
+        ("no keys",        "",            "",              "mock"),
+        ("OpenAI only",    real_openai,   "",              "openai"),
+        ("Anthropic only", "",            real_anthropic,  "anthropic"),
+        ("both keys",      real_openai,   real_anthropic,  "openai"),  # OpenAI checked first
+    ]
+
+# Strict detector: anchor on "→ Using:" prefix and look at the *first word*
+# that follows. Avoids matching substrings like "set OPENAI_API_KEY or ...".
+USING_RE = re.compile(r"→\s*Using:\s*(\w+)", re.IGNORECASE)
+
+
+def detect_provider(stdout: str) -> str:
+    m = USING_RE.search(stdout)
+    if not m:
+        return "unknown"
+    word = m.group(1).lower()
+    # First word after "Using:" is the provider name as the example prints it:
+    #   "Using: OpenAI gpt-4o-mini"            → "openai"
+    #   "Using: Anthropic claude-haiku-..."    → "anthropic"
+    #   "Using: mock LLM (...)"                → "mock"
+    if word in ("openai", "anthropic", "mock"):
+        return word
+    return "unknown"
+
+
+def run_scenario(example: Tuple[str, str], scenario: Tuple[str, str, str, str],
+                 timeout_sec: int, log_dir: Path) -> dict:
+    ex_name, ex_path = example
+    scen_name, openai_val, anth_val, expected = scenario
+
+    # Build env: copy current, then override the two keys per scenario.
+    # We never write to os.environ — only the subprocess sees the override.
+    env = os.environ.copy()
+    if openai_val:
+        env["OPENAI_API_KEY"] = openai_val
+    else:
+        env.pop("OPENAI_API_KEY", None)
+    if anth_val:
+        env["ANTHROPIC_API_KEY"] = anth_val
+    else:
+        env.pop("ANTHROPIC_API_KEY", None)
+
+    log_path = log_dir / f"{ex_name}__{scen_name.replace(' ', '_')}.log"
+    print(f"  [{ex_name:<26}] [{scen_name:<14}] running ...", end="", flush=True)
+
+    t0 = time.time()
+    try:
+        r = subprocess.run([sys.executable, ex_path], env=env,
+                           capture_output=True, text=True,
+                           timeout=timeout_sec, cwd=REPO_ROOT)
+        wallclock = time.time() - t0
+        log_path.write_text(
+            "=== STDOUT ===\n" + r.stdout +
+            "\n=== STDERR ===\n" + r.stderr +
+            f"\n=== exit: {r.returncode}, wallclock: {wallclock:.1f}s ===\n"
+        )
+        detected = detect_provider(r.stdout)
+        ok = (detected == expected and r.returncode == 0)
+        marker = "OK" if ok else "MISMATCH"
+        print(f" {marker:<8} detected={detected:<10} exit={r.returncode}  ({wallclock:.1f}s)")
+        return {"example": ex_name, "scenario": scen_name,
+                "expected": expected, "detected": detected,
+                "exit_code": r.returncode, "wallclock": wallclock,
+                "ok": ok, "log": str(log_path)}
+    except subprocess.TimeoutExpired:
+        wallclock = time.time() - t0
+        log_path.write_text(f"TIMEOUT after {wallclock:.1f}s (limit {timeout_sec}s)\n")
+        print(f" TIMEOUT  {wallclock:.1f}s")
+        return {"example": ex_name, "scenario": scen_name,
+                "expected": expected, "detected": "TIMEOUT",
+                "exit_code": -1, "wallclock": wallclock,
+                "ok": False, "log": str(log_path)}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--timeout", type=int, default=240,
+                   help="per-scenario wall-clock timeout in seconds (default: 240). "
+                        "Real LLM calls + cold MiniLM warmup can take 100-150s.")
+    p.add_argument("--scenarios", nargs="+", default=None,
+                   help='filter to specific scenario labels: "no keys", "OpenAI only", '
+                        '"Anthropic only", "both keys"')
+    p.add_argument("--examples", nargs="+", default=None,
+                   help="filter to specific example basenames "
+                        "(e.g. langchain_example.py)")
+    p.add_argument("--log-dir", default="/tmp/sulci-verify-integration-examples",
+                   help="where to save per-scenario log output")
+    args = p.parse_args()
+
+    real_openai    = os.environ.get("OPENAI_API_KEY", "")
+    real_anthropic = os.environ.get("ANTHROPIC_API_KEY", "")
+
+    if not real_openai or not real_anthropic:
+        missing = []
+        if not real_openai:    missing.append("OPENAI_API_KEY")
+        if not real_anthropic: missing.append("ANTHROPIC_API_KEY")
+        print("ERROR: provider matrix requires both API keys.", file=sys.stderr)
+        print(f"       Missing in environment: {', '.join(missing)}", file=sys.stderr)
+        print(f"       Set them and re-run, or filter scenarios with --scenarios "
+              f"to test only the no-keys path.", file=sys.stderr)
+        return 2
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    scenarios = build_scenarios(real_openai, real_anthropic)
+    if args.scenarios:
+        wanted = set(args.scenarios)
+        scenarios = [s for s in scenarios if s[0] in wanted]
+        if not scenarios:
+            print(f"ERROR: no scenarios match {args.scenarios}. "
+                  f"Available: 'no keys', 'OpenAI only', 'Anthropic only', 'both keys'",
+                  file=sys.stderr)
+            return 2
+
+    examples = EXAMPLES
+    if args.examples:
+        wanted = set(args.examples)
+        examples = [(name, path) for name, path in examples if name in wanted]
+        if not examples:
+            print(f"ERROR: no examples match {args.examples}", file=sys.stderr)
+            return 2
+
+    total = len(examples) * len(scenarios)
+
+    print("=" * 84)
+    print(f" Sulci integration-examples verifier (provider-detection matrix)")
+    print(f" examples: {len(examples)}   scenarios: {len(scenarios)}   "
+          f"runs: {total}   timeout: {args.timeout}s")
+    print(f" logs: {log_dir}")
+    print("=" * 84)
+
+    results = []
+    t0_overall = time.time()
+    for example in examples:
+        for scenario in scenarios:
+            results.append(run_scenario(example, scenario, args.timeout, log_dir))
+    total_wall = time.time() - t0_overall
+
+    # Summary
+    print("\n" + "=" * 84)
+    print(f" MATRIX ({total_wall:.1f}s total wall-clock)")
+    print("=" * 84)
+    print(f"  {'Example':<26} {'Scenario':<16} {'Expected':<10} "
+          f"{'Detected':<10} {'Exit':>4} {'Time':>7}  Result")
+    print(f"  {'-'*26} {'-'*16} {'-'*10} {'-'*10} {'-'*4} {'-'*7}  ------")
+    for r in results:
+        print(f"  {r['example']:<26} {r['scenario']:<16} {r['expected']:<10} "
+              f"{r['detected']:<10} {r['exit_code']:>4} {r['wallclock']:>6.1f}s  "
+              f"{'PASS' if r['ok'] else 'FAIL'}")
+
+    passed = sum(1 for r in results if r["ok"])
+    failing = [r for r in results if not r["ok"]]
+    print(f"\n  {passed}/{len(results)} scenarios passed")
+    if failing:
+        print(f"\n  Failing scenarios (logs in {log_dir}):")
+        for r in failing:
+            print(f"    - {r['example']} [{r['scenario']}]  →  {r['log']}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -56,6 +56,16 @@ import os
 import threading
 import time
 from typing import Optional
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
+# ── Package version ──────────────────────────────────────────────────────────
+# Single source of truth: pyproject.toml. We read it via importlib.metadata
+# at import time. Editable installs and uninstalled trees fall back to a
+# placeholder so the import doesn't crash in dev/test environments.
+try:
+    __version__ = _pkg_version("sulci")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 # ── Module-level telemetry state ─────────────────────────────────────────────
 # Both are False/None by default — connect() is the only way to change them.
@@ -64,7 +74,7 @@ _api_key:           Optional[str] = None
 _telemetry_enabled: bool          = False
 
 _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
-_SDK_VERSION   = "0.3.7"
+_SDK_VERSION   = __version__   # deprecated alias; new code should use sulci.__version__
 _FLUSH_INTERVAL_SECONDS = 30
 
 _event_buffer: list  = []

--- a/sulci/backends/__init__.py
+++ b/sulci/backends/__init__.py
@@ -2,4 +2,9 @@
 # Copyright 2026 Kathiravan Sengodan
 
 # sulci/backends/__init__.py
-# Backend implementations are loaded dynamically by core.py
+# Backend implementations are loaded dynamically by core.py.
+# The Backend protocol is exported here for type-hint and conformance use.
+
+from sulci.backends.protocol import Backend
+
+__all__ = ["Backend"]

--- a/sulci/backends/chroma.py
+++ b/sulci/backends/chroma.py
@@ -15,6 +15,9 @@ from typing import Optional
 
 
 class ChromaBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = False
 
     def __init__(self, db_path: str = "./sulci_db"):
         try:

--- a/sulci/backends/chroma.py
+++ b/sulci/backends/chroma.py
@@ -33,6 +33,8 @@ class ChromaBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -41,9 +43,10 @@ class ChromaBackend:
             embeddings = [embedding],
             documents  = [response],
             metadatas  = [{
-                "query":   query,
-                "expires": expires or 0.0,
-                "user_id": user_id or "global",
+                "query":     query,
+                "expires":   expires or 0.0,
+                "user_id":   user_id or "global",
+                "tenant_id": tenant_id or "global",
                 **(metadata or {}),
             }],
         )
@@ -51,6 +54,8 @@ class ChromaBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         now   = now or time.time()

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -37,6 +37,12 @@ class SulciCloudBackend:
         - Never raises to the caller — the user's app must never crash due to cache
     """
 
+    #: Tenant isolation is enforced server-side by the Sulci Cloud gateway,
+    #: keyed off the api_key (1:1 with a tenant). Declared False here because
+    #: the OSS conformance suite cannot reach the gateway to verify enforcement
+    #: locally. A custom local-gateway test harness could flip this to True.
+    ENFORCES_TENANT_ISOLATION: bool = False
+
     CLOUD_URL    = "https://api.sulci.io"
     USER_AGENT   = "sulci/0.3.0"
 

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -23,6 +23,8 @@ All public methods match the contract expected by Cache in core.py:
 import httpx
 from typing import Optional
 
+from sulci import __version__
+
 
 class SulciCloudBackend:
     """
@@ -44,7 +46,7 @@ class SulciCloudBackend:
     ENFORCES_TENANT_ISOLATION: bool = False
 
     CLOUD_URL    = "https://api.sulci.io"
-    USER_AGENT   = "sulci/0.3.0"
+    USER_AGENT   = f"sulci/{__version__}"
 
     def __init__(
         self,

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -71,11 +71,18 @@ class SulciCloudBackend:
         self,
         embedding:  list,
         threshold:  float,
+        *,
+        tenant_id:  Optional[str] = None,
         user_id:    Optional[str] = None,
         now:        Optional[float] = None,
     ) -> tuple:
         """
         Semantic lookup via cloud API.
+
+        Tenant isolation is enforced server-side by the gateway based on
+        the api_key (which maps 1:1 to a tenant). The `tenant_id` kwarg
+        is forwarded to the gateway for logging and for the rare cases
+        where one api_key is authorized across multiple tenants.
 
         Returns:
             (response, similarity) where response is None on miss.
@@ -87,6 +94,7 @@ class SulciCloudBackend:
                 json={
                     "embedding": embedding,
                     "threshold": threshold,
+                    "tenant_id": tenant_id,
                     "user_id":   user_id,
                 },
             )
@@ -102,6 +110,49 @@ class SulciCloudBackend:
         except Exception:
             # Any other error — treat as cache miss, never crash
             return None, 0.0
+
+    def store(
+        self,
+        key: str,
+        query: str,
+        response: str,
+        embedding: list,
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        expires: Optional[float] = None,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        """
+        Store a cache entry in the cloud (Backend protocol method).
+
+        Translates the protocol's (key, expires) parameters to the cloud
+        API's (ttl_seconds) shape and forwards to /v1/set. Fire-and-forget
+        — silently ignores all errors per the Backend protocol contract.
+
+        Note: `key` and `metadata` are sent to the gateway for record-
+        keeping but the cloud API does not currently use them for lookup.
+        """
+        import time as _time
+        ttl_seconds: Optional[int] = None
+        if expires:
+            ttl_seconds = max(0, int(expires - _time.time()))
+        try:
+            self._client.post(
+                "/v1/set",
+                json={
+                    "key":         key,
+                    "embedding":   embedding,
+                    "query":       query,
+                    "response":    response,
+                    "tenant_id":   tenant_id,
+                    "user_id":     user_id,
+                    "ttl_seconds": ttl_seconds,
+                    "metadata":    metadata,
+                },
+            )
+        except Exception:
+            pass
 
     def upsert(
         self,

--- a/sulci/backends/faiss.py
+++ b/sulci/backends/faiss.py
@@ -15,6 +15,9 @@ from typing import Optional
 
 
 class FAISSBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = False
 
     def __init__(self, db_path: str = "./sulci_faiss"):
         try:

--- a/sulci/backends/faiss.py
+++ b/sulci/backends/faiss.py
@@ -56,6 +56,8 @@ class FAISSBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -73,6 +75,8 @@ class FAISSBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         if self._index is None or self._index.ntotal == 0:

--- a/sulci/backends/milvus.py
+++ b/sulci/backends/milvus.py
@@ -52,6 +52,8 @@ class MilvusBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -67,6 +69,8 @@ class MilvusBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         if not self._ready:

--- a/sulci/backends/milvus.py
+++ b/sulci/backends/milvus.py
@@ -15,6 +15,9 @@ from typing import Optional
 
 
 class MilvusBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = False
 
     COLLECTION = "sulci"
 

--- a/sulci/backends/protocol.py
+++ b/sulci/backends/protocol.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+sulci/backends/protocol.py
+==========================
+Public Backend protocol — first introduced in v0.4.0.
+
+STABLE API — modifications require api-reviewer approval per ADR 0005.
+Changes to this protocol are BREAKING CHANGES for all customer-authored
+backend implementations. Do not modify without a superseding ADR.
+
+This protocol formalizes the shape every shipped backend
+(chroma, qdrant, sqlite, redis, faiss, milvus, cloud) has, with one
+v0.4.0 addition: `tenant_id` for multi-tenant partition isolation.
+All shipped backends accept this kwarg; QdrantBackend enforces tenant
+isolation natively via payload filters, while other backends currently
+store `tenant_id` as a labeling field. See ADR 0005 for the rationale.
+
+Usage
+-----
+Verify your custom backend conforms:
+
+    from sulci.backends import Backend
+
+    class MyBackend:
+        def store(self, key, query, response, embedding, *,
+                  tenant_id=None, user_id=None,
+                  expires=None, metadata=None):
+            ...
+        def search(self, embedding, threshold, *,
+                   tenant_id=None, user_id=None, now=None):
+            ...
+        def clear(self):
+            ...
+
+    # Duck-typed conformance (Protocol is structural):
+    isinstance(MyBackend(), Backend)  # True if methods match by name
+    # NOTE: runtime_checkable only validates method NAMES, not signatures.
+    # Run sulci.tests.compat.test_backend_conformance for full validation.
+
+Inject into Cache:
+
+    from sulci import Cache
+    cache = Cache(backend=MyBackend(...))
+
+Run the conformance suite against your implementation:
+
+    from sulci.tests.compat import test_backend_conformance
+    # Run with: pytest path/to/test_backend_conformance.py --backend-cls=MyBackend
+
+See docs/protocols.md for the complete extension guide.
+"""
+from __future__ import annotations
+from typing import Protocol, runtime_checkable, Optional
+
+
+@runtime_checkable
+class Backend(Protocol):
+    """
+    Protocol every sulci vector-cache backend must satisfy.
+
+    Implementations shipped in v0.4.0:
+      - ChromaBackend       sulci/backends/chroma.py
+      - QdrantBackend       sulci/backends/qdrant.py     (enforces tenant_id)
+      - SQLiteBackend       sulci/backends/sqlite.py
+      - RedisBackend        sulci/backends/redis.py
+      - FaissBackend        sulci/backends/faiss.py
+      - MilvusBackend       sulci/backends/milvus.py
+      - SulciCloudBackend   sulci/backends/cloud.py      (enforces tenant_id)
+
+    Custom implementations: any class matching this surface.
+    Verify conformance: sulci.tests.compat.test_backend_conformance
+    """
+
+    def store(
+        self,
+        key: str,
+        query: str,
+        response: str,
+        embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        expires: Optional[float] = None,
+        metadata: Optional[dict] = None,
+    ) -> None:
+        """
+        Insert or replace a cache entry.
+
+        Args:
+            key:       Deterministic identifier for this cache entry
+                       (typically hash of tenant + user + query text).
+            query:     Original query text (for debugging / display).
+            response:  The LLM response being cached.
+            embedding: Normalized vector representation of `query`.
+            tenant_id: Optional tenant (organization) scoping. Entries
+                       written with a `tenant_id` are isolated from other
+                       tenants — a `search` call without a matching
+                       `tenant_id` MUST NOT return them. None = no tenant
+                       scoping (single-tenant deployment).
+            user_id:   Optional per-user scoping within a tenant. Layered
+                       on top of `tenant_id`: tenant partitions first,
+                       then user within tenant. "global" if None.
+            expires:   Unix timestamp after which this entry is stale.
+                       None or 0.0 = never expires.
+            metadata:  Arbitrary additional fields to store in the backend.
+
+        Raises:
+            Implementation-specific errors are acceptable but should be
+            logged; never let a backend error crash the caller's request.
+            The recommended pattern is to log and either swallow (store
+            failures are not critical) or re-raise (as most backends do).
+        """
+        ...
+
+    def search(
+        self,
+        embedding: list[float],
+        threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> tuple[Optional[str], float]:
+        """
+        Approximate nearest-neighbor cosine search.
+
+        Args:
+            embedding: Query embedding to search with.
+            threshold: Minimum cosine similarity (0.0-1.0) for a match.
+                       Results below this score are treated as misses.
+            tenant_id: Optional tenant filter. When set, only entries
+                       stored with the same `tenant_id` are eligible
+                       matches. Tenant isolation is a hard boundary:
+                       entries from other tenants MUST NOT be returned
+                       even if their similarity exceeds `threshold`.
+            user_id:   Optional filter — only match entries stored with
+                       this `user_id` (or "global" entries if permitted),
+                       within the tenant scope.
+            now:       Unix timestamp for TTL comparison. Uses time.time()
+                       if None. Parameter is for test determinism.
+
+        Returns:
+            (response, similarity) on hit above threshold
+            (None, 0.0) on miss (empty backend or no match above threshold)
+
+        Must not raise on connectivity errors — log and return (None, 0.0)
+        so that cache misses don't crash user applications. This is a core
+        sulci invariant: a broken cache degrades to "no cache" quietly.
+        """
+        ...
+
+    def clear(self) -> None:
+        """
+        Remove all entries from this backend. Destructive operation.
+
+        Typically used in tests. In production, prefer TTL-based expiry
+        and per-user deletion rather than clearing everything.
+        """
+        ...

--- a/sulci/backends/qdrant.py
+++ b/sulci/backends/qdrant.py
@@ -47,6 +47,8 @@ class QdrantBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -58,6 +60,7 @@ class QdrantBackend:
                 vector  = embedding,
                 payload = {
                     "key": key, "query": query, "response": response,
+                    "tenant_id": tenant_id or "global",
                     "user_id": user_id or "global",
                     "expires": expires or 0.0,
                     **(metadata or {}),
@@ -68,13 +71,26 @@ class QdrantBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         from qdrant_client.models import Filter, FieldCondition, MatchValue
-        now     = now or time.time()
-        filter_ = Filter(must=[FieldCondition(
-            key="user_id", match=MatchValue(value=user_id)
-        )]) if user_id else None
+        now = now or time.time()
+
+        # Build payload filter conditions. Tenant isolation is a hard
+        # boundary — entries from other tenants must never be returned,
+        # even if their similarity exceeds threshold.
+        must_conditions = []
+        if tenant_id is not None:
+            must_conditions.append(FieldCondition(
+                key="tenant_id", match=MatchValue(value=tenant_id)
+            ))
+        if user_id is not None:
+            must_conditions.append(FieldCondition(
+                key="user_id", match=MatchValue(value=user_id)
+            ))
+        filter_ = Filter(must=must_conditions) if must_conditions else None
 
         results = self._client.search(
             collection_name = self.COLLECTION,

--- a/sulci/backends/qdrant.py
+++ b/sulci/backends/qdrant.py
@@ -15,6 +15,9 @@ from typing import Optional
 
 
 class QdrantBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = True
 
     COLLECTION = "sulci"
 

--- a/sulci/backends/qdrant.py
+++ b/sulci/backends/qdrant.py
@@ -83,26 +83,31 @@ class QdrantBackend:
 
         # Build payload filter conditions. Tenant isolation is a hard
         # boundary — entries from other tenants must never be returned,
-        # even if their similarity exceeds threshold.
-        must_conditions = []
-        if tenant_id is not None:
-            must_conditions.append(FieldCondition(
-                key="tenant_id", match=MatchValue(value=tenant_id)
-            ))
-        if user_id is not None:
-            must_conditions.append(FieldCondition(
-                key="user_id", match=MatchValue(value=user_id)
-            ))
-        filter_ = Filter(must=must_conditions) if must_conditions else None
+        # even if their similarity exceeds threshold. The store path
+        # writes tenant_id="global" when None is passed; the read path
+        # mirrors that by filtering to "global" for None — otherwise
+        # an unscoped read would silently see entries from named tenants
+        # and break the operational migration to multi-tenancy.
+        must_conditions = [
+            FieldCondition(
+                key="tenant_id",
+                match=MatchValue(value=tenant_id if tenant_id is not None else "global"),
+            ),
+            FieldCondition(
+                key="user_id",
+                match=MatchValue(value=user_id if user_id is not None else "global"),
+            ),
+        ]
+        filter_ = Filter(must=must_conditions)
 
-        results = self._client.search(
+        results = self._client.query_points(
             collection_name = self.COLLECTION,
-            query_vector    = embedding,
+            query           = embedding,
             query_filter    = filter_,
             limit           = 5,
             with_payload    = True,
         )
-        for r in results:
+        for r in results.points:
             p = r.payload or {}
             if p.get("expires") and now > p["expires"]:
                 continue
@@ -111,4 +116,17 @@ class QdrantBackend:
         return None, 0.0
 
     def clear(self) -> None:
-        self._client.delete_collection(self.COLLECTION)
+        # Delete all points but keep the collection (and its HNSW index)
+        # intact. qdrant-client 1.x raises ValueError on subsequent
+        # operations against a missing collection, so a recreate-on-clear
+        # would also work but costs a full index rebuild on first store.
+        from qdrant_client.models import Filter
+        try:
+            self._client.delete(
+                collection_name = self.COLLECTION,
+                points_selector = Filter(must=[]),
+            )
+        except Exception:
+            # Empty collection or other transient error — clear is
+            # idempotent so we swallow.
+            pass

--- a/sulci/backends/redis.py
+++ b/sulci/backends/redis.py
@@ -23,6 +23,9 @@ from typing import Optional
 
 
 class RedisBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = False
 
     def __init__(
         self,

--- a/sulci/backends/redis.py
+++ b/sulci/backends/redis.py
@@ -57,6 +57,8 @@ class RedisBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -74,6 +76,8 @@ class RedisBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         now       = now or time.time()

--- a/sulci/backends/sqlite.py
+++ b/sulci/backends/sqlite.py
@@ -16,6 +16,9 @@ from typing import Optional
 
 
 class SQLiteBackend:
+    #: True if this backend enforces tenant_id partition isolation.
+    #: When True, search() must not return entries with mismatched tenant_id.
+    ENFORCES_TENANT_ISOLATION: bool = False
 
     def __init__(self, db_path: str = "./sulci_db"):
         os.makedirs(db_path, exist_ok=True)

--- a/sulci/backends/sqlite.py
+++ b/sulci/backends/sqlite.py
@@ -58,6 +58,8 @@ class SQLiteBackend:
     def store(
         self,
         key: str, query: str, response: str, embedding: list[float],
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, expires: Optional[float] = None,
         metadata: Optional[dict] = None,
     ) -> None:
@@ -82,6 +84,8 @@ class SQLiteBackend:
     def search(
         self,
         embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
         now       = now or time.time()

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -206,6 +206,8 @@ class Cache:
     def get(
         self,
         query:      str,
+        *,
+        tenant_id:  Optional[str] = None,
         user_id:    Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> tuple:
@@ -226,6 +228,7 @@ class Cache:
         resp, sim  = self._backend.search(
             embedding = vec,
             threshold = self.threshold,
+            tenant_id = tenant_id,
             user_id   = user_id if self.personalized else None,
             now       = time.time(),
         )
@@ -249,6 +252,8 @@ class Cache:
         self,
         query:      str,
         response:   str,
+        *,
+        tenant_id:  Optional[str]  = None,
         user_id:    Optional[str]  = None,
         session_id: Optional[str]  = None,
         metadata:   Optional[dict] = None,
@@ -271,6 +276,7 @@ class Cache:
             query     = query,
             response  = response,
             embedding = raw_vec,
+            tenant_id = tenant_id,
             user_id   = user_id if self.personalized else None,
             expires   = expires,
             metadata  = metadata or {},
@@ -282,6 +288,8 @@ class Cache:
         self,
         query:         str,
         llm_fn:        Callable,
+        *,
+        tenant_id:     Optional[str] = None,
         user_id:       Optional[str] = None,
         session_id:    Optional[str] = None,
         cost_per_call: float         = 0.005,
@@ -314,7 +322,7 @@ class Cache:
             }
         """
         t0              = time.perf_counter()
-        hit, sim, depth = self.get(query, user_id=user_id, session_id=session_id)
+        hit, sim, depth = self.get(query, tenant_id=tenant_id, user_id=user_id, session_id=session_id)
         ms              = (time.perf_counter() - t0) * 1000
 
         if hit is not None:
@@ -334,7 +342,7 @@ class Cache:
             }
 
         response = llm_fn(query, **llm_kwargs)
-        self.set(query, response, user_id=user_id, session_id=session_id)
+        self.set(query, response, tenant_id=tenant_id, user_id=user_id, session_id=session_id)
         ms = (time.perf_counter() - t0) * 1000
         self._stats["misses"] += 1
         return {

--- a/sulci/embeddings/__init__.py
+++ b/sulci/embeddings/__init__.py
@@ -2,4 +2,9 @@
 # Copyright 2026 Kathiravan Sengodan
 
 # sulci/embeddings/__init__.py
-# Embedding models are loaded dynamically by core.py
+# Embedding models are loaded dynamically by core.py.
+# The Embedder protocol is exported here for type-hint and conformance use.
+
+from sulci.embeddings.protocol import Embedder
+
+__all__ = ["Embedder"]

--- a/sulci/embeddings/protocol.py
+++ b/sulci/embeddings/protocol.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+sulci/embeddings/protocol.py
+============================
+Public Embedder protocol — first introduced in v0.4.0.
+
+STABLE API — modifications require api-reviewer approval per ADR 0005.
+Changes to this protocol are BREAKING CHANGES for all customer-authored
+embedder implementations. Do not modify without a superseding ADR.
+
+This protocol formalizes the shape that MiniLMEmbedder and OpenAIEmbedder
+already have. No embedder implementation changed to match this protocol.
+
+Usage
+-----
+Verify your custom embedder conforms:
+
+    from sulci.embeddings import Embedder
+
+    class MyEmbedder:
+        @property
+        def dimension(self) -> int: return 768
+        def embed(self, text: str) -> list[float]: ...
+        def embed_batch(self, texts: list[str]) -> list[list[float]]: ...
+
+    isinstance(MyEmbedder(), Embedder)  # True
+
+Inject into Cache:
+
+    from sulci import Cache
+    cache = Cache(embedding_model=MyEmbedder())
+"""
+from __future__ import annotations
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """
+    Protocol every sulci embedder must satisfy.
+
+    Implementations shipped in v0.4.0:
+      - MiniLMEmbedder  sulci/embeddings/minilm.py
+         (supports model_name "minilm", "mpnet", "bge")
+      - OpenAIEmbedder  sulci/embeddings/openai.py
+
+    Custom implementations: any class matching this surface.
+    Verify conformance: sulci.tests.compat.test_embedder_conformance
+    """
+
+    @property
+    def dimension(self) -> int:
+        """
+        Vector dimensionality this embedder produces.
+
+        MiniLM: 384
+        MPNet: 768
+        BGE: 768
+        OpenAI text-embedding-3-small: 1536
+
+        Cache uses this to initialize backends with matching vector sizes.
+        MUST be stable for the lifetime of the embedder instance.
+        """
+        ...
+
+    def embed(self, text: str) -> list[float]:
+        """
+        Embed a single text string.
+
+        Returns:
+            L2-normalized vector of length `self.dimension`.
+
+        Normalization is required because sulci backends use cosine
+        similarity and assume unit-length vectors. Unnormalized vectors
+        produce incorrect similarity scores.
+        """
+        ...
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """
+        Embed multiple texts efficiently in a single call.
+
+        Returns:
+            List of L2-normalized vectors, one per input text,
+            each of length `self.dimension`.
+
+        This is the hot path for bulk-loading caches and for
+        benchmark workloads. Implementations should batch internally
+        when possible (e.g., sentence-transformers supports batch_size).
+        """
+        ...

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+# tests/compat/__init__.py
+# Conformance test suite for the Backend and Embedder protocols (v0.4.0+).
+#
+# Custom backend/embedder authors can verify their implementation conforms
+# to the sulci protocols by adding their class to BACKEND_CLASSES /
+# EMBEDDER_CLASSES in conftest.py and running:
+#
+#   pytest tests/compat/ -v

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -89,11 +89,12 @@ def _try_construct_backend(cls: Type) -> Optional[Any]:
             import qdrant_client  # noqa: F401
         except ImportError:
             return None
-        # Local Qdrant requires either :memory: or a running server. We try
-        # the in-memory path; if the underlying client doesn't support it
-        # in this version we return None and skip behavioral tests.
+        # QdrantBackend supports embedded mode via db_path — same wire
+        # format as a remote Qdrant server, no infrastructure needed.
+        # If the embedded client fails to construct (rare), skip
+        # behavioral tests rather than blocking the suite.
         try:
-            return cls(url=":memory:")
+            return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
         except Exception:
             return None
 

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+tests/compat/conftest.py
+========================
+Fixtures and registries for the Backend/Embedder conformance suite.
+
+To validate a custom backend or embedder, add the class to the
+appropriate registry below and run `pytest tests/compat/`.
+"""
+from __future__ import annotations
+import importlib
+import os
+import tempfile
+from typing import Any, Optional, Type
+
+import pytest
+
+
+# -----------------------------------------------------------------------------
+# Registries — extend these to test custom implementations.
+# -----------------------------------------------------------------------------
+
+def _import_or_none(module_path: str, attr: str) -> Optional[Type]:
+    """Try to import attr from module_path; return None if module missing."""
+    try:
+        mod = importlib.import_module(module_path)
+        return getattr(mod, attr)
+    except ImportError:
+        return None
+
+
+BACKEND_CLASSES = [
+    cls for cls in [
+        _import_or_none("sulci.backends.sqlite", "SQLiteBackend"),
+        _import_or_none("sulci.backends.chroma", "ChromaBackend"),
+        _import_or_none("sulci.backends.faiss",  "FAISSBackend"),
+        _import_or_none("sulci.backends.redis",  "RedisBackend"),
+        _import_or_none("sulci.backends.qdrant", "QdrantBackend"),
+        _import_or_none("sulci.backends.milvus", "MilvusBackend"),
+        _import_or_none("sulci.backends.cloud",  "SulciCloudBackend"),
+    ]
+    if cls is not None
+]
+
+EMBEDDER_CLASSES = [
+    cls for cls in [
+        _import_or_none("sulci.embeddings.minilm", "MiniLMEmbedder"),
+        _import_or_none("sulci.embeddings.openai", "OpenAIEmbedder"),
+    ]
+    if cls is not None
+]
+
+
+# -----------------------------------------------------------------------------
+# Construction helpers — return a live instance, or None if local construction
+# isn't possible (missing dep, no running server, no api key, etc.). Tests use
+# the None signal to skip behavioral checks while still running structural ones.
+# -----------------------------------------------------------------------------
+
+def _try_construct_backend(cls: Type) -> Optional[Any]:
+    """
+    Try to construct a backend instance with sensible local defaults.
+    Return None if the backend can't run locally in this environment.
+    """
+    name = cls.__name__
+
+    if name == "SQLiteBackend":
+        # SQLite always works — uses a temp directory.
+        return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
+
+    if name == "FAISSBackend":
+        try:
+            import faiss  # noqa: F401
+        except ImportError:
+            return None
+        return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
+
+    if name == "ChromaBackend":
+        try:
+            import chromadb  # noqa: F401
+        except ImportError:
+            return None
+        return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
+
+    if name == "QdrantBackend":
+        try:
+            import qdrant_client  # noqa: F401
+        except ImportError:
+            return None
+        # Local Qdrant requires either :memory: or a running server. We try
+        # the in-memory path; if the underlying client doesn't support it
+        # in this version we return None and skip behavioral tests.
+        try:
+            return cls(url=":memory:")
+        except Exception:
+            return None
+
+    if name == "RedisBackend":
+        try:
+            import redis  # noqa: F401
+        except ImportError:
+            return None
+        # Requires a running redis-server on localhost. Probe and skip if absent.
+        try:
+            instance = cls()
+            instance._redis.ping()  # connection check
+            return instance
+        except Exception:
+            return None
+
+    if name == "MilvusBackend":
+        try:
+            import pymilvus  # noqa: F401
+        except ImportError:
+            return None
+        try:
+            return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
+        except Exception:
+            return None
+
+    if name == "SulciCloudBackend":
+        # Cloud needs a running gateway — out of scope for local conformance.
+        # Construction succeeds with a fake key for structural checks only;
+        # behavioral checks will skip because we never get a working instance.
+        return None
+
+    return None
+
+
+def _try_construct_embedder(cls: Type) -> Optional[Any]:
+    """
+    Try to construct an embedder instance. Return None if not possible.
+    """
+    name = cls.__name__
+
+    if name == "MiniLMEmbedder":
+        # Always works locally; first call may download the MiniLM model.
+        try:
+            return cls()
+        except Exception:
+            return None
+
+    if name == "OpenAIEmbedder":
+        # Constructs without a key, but behavioral tests need OPENAI_API_KEY
+        # to actually call the API. Return the instance; tests will skip
+        # behavioral assertions when the env var is missing.
+        if not os.environ.get("OPENAI_API_KEY"):
+            return None
+        try:
+            return cls()
+        except Exception:
+            return None
+
+    return None
+
+
+# -----------------------------------------------------------------------------
+# Pytest parametrize fixtures — yield (cls, instance_or_None) tuples.
+# -----------------------------------------------------------------------------
+
+@pytest.fixture(params=BACKEND_CLASSES, ids=lambda c: c.__name__)
+def backend_class(request) -> Type:
+    """Yields each registered backend class (no instance)."""
+    return request.param
+
+
+@pytest.fixture
+def backend_instance(backend_class) -> Any:
+    """
+    Yields a live backend instance, or skips if the backend cannot be
+    constructed locally (missing dep, no running server, etc.).
+    """
+    inst = _try_construct_backend(backend_class)
+    if inst is None:
+        pytest.skip(f"{backend_class.__name__}: no local construction available")
+    yield inst
+    # Best-effort cleanup
+    try:
+        inst.clear()
+    except Exception:
+        pass
+
+
+@pytest.fixture(params=EMBEDDER_CLASSES, ids=lambda c: c.__name__)
+def embedder_class(request) -> Type:
+    """Yields each registered embedder class (no instance)."""
+    return request.param
+
+
+@pytest.fixture
+def embedder_instance(embedder_class) -> Any:
+    """
+    Yields a live embedder instance, or skips if the embedder cannot be
+    constructed locally (missing dep, missing api key, etc.).
+    """
+    inst = _try_construct_embedder(embedder_class)
+    if inst is None:
+        pytest.skip(f"{embedder_class.__name__}: no local construction available")
+    yield inst

--- a/tests/compat/test_backend_conformance.py
+++ b/tests/compat/test_backend_conformance.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+tests/compat/test_backend_conformance.py
+=========================================
+Conformance tests for the Backend protocol.
+
+Tests are organized into three groups, each with different infrastructure
+requirements:
+
+  TestStructural   - inspect.signature checks; no instance needed.
+                     Always runs for every registered backend class.
+
+  TestRoundTrip    - store + search + clear with real data.
+                     Skips if the backend can't be constructed locally.
+
+  TestTenantIsolation - cross-tenant search returns no leak.
+                     Runs only on backends with ENFORCES_TENANT_ISOLATION = True.
+"""
+from __future__ import annotations
+import inspect
+from typing import Any
+
+import pytest
+
+from sulci.backends import Backend
+
+
+# =============================================================================
+# Structural — runs against every registered backend class, no instance needed.
+# =============================================================================
+
+class TestStructural:
+    """Signature/protocol contract — works on the class, no infra needed."""
+
+    REQUIRED_METHODS = ("store", "search", "clear")
+
+    def test_isinstance_backend(self, backend_class):
+        # runtime_checkable only verifies method names exist
+        instance_proxy = type("X", (backend_class,), {})
+        # A bare class isn't an instance; Protocol structural check happens on
+        # objects, but for class-level we use the safer inspect-based approach:
+        for name in self.REQUIRED_METHODS:
+            assert hasattr(backend_class, name), \
+                f"{backend_class.__name__} missing required method {name!r}"
+
+    def test_class_attribute_enforces_tenant_isolation(self, backend_class):
+        """All registered backends must declare ENFORCES_TENANT_ISOLATION."""
+        assert hasattr(backend_class, "ENFORCES_TENANT_ISOLATION"), (
+            f"{backend_class.__name__} must declare ENFORCES_TENANT_ISOLATION "
+            "as a class attribute (True or False)."
+        )
+        assert isinstance(backend_class.ENFORCES_TENANT_ISOLATION, bool)
+
+    def test_store_signature_required_params(self, backend_class):
+        sig = inspect.signature(backend_class.store)
+        params = sig.parameters
+
+        for required in ("self", "key", "query", "response", "embedding"):
+            assert required in params, (
+                f"{backend_class.__name__}.store() missing required "
+                f"parameter {required!r}"
+            )
+
+    def test_store_signature_keyword_only_kwargs(self, backend_class):
+        """
+        tenant_id, user_id, expires, metadata must be keyword-only.
+        Enforced via the `*,` separator in the protocol.
+        """
+        sig = inspect.signature(backend_class.store)
+        params = sig.parameters
+
+        for kw in ("tenant_id", "user_id", "expires", "metadata"):
+            assert kw in params, (
+                f"{backend_class.__name__}.store() missing kwarg {kw!r}"
+            )
+            assert params[kw].kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"{backend_class.__name__}.store() parameter {kw!r} must be "
+                f"keyword-only (got {params[kw].kind})"
+            )
+            assert params[kw].default is None, (
+                f"{backend_class.__name__}.store() parameter {kw!r} must "
+                f"default to None (got {params[kw].default!r})"
+            )
+
+    def test_search_signature_required_params(self, backend_class):
+        sig = inspect.signature(backend_class.search)
+        params = sig.parameters
+
+        for required in ("self", "embedding", "threshold"):
+            assert required in params, (
+                f"{backend_class.__name__}.search() missing required "
+                f"parameter {required!r}"
+            )
+
+    def test_search_signature_keyword_only_kwargs(self, backend_class):
+        sig = inspect.signature(backend_class.search)
+        params = sig.parameters
+
+        for kw in ("tenant_id", "user_id", "now"):
+            assert kw in params, (
+                f"{backend_class.__name__}.search() missing kwarg {kw!r}"
+            )
+            assert params[kw].kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"{backend_class.__name__}.search() parameter {kw!r} must "
+                f"be keyword-only (got {params[kw].kind})"
+            )
+            assert params[kw].default is None, (
+                f"{backend_class.__name__}.search() parameter {kw!r} must "
+                f"default to None (got {params[kw].default!r})"
+            )
+
+    def test_clear_signature(self, backend_class):
+        sig = inspect.signature(backend_class.clear)
+        # Only `self`. No required positional args.
+        params = list(sig.parameters.values())
+        non_self = [p for p in params if p.name != "self"]
+        for p in non_self:
+            assert p.default is not inspect.Parameter.empty, (
+                f"{backend_class.__name__}.clear() parameter {p.name!r} "
+                "must have a default (clear takes no required args)"
+            )
+
+
+# =============================================================================
+# Round-trip — needs a live backend instance.
+# =============================================================================
+
+class TestRoundTrip:
+    """Store + search + retrieve. Skips when no local instance available."""
+
+    EMB_DIM = 384  # MiniLM dimension; backends accept any size
+
+    def _vec(self, fill: float = 1.0) -> list[float]:
+        # Unit-norm vector pointing in one direction. Sufficient for cosine
+        # similarity to return ~1.0 against itself.
+        v = [0.0] * self.EMB_DIM
+        v[0] = fill
+        return v
+
+    def test_empty_search_returns_miss(self, backend_instance):
+        resp, sim = backend_instance.search(self._vec(), threshold=0.5)
+        assert resp is None
+        assert sim == 0.0
+
+    def test_store_then_search_returns_hit(self, backend_instance):
+        backend_instance.store(
+            "k1",
+            "what is python",
+            "Python is a programming language.",
+            self._vec(),
+        )
+        resp, sim = backend_instance.search(self._vec(), threshold=0.85)
+        assert resp == "Python is a programming language."
+        assert sim >= 0.85
+
+    def test_clear_empties_backend(self, backend_instance):
+        backend_instance.store(
+            "k1", "q", "A", self._vec(),
+        )
+        backend_instance.clear()
+        # After clear, lookup should miss. (Some backends may need a fresh
+        # store afterwards to be functional; we only assert the miss here.)
+        resp, _ = backend_instance.search(self._vec(), threshold=0.85)
+        assert resp is None
+
+
+# =============================================================================
+# Tenant isolation — runs only on backends with ENFORCES_TENANT_ISOLATION=True.
+# =============================================================================
+
+class TestTenantIsolation:
+    """
+    Asserts the protocol's hard isolation guarantee:
+        Entries from other tenants MUST NOT be returned, even if their
+        similarity exceeds threshold.
+    """
+
+    EMB_DIM = 384
+
+    def _vec(self, fill: float = 1.0) -> list[float]:
+        v = [0.0] * self.EMB_DIM
+        v[0] = fill
+        return v
+
+    def test_cross_tenant_search_misses(self, backend_instance):
+        cls = type(backend_instance)
+        if not getattr(cls, "ENFORCES_TENANT_ISOLATION", False):
+            pytest.skip(
+                f"{cls.__name__} does not enforce tenant isolation; "
+                f"contract not applicable."
+            )
+
+        # Tenant A stores an entry.
+        backend_instance.store(
+            "k1", "q", "tenant_A_secret", self._vec(),
+            tenant_id="tenant_a",
+        )
+
+        # Tenant B searches with the same embedding — must miss.
+        resp, sim = backend_instance.search(
+            self._vec(), threshold=0.5,
+            tenant_id="tenant_b",
+        )
+        assert resp is None, (
+            f"{cls.__name__} leaked tenant_a entry to tenant_b search "
+            f"(got response={resp!r}, similarity={sim})"
+        )
+
+    def test_same_tenant_search_hits(self, backend_instance):
+        cls = type(backend_instance)
+        if not getattr(cls, "ENFORCES_TENANT_ISOLATION", False):
+            pytest.skip(
+                f"{cls.__name__} does not enforce tenant isolation."
+            )
+
+        backend_instance.store(
+            "k1", "q", "tenant_A_data", self._vec(),
+            tenant_id="tenant_a",
+        )
+        resp, sim = backend_instance.search(
+            self._vec(), threshold=0.5,
+            tenant_id="tenant_a",
+        )
+        assert resp == "tenant_A_data"

--- a/tests/compat/test_embedder_conformance.py
+++ b/tests/compat/test_embedder_conformance.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+tests/compat/test_embedder_conformance.py
+==========================================
+Conformance tests for the Embedder protocol.
+"""
+from __future__ import annotations
+import inspect
+import math
+
+
+class TestStructural:
+    """Signature/protocol contract — works on the class, no infra needed."""
+
+    def test_has_dimension_property(self, embedder_class):
+        assert hasattr(embedder_class, "dimension"), (
+            f"{embedder_class.__name__} missing 'dimension' attribute"
+        )
+        # Protocol says dimension is a property
+        attr = inspect.getattr_static(embedder_class, "dimension")
+        assert isinstance(attr, property), (
+            f"{embedder_class.__name__}.dimension must be a @property "
+            f"(got {type(attr).__name__})"
+        )
+
+    def test_has_embed_method(self, embedder_class):
+        assert hasattr(embedder_class, "embed")
+        sig = inspect.signature(embedder_class.embed)
+        params = sig.parameters
+        assert "self" in params
+        assert "text" in params
+
+    def test_has_embed_batch_method(self, embedder_class):
+        assert hasattr(embedder_class, "embed_batch")
+        sig = inspect.signature(embedder_class.embed_batch)
+        params = sig.parameters
+        assert "self" in params
+        assert "texts" in params
+
+
+class TestBehavior:
+    """Round-trip behavior — needs a live embedder instance."""
+
+    def test_dimension_is_positive_int(self, embedder_instance):
+        d = embedder_instance.dimension
+        assert isinstance(d, int)
+        assert d > 0
+
+    def test_dimension_is_stable(self, embedder_instance):
+        assert embedder_instance.dimension == embedder_instance.dimension
+
+    def test_embed_returns_list_of_dimension_floats(self, embedder_instance):
+        vec = embedder_instance.embed("hello world")
+        assert isinstance(vec, list)
+        assert len(vec) == embedder_instance.dimension
+        assert all(isinstance(x, float) for x in vec)
+
+    def test_embed_is_l2_normalized(self, embedder_instance):
+        vec = embedder_instance.embed("hello world")
+        norm = math.sqrt(sum(x * x for x in vec))
+        # L2 norm should be ~1.0 (allow some float drift)
+        assert abs(norm - 1.0) < 1e-3, (
+            f"{type(embedder_instance).__name__} produced un-normalized "
+            f"vector (||v|| = {norm:.6f}, expected ~1.0)"
+        )
+
+    def test_embed_batch_length_matches_input(self, embedder_instance):
+        texts = ["one", "two", "three"]
+        vecs = embedder_instance.embed_batch(texts)
+        assert len(vecs) == len(texts)
+        assert all(len(v) == embedder_instance.dimension for v in vecs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,3 +244,71 @@ class TestPersonalization:
         cache.set("What is Python?", "Python is a language.", user_id="alice")
         result, _, __ = cache.get("What is Python?", user_id="bob")
         assert result is None, "Bob should not see Alice's cached entry"
+
+
+# ── Tenant ID (v0.4.0+) ────────────────────────────────────────
+
+class TestTenantId:
+    """
+    Verify tenant_id is plumbed through Cache public API (added in v0.4.0).
+
+    These tests use SQLite (ENFORCES_TENANT_ISOLATION=False), so they only
+    verify the kwarg is accepted and forwarded — not enforced. Real
+    isolation enforcement is verified in tests/test_qdrant_tenant_isolation.py.
+    """
+
+    def test_cache_set_then_get_round_trips_with_tenant_id(self, tmp_path):
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "ti1"))
+        cache.set("hello", "world", tenant_id="acme")
+        resp, sim, _ = cache.get("hello", tenant_id="acme")
+        assert resp == "world"
+        assert sim >= 0.99
+
+    def test_cache_cached_call_accepts_tenant_id_kwarg(self, tmp_path):
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "ti2"))
+        def mock_llm(q, **_):
+            return f"response to {q}"
+
+        # First call — cache miss, LLM invoked
+        result = cache.cached_call("hi", mock_llm, tenant_id="acme")
+        assert result["source"] == "llm"
+        assert result["response"] == "response to hi"
+
+        # Second call — cache hit, LLM not invoked
+        result = cache.cached_call("hi", mock_llm, tenant_id="acme")
+        assert result["source"] == "cache"
+
+    def test_cache_set_rejects_positional_after_response(self, tmp_path):
+        """
+        The ``*,`` separator must enforce keyword-only for partition kwargs
+        after the required positional args. Without this guard, a future
+        refactor could silently drop ``*,`` and let callers pass partition
+        keys positionally — which would let argument-order mistakes go
+        undetected and create cross-tenant data leak risks.
+        """
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "ti3"))
+        with pytest.raises(TypeError, match=r"takes \d+ positional argument"):
+            cache.set("query", "response", "should-fail-positional")
+
+    def test_cache_signatures_have_keyword_only_partition_kwargs(self):
+        """
+        Lock the contract: tenant_id, user_id, session_id are keyword-only
+        on Cache.get / .set / .cached_call. Locks the v0.4.0 API shape so
+        a future refactor can't silently drop ``*,`` and break callers.
+        """
+        import inspect
+        for method_name in ("get", "set", "cached_call"):
+            sig = inspect.signature(getattr(Cache, method_name))
+            for partition_kw in ("tenant_id", "user_id", "session_id"):
+                p = sig.parameters[partition_kw]
+                assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
+                    f"Cache.{method_name}.{partition_kw} must be KEYWORD_ONLY, "
+                    f"got {p.kind}"
+                )
+                assert p.default is None, (
+                    f"Cache.{method_name}.{partition_kw} must default to None, "
+                    f"got {p.default!r}"
+                )

--- a/tests/test_qdrant_tenant_isolation.py
+++ b/tests/test_qdrant_tenant_isolation.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+tests/test_qdrant_tenant_isolation.py
+======================================
+End-to-end tenant isolation tests for QdrantBackend, framed around real
+multi-tenant SaaS scenarios.
+
+These tests verify the protocol's hard isolation guarantee:
+    "Tenant isolation is a hard boundary — entries from other tenants
+     MUST NOT be returned, even if their similarity exceeds threshold."
+
+Test names are deliberately written as customer-support product scenarios
+(rather than abstract test_filter_with_must_clause names) so that:
+  - A failure tells the reader what user-impacting thing broke
+  - The file doubles as documentation of the multi-tenancy contract
+  - Auditors and security reviewers can read it as a behavioral spec
+
+Backstory: HelpDesk AI is a SaaS support chatbot company. Their customers
+are tenants — Acme Corp (industrial pumps), Globex Health (hospital
+HIPAA), Initech Software (B2B API). The semantic cache sits in front of
+the LLM; tenant isolation prevents one customer's cached responses from
+leaking to another customer.
+
+These scenarios run against an embedded Qdrant via db_path; if
+qdrant-client is not installed, all tests skip cleanly.
+"""
+from __future__ import annotations
+import math
+import tempfile
+
+import pytest
+
+qdrant_client = pytest.importorskip("qdrant_client")
+from sulci.backends.qdrant import QdrantBackend  # noqa: E402
+
+
+# -----------------------------------------------------------------------------
+# Test fixtures and helpers.
+# -----------------------------------------------------------------------------
+
+def _normalized(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    return [x / norm for x in vec]
+
+
+@pytest.fixture
+def backend(tmp_path):
+    """Embedded Qdrant backend, fresh per test."""
+    return QdrantBackend(db_path=str(tmp_path / "qdrant"))
+
+
+# Two semantically-similar embeddings — close enough that a broken filter
+# would happily match across them. We use these to ensure that *similarity*
+# alone never bypasses tenant isolation.
+WARRANTY_QUERY_VEC  = _normalized([1.0, 0.05, 0.0] + [0.0] * 381)
+WARRANTY_QUERY_VEC2 = _normalized([1.0, 0.06, 0.01] + [0.0] * 381)  # ~99% sim
+PRICING_QUERY_VEC   = _normalized([0.0, 1.0, 0.0] + [0.0] * 381)   # orthogonal
+
+
+# =============================================================================
+# Scenario 1: Acme Corp agents share each other's cache (the value prop)
+# =============================================================================
+
+class TestAcmeAgentsShareCache:
+    """Same-tenant agents benefit from each other's cached LLM responses."""
+
+    def test_second_agent_gets_cache_hit_on_paraphrased_query(self, backend):
+        # Agent #1 asks about warranty; cache stores the LLM's response.
+        backend.store(
+            key       = "acme-warranty-1",
+            query     = "What's the warranty on the Acme P500 pump?",
+            response  = "The Acme P500 has a 5-year limited warranty.",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = "acme_corp",
+        )
+
+        # Agent #2 asks a paraphrased version of the same question.
+        # Vector is highly similar (~99%) — they should hit the cache.
+        resp, sim = backend.search(
+            WARRANTY_QUERY_VEC2,
+            threshold = 0.85,
+            tenant_id = "acme_corp",
+        )
+        assert resp == "The Acme P500 has a 5-year limited warranty."
+        assert sim >= 0.85, f"Expected high similarity for paraphrase; got {sim}"
+
+
+# =============================================================================
+# Scenario 2: PHI must not leak from Globex Health to Initech Software
+# =============================================================================
+
+class TestGlobexPhiDoesNotLeakToInitech:
+    """
+    The single most important test in this file. If this fails, the
+    multi-tenant SaaS deployment model is unsafe — a HIPAA breach and a
+    company-ending lawsuit waiting to happen.
+    """
+
+    def test_initech_search_never_returns_globex_phi(self, backend):
+        # Globex stores a response containing patient PHI.
+        backend.store(
+            key       = "globex-phi-1",
+            query     = "Bill code for John Smith's surgery on March 15?",
+            response  = "Patient John Smith MRN 4471823, bill code 49505 to UHC. Balance $1,247.83.",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = "globex_health",
+        )
+
+        # Initech, an unrelated tenant, asks something semantically similar.
+        # Without tenant isolation, the high vector similarity would match.
+        # WITH tenant isolation, this must miss — even though the vectors
+        # are identical.
+        resp, sim = backend.search(
+            WARRANTY_QUERY_VEC,
+            threshold = 0.85,
+            tenant_id = "initech_software",
+        )
+        assert resp is None, (
+            f"CRITICAL: tenant isolation breach. Globex PHI ({resp!r}) was "
+            f"returned to Initech with similarity {sim}. Multi-tenant SaaS "
+            f"deployment model is not safe."
+        )
+        assert sim == 0.0
+
+
+# =============================================================================
+# Scenario 3: Within-tenant user partitions when user_id is set
+# =============================================================================
+
+class TestAcmeAgentsIsolatedWhenUserIdSet:
+    """
+    Optional within-tenant user partitioning. Two agents at the same
+    company but with different access permissions — caches partition by
+    user_id so one agent's privileged responses don't leak to another
+    agent who shouldn't see them.
+    """
+
+    def test_user_a_response_does_not_leak_to_user_b(self, backend):
+        # Agent A (enterprise sales) caches a response with privileged data.
+        backend.store(
+            key       = "acme-pricing-a",
+            query     = "What pricing tier does Northrop Industries get?",
+            response  = "Northrop is Tier-3 enterprise: 22% discount, net-60 terms.",
+            embedding = PRICING_QUERY_VEC,
+            tenant_id = "acme_corp",
+            user_id   = "agent_001_enterprise",
+        )
+
+        # Agent B (residential sales, no enterprise access) asks similarly.
+        resp, sim = backend.search(
+            PRICING_QUERY_VEC,
+            threshold = 0.85,
+            tenant_id = "acme_corp",
+            user_id   = "agent_002_residential",
+        )
+        assert resp is None
+        assert sim == 0.0
+
+    def test_user_a_can_still_hit_their_own_cache(self, backend):
+        # Sanity check: user_id partitioning doesn't break same-user hits.
+        backend.store(
+            key       = "acme-pricing-a",
+            query     = "What pricing tier does Northrop Industries get?",
+            response  = "Northrop is Tier-3 enterprise: 22% discount, net-60 terms.",
+            embedding = PRICING_QUERY_VEC,
+            tenant_id = "acme_corp",
+            user_id   = "agent_001_enterprise",
+        )
+
+        resp, sim = backend.search(
+            PRICING_QUERY_VEC,
+            threshold = 0.85,
+            tenant_id = "acme_corp",
+            user_id   = "agent_001_enterprise",
+        )
+        assert resp == "Northrop is Tier-3 enterprise: 22% discount, net-60 terms."
+
+
+# =============================================================================
+# Scenario 4: Solo-developer single-tenant deployment (no tenant filter)
+# =============================================================================
+
+class TestSoloDeveloperNoTenantFilter:
+    """
+    Backwards-compatible single-tenant use. A solo developer using sulci
+    as a personal cache passes neither tenant_id nor user_id; everything
+    goes into the implicit 'global' partition.
+    """
+
+    def test_unfiltered_store_and_search_round_trips(self, backend):
+        backend.store(
+            key       = "solo-aws",
+            query     = "How do I deploy a Python app to AWS Lambda?",
+            response  = "Package code as a .zip, upload via aws lambda create-function.",
+            embedding = WARRANTY_QUERY_VEC,
+        )
+
+        resp, sim = backend.search(WARRANTY_QUERY_VEC, threshold=0.85)
+        assert resp == "Package code as a .zip, upload via aws lambda create-function."
+        assert sim >= 0.99
+
+
+# =============================================================================
+# Scenario 5: tenant_id and user_id compose correctly (the four-quadrant test)
+# =============================================================================
+
+class TestTenantAndUserCompose:
+    """
+    Four-quadrant matrix: same/different tenant × same/different user.
+    Only the (same-tenant, same-user) quadrant should hit. The other three
+    must miss — including the ambiguous (different-tenant, same-user-id)
+    case where the user_id collides across tenants.
+    """
+
+    def test_four_quadrants(self, backend):
+        # Store one entry under tenant=acme, user=agent_001
+        backend.store(
+            key       = "compose-1",
+            query     = "warranty question",
+            response  = "acme-agent_001 response",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = "acme_corp",
+            user_id   = "agent_001",
+        )
+
+        # Quadrant 1: same tenant, same user → HIT
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85,
+            tenant_id="acme_corp", user_id="agent_001",
+        )
+        assert resp == "acme-agent_001 response", "same-tenant same-user must hit"
+
+        # Quadrant 2: same tenant, different user → MISS
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85,
+            tenant_id="acme_corp", user_id="agent_002",
+        )
+        assert resp is None, "same-tenant different-user must miss"
+
+        # Quadrant 3: different tenant, same user_id → MISS
+        # (This is the trap: a user_id that happens to match across tenants
+        # must NOT bridge the tenant boundary. Tenant filter wins.)
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85,
+            tenant_id="globex_health", user_id="agent_001",
+        )
+        assert resp is None, "different-tenant same-user_id must miss"
+
+        # Quadrant 4: different tenant, different user → MISS
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85,
+            tenant_id="globex_health", user_id="other_agent",
+        )
+        assert resp is None, "different-tenant different-user must miss"
+
+
+# =============================================================================
+# Scenario 6: 'global' default sentinel does not leak to named tenants
+# =============================================================================
+
+class TestGlobalDefaultDoesNotLeakToNamedTenants:
+    """
+    Operational migration safety: a deployment that started as
+    single-tenant (no tenant_id) and later added multi-tenant features
+    should not have its old un-tenanted entries suddenly start matching
+    any specific tenant's searches.
+    """
+
+    def test_global_entry_does_not_match_named_tenant_search(self, backend):
+        # Old entry stored before multi-tenancy was introduced.
+        backend.store(
+            key       = "legacy-1",
+            query     = "How do I deploy?",
+            response  = "Use docker-compose up.",
+            embedding = WARRANTY_QUERY_VEC,
+            # tenant_id=None — stored internally as "global"
+        )
+
+        # New code searches with a real tenant_id.
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC,
+            threshold = 0.85,
+            tenant_id = "acme_corp",
+        )
+        assert resp is None, (
+            "Legacy 'global' entry leaked into a named-tenant search. "
+            "Operational migration to multi-tenancy is unsafe."
+        )
+
+    def test_named_tenant_entry_does_not_match_global_search(self, backend):
+        # Reverse direction: a tenant-scoped entry must not appear in
+        # an un-scoped (global) search either.
+        backend.store(
+            key       = "acme-1",
+            query     = "warranty",
+            response  = "acme warranty info",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = "acme_corp",
+        )
+
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC,
+            threshold = 0.85,
+            # tenant_id=None — searches "global" partition
+        )
+        assert resp is None
+
+
+# =============================================================================
+# Scenario 7: None and empty string tenant_id pin sentinel semantics
+# =============================================================================
+
+class TestNoneAndEmptyStringSentinelSemantics:
+    """
+    The protocol stores tenant_id=None as 'global'. Empty string ''
+    is undefined in the protocol docstring; this test pins the actual
+    behavior so future refactors don't accidentally change it.
+    """
+
+    def test_none_searches_match_none_stores(self, backend):
+        backend.store(
+            key       = "k1",
+            query     = "q",
+            response  = "r",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = None,
+        )
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85, tenant_id=None,
+        )
+        assert resp == "r"
+
+    def test_empty_string_does_not_match_none(self, backend):
+        # Pin current behavior: tenant_id="" is not the same as None.
+        # tenant_id="" hits Qdrant's filter as a literal empty-string
+        # match, while tenant_id=None falls through to no filter at all
+        # (which then matches "global" payloads). They are distinct.
+        backend.store(
+            key       = "k1",
+            query     = "q",
+            response  = "r",
+            embedding = WARRANTY_QUERY_VEC,
+            tenant_id = None,  # stored as "global"
+        )
+        resp, _ = backend.search(
+            WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="",
+        )
+        # If this assertion fails, someone changed the sentinel semantics.
+        # That's not necessarily wrong — but it's a contract change that
+        # needs deliberate review and a docstring update.
+        assert resp is None
+
+
+# =============================================================================
+# Scenario 8: Tenant isolation survives clear-and-restore lifecycle
+# =============================================================================
+
+class TestTenantIsolationSurvivesClear:
+    """
+    Operational test: clear() should not corrupt the tenant-isolation
+    behavior on subsequent stores. Specifically guards against a
+    regression where clear() destroys the collection (qdrant-client 1.x
+    raises on subsequent operations) or leaves the filter index in a
+    broken state.
+    """
+
+    def test_clear_then_restore_preserves_tenant_isolation(self, backend):
+        # First lifecycle: store + verify isolation
+        backend.store(
+            key="k1", query="q", response="acme1",
+            embedding=WARRANTY_QUERY_VEC, tenant_id="acme_corp",
+        )
+        backend.store(
+            key="k2", query="q", response="globex1",
+            embedding=WARRANTY_QUERY_VEC, tenant_id="globex_health",
+        )
+
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="acme_corp")
+        assert resp == "acme1"
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="globex_health")
+        assert resp == "globex1"
+
+        # Clear everything
+        backend.clear()
+
+        # After clear, both tenants must miss
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="acme_corp")
+        assert resp is None
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="globex_health")
+        assert resp is None
+
+        # Re-store and verify isolation still works
+        backend.store(
+            key="k3", query="q", response="acme2",
+            embedding=WARRANTY_QUERY_VEC, tenant_id="acme_corp",
+        )
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="acme_corp")
+        assert resp == "acme2"
+
+        # And cross-tenant still misses
+        resp, _ = backend.search(WARRANTY_QUERY_VEC, threshold=0.85, tenant_id="globex_health")
+        assert resp is None


### PR DESCRIPTION
## Summary

v0.4.0 introduces public Backend and Embedder protocols, first-class
tenant_id partition isolation throughout the OSS library, and developer
tooling for repeatable pre-PR verification. Also fixes qdrant-client 1.x
compatibility regressions and the anthropic_example.py default-install
ImportError.

Bumps 0.3.7 -> 0.4.0. 12 focused commits stacked on pre-v040-baseline.

## Highlights

- Backend / Embedder protocols with conformance test suite
- tenant_id partition isolation plumbed through Cache.get/set/cached_call
- qdrant-client 1.x compatibility restored (search -> query_points)
- Caught and fixed real cross-tenant data leak in tenant_id=None read path
- Dynamic __version__ via importlib.metadata (single source of truth)
- Developer tooling (scripts/, make checkin) for pre-PR verification
- docs/protocols.md + docs/multi_tenancy_and_isolation.md
- examples/extending_sulci/custom_backend.py reference impl

## How to review

12 commits, each reviewable independently. High-stakes:

- 6c3bc9d (1.1) - Protocol files
- a22a440 (1.4) - Qdrant tenant isolation + qdrant-client 1.x fixes
- 990e743 (1.7b) - Cache public API tenant_id

Lower-stakes / mechanical: 1.2, 1.3, 1.5a/b/c, 1.6.5a/b, 1.7a, 1.7c.

## Verification

`make checkin` end-to-end (~12 min wall-clock):
- smoke: 4/4
- test sweep: 294 passed, 0 failed, 33 skipped
- examples: 12/12 passed (with real OpenAI + Anthropic API calls)
- benchmark: all 17 metrics within tolerance vs baseline.json

## Backwards compatibility

tenant_id is additive at the public API. Existing v0.3.x callers without
tenant_id see identical behavior. user_id remains gated by `personalized`
for backwards compatibility (asymmetry documented; reconciliation in v0.5.0+).

## Follow-ups (separate issues, not blocking)

- Test infra: cache MiniLMEmbedder at session scope
- Examples: db_path pollution across runs
- Examples: fail fast on rejected API key
- Docs: clarify TF-IDF vs MiniLM engine in benchmark numbers
- Benchmark: --use-sulci leaves SQLite directories
- API: reconsider `personalized` flag for v0.5.0+

## After merge

1. Tag v0.4.0 on main
2. Push tag to trigger PyPI publish
3. Verify `pip install --upgrade "sulci[sqlite]"` in fresh venv
4. (Optional) Create GitHub Release with CHANGELOG entry