### PR TITLE
v0.5.0 — Sessions and sinks protocols + B1 adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,20 +22,34 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Redis (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y redis-server
+          sudo service redis-server start
+          redis-cli ping
+
       - name: Install
-        run: pip install ".[sqlite]" qdrant-client pytest pytest-cov httpx pytest-asyncio==0.21.1
+        run: pip install ".[sqlite,redis]" qdrant-client pytest pytest-cov httpx pytest-asyncio==0.21.1
 
       - name: Test Qdrant tenant isolation
         run: pytest tests/test_qdrant_tenant_isolation.py -v --tb=short
 
       - name: Conformance suite
-        run: pytest tests/compat/ -v --tb=short
+        run: pytest tests/compat/ sulci/tests/compat/ -v --tb=short
 
       - name: Test core
         run: pytest tests/test_core.py -v --tb=short --cov=sulci --cov-report=term-missing
 
       - name: Test context
         run: pytest tests/test_context.py -v --tb=short
+
+      - name: Test sessions
+        run: pytest tests/test_sessions.py -v --tb=short
+
+      - name: Test sinks
+        run: pytest tests/test_sinks.py -v --tb=short
 
       - name: Backend tests (skip missing deps)
         run: pytest tests/test_backends.py -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,72 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.0] — 2026-04-27
+
+### Added
+
+- `sulci.sessions` package — SessionStore protocol and implementations
+  - `SessionStore` — public stable protocol
+  - `InMemorySessionStore` — default, process-local (extracted from sulci/context.py)
+  - `RedisSessionStore` — Redis Lists-backed for horizontal scaling
+- `sulci.sinks` package — EventSink protocol and implementations
+  - `EventSink` — public stable protocol
+  - `CacheEvent` — dataclass representing a cache event
+  - `NullSink` — default no-op sink
+  - `TelemetrySink` — HTTPS POST with strict field allowlist (never emits query/response/vectors)
+  - `RedisStreamSink` — writes scrubbed events to a Redis Stream
+- `Cache(session_store=..., event_sink=...)` — two new constructor kwargs
+  - Both default to `None`, which uses `InMemorySessionStore()` and `NullSink()` respectively
+  - Enables horizontal-scale deployments (via `RedisSessionStore`) and observability/billing (via any EventSink)
+- `SyncCache` — alias for `Cache` exported from the top-level `sulci` namespace
+  - Naming symmetry with existing `AsyncCache`
+  - `sulci.SyncCache is sulci.Cache` returns True
+- Conformance suites: `sulci.tests.compat.test_session_store_conformance` + `test_event_sink_conformance`
+
+### Changed
+
+- `sulci/__init__.py` exports `SyncCache` and the new session/sink primitives
+- `Cache.__init__` gains `session_store` and `event_sink` kwargs (both `None` by default).
+  When `session_store` is injected, Cache uses an internal bridge
+  (`_ProtocolAdaptedSessionStore`) to translate between the new
+  `sulci.sessions.SessionStore` protocol and the legacy `ContextWindow` surface
+  Cache uses internally.
+- `sulci/context.py` is **unchanged** — the legacy `SessionStore` class
+  (higher-level ContextWindow manager) remains the default when no
+  `session_store` kwarg is passed. See ADR 0007.
+
+### Compatibility
+
+- Fully backward-compatible. All v0.4.x code continues to work unchanged.
+- 335+ existing tests pass + ~50 new tests added (sessions, sinks, conformance, injection).
+- `AsyncCache` behavior unchanged. No async-native refactor.
+- Defaults preserve exact v0.4.x behavior if new kwargs are not supplied.
+- `from sulci.context import SessionStore` returns the **legacy** higher-level
+  manager class (unchanged), not `sulci.sessions.InMemorySessionStore`. The
+  bundle originally proposed aliasing them; we kept them separate to preserve
+  v0.4.x behavior for direct importers. See ADR 0007 for the full rationale.
+  When `Cache(session_store=<sulci.sessions.SessionStore impl>)` is injected,
+  Cache adapts via an internal bridge (`_ProtocolAdaptedSessionStore`) that
+  rebuilds a transient `ContextWindow` per lookup.
+
+### Privacy
+
+- `TelemetrySink` and `RedisStreamSink` enforce a strict field allowlist (`_ALLOWED_FIELDS` frozenset).
+- The `CacheEvent.metadata` dict is NEVER shipped externally.
+- Query text, response text, and embedding vectors NEVER leave the process via shipped sinks.
+
+### Related ADRs
+
+- ADR 0004 — SessionStore and EventSink protocols
+- ADR 0007 — Preserve the legacy `sulci.context.SessionStore` class (B1 adapter)
+
+### Roadmap
+
+- See `docs/roadmap/FUTURE-DESIGN-OPTIONS.md` — v0.5.0 is additive by design.
+  True async-native Cache refactor is deferred as roadmap item R2.
+
+---
+
 ## [0.4.0] — 2026-04-26
 
 ### Added
@@ -60,7 +126,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 - **`__version__`** is now derived dynamically from `pyproject.toml` via
   `importlib.metadata.version("sulci")`. Previously hardcoded in three
-  places (pyproject.toml, _SDK_VERSION, USER_AGENT) which had drifted.
+  places (pyproject.toml, \_SDK_VERSION, USER_AGENT) which had drifted.
 - **`_SDK_VERSION`** still exists (telemetry payload field name unchanged
   on the wire) but now equals `__version__`. Marked as deprecated alias.
 - **`SulciCloudBackend.USER_AGENT`** now `f"sulci/{__version__}"` (was
@@ -370,6 +436,7 @@ Total                             152 tests
 ## [0.3.2] — 2026-03-27
 
 ### Patent & Legal
+
 - Updated NOTICE file with US Patent Application No. 64/018,452
 - Added Patent Pending badge and notice to README
 - Updated PyPI description to include Patent Pending
@@ -381,6 +448,7 @@ Total                             152 tests
 ## [0.3.1] — 2026-03-27
 
 ### License
+
 - Changed from MIT License to Apache License 2.0
 - Added NOTICE file as required by Apache 2.0
 - Updated pyproject.toml classifier to Apache Software License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version         = "0.4.0"
+version = "0.5.0"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -240,11 +240,26 @@ try:
     from sulci.core import Cache
     from sulci.context import ContextWindow, SessionStore
     from sulci.async_cache import AsyncCache
+    # v0.5.0 — new protocols and implementations (additive; ADR 0004 + ADR 0007)
+    # Note: top-level `sulci.SessionStore` continues to be the legacy class
+    # from sulci.context (backward compat). The new sulci.sessions.SessionStore
+    # protocol is namespaced and accessed via `from sulci.sessions import SessionStore`.
+    from sulci.sessions import InMemorySessionStore, RedisSessionStore
+    from sulci.sinks    import EventSink, NullSink, RedisStreamSink, TelemetrySink, CacheEvent
+    SyncCache = Cache   # naming symmetry with AsyncCache
 except ImportError:
-    Cache         = None  # type: ignore[assignment]
-    ContextWindow = None  # type: ignore[assignment]
-    SessionStore  = None  # type: ignore[assignment]
-    AsyncCache    = None  # type: ignore[assignment]
+    Cache                = None  # type: ignore[assignment]
+    ContextWindow        = None  # type: ignore[assignment]
+    SessionStore         = None  # type: ignore[assignment]
+    AsyncCache           = None  # type: ignore[assignment]
+    SyncCache            = None  # type: ignore[assignment]
+    InMemorySessionStore = None  # type: ignore[assignment]
+    RedisSessionStore    = None  # type: ignore[assignment]
+    EventSink            = None  # type: ignore[assignment]
+    NullSink             = None  # type: ignore[assignment]
+    RedisStreamSink      = None  # type: ignore[assignment]
+    TelemetrySink        = None  # type: ignore[assignment]
+    CacheEvent           = None  # type: ignore[assignment]
 
 
 def _python_version() -> str:
@@ -257,8 +272,16 @@ def _python_version() -> str:
 
 __all__ = [
     "Cache",
+    "SyncCache",
     "AsyncCache",
     "ContextWindow",
-    "SessionStore",
+    "SessionStore",            # legacy class (sulci.context)
+    "InMemorySessionStore",    # new protocol impl (sulci.sessions)
+    "RedisSessionStore",       # new protocol impl (sulci.sessions)
+    "EventSink",               # new protocol (sulci.sinks)
+    "NullSink",                # new protocol impl
+    "RedisStreamSink",         # new protocol impl
+    "TelemetrySink",           # new protocol impl
+    "CacheEvent",              # event dataclass
     "connect",
 ]

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -16,7 +16,104 @@ import importlib
 import time as _time
 from typing import Optional, Callable, Any
 
-from sulci.context import ContextWindow, SessionStore
+from sulci.context import ContextWindow
+from sulci.context import SessionStore as _BuiltinSessionStore
+
+# v0.5.0 — sessions and sinks protocols (additive; see ADR 0004 + ADR 0007)
+from sulci.sessions import SessionStore as SessionStoreProtocol
+from sulci.sinks import EventSink, NullSink, CacheEvent
+
+
+class _ProtocolAdaptedSessionStore:
+    """
+    Internal adapter — bridges injected SessionStore-protocol stores
+    (sulci.sessions.SessionStore: raw vector storage) to the legacy
+    surface Cache uses internally (ContextWindow-returning manager).
+
+    Per ADR 0007: rebuilds a transient ContextWindow on every .get(),
+    seeded from the inner store's vectors. The returned window's
+    add_turn(role='user', embedding=...) is wrapped to round-trip
+    user-vector additions back to the inner store. Assistant turns
+    stay window-local (the new protocol doesn't carry response text).
+
+    Not part of the public API.
+    """
+
+    def __init__(
+        self,
+        inner:        SessionStoreProtocol,
+        query_weight: float,
+        decay:        float,
+        max_turns:    int,
+    ):
+        self._inner     = inner
+        self._max_turns = max_turns
+        self._cfg       = dict(
+            max_turns    = max_turns,
+            query_weight = query_weight,
+            decay        = decay,
+        )
+
+    def get(self, session_id: str) -> ContextWindow:
+        """Rebuild a transient window seeded from the inner store."""
+        window = ContextWindow(**self._cfg)
+        try:
+            for v in self._inner.get(session_id):
+                window.add_turn("", role="user", embedding=v)
+        except Exception:
+            # Inner-store read failures degrade to empty context
+            pass
+        self._wrap_add_turn(window, session_id)
+        return window
+
+    def _wrap_add_turn(self, window, session_id):
+        original    = window.add_turn
+        inner       = self._inner
+        max_turns   = self._max_turns
+        def wrapped(text, role="user", embedding=None):
+            result = original(text, role=role, embedding=embedding)
+            # Write-through: only user-role turns with embeddings
+            # round-trip to the inner store. Assistant turns and
+            # text-only user turns stay window-local.
+            if role == "user" and embedding is not None:
+                try:
+                    inner.append(session_id, embedding, max_turns=max_turns)
+                except Exception:
+                    # Inner-store write failures must not break Cache calls
+                    pass
+            return result
+        window.add_turn = wrapped
+
+    def delete(self, session_id: str) -> None:
+        try:
+            self._inner.clear(session_id)
+        except Exception:
+            pass
+
+    def clear_all(self) -> None:
+        # The new protocol doesn't expose enumeration. For multi-replica
+        # deployments (the primary motivation for injection), clear-all
+        # at the library level is a no-op — operators clear via their
+        # own admin tooling. Behavioral parity with legacy in the
+        # single-process case is satisfied by the adapter being
+        # discarded with the Cache instance.
+        pass
+
+    def active_sessions(self) -> list:
+        # Same enumeration limitation as clear_all().
+        return []
+
+    def summary(self) -> dict:
+        try:
+            inner_sum = self._inner.summary() or {}
+        except Exception:
+            inner_sum = {}
+        # Translate new-protocol shape to legacy shape
+        return {
+            "active_sessions": int(inner_sum.get("sessions", 0)),
+            "ttl_seconds":     None,
+            "sessions":        {},  # per-session breakdown not available
+        }
 
 
 class Cache:
@@ -90,29 +187,47 @@ class Cache:
         telemetry                      = True,
         api_key:         Optional[str] = None,
         gateway_url:     str           = "",
+        # ── v0.5.0 additions (ADR 0004 + ADR 0007) ──
+        session_store:   Optional[SessionStoreProtocol] = None,
+        event_sink:      Optional[EventSink]            = None,
     ):
         self._telemetry     = telemetry
         self.backend        = backend
         self.threshold      = threshold
         self.ttl_seconds    = ttl_seconds
         self.personalized   = personalized
-        self.context_window = context_window
-        self._stats         = {"hits": 0, "misses": 0, "saved_cost": 0.0}
+        self.context_window  = context_window
+        self.embedding_model = embedding_model
+        self._stats          = {"hits": 0, "misses": 0, "saved_cost": 0.0}
 
         self._embedder = self._load_embedder(embedding_model)
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
-        # Session store — created only when context_window > 0
-        self._sessions: Optional[SessionStore] = (
-            SessionStore(
+        # ── v0.5.0 session-store wiring (ADR 0007) ──
+        # Three branches, in priority order:
+        #   1. session_store= injected → wrap with adapter (B1 approach)
+        #   2. context_window > 0      → legacy _BuiltinSessionStore (default)
+        #   3. otherwise               → no context tracking
+        if session_store is not None:
+            self._sessions = _ProtocolAdaptedSessionStore(
+                inner        = session_store,
+                query_weight = query_weight,
+                decay        = context_decay,
+                max_turns    = context_window if context_window > 0 else 6,
+            )
+        elif context_window > 0:
+            self._sessions = _BuiltinSessionStore(
                 max_turns    = context_window,
                 query_weight = query_weight,
                 decay        = context_decay,
                 ttl_seconds  = session_ttl,
             )
-            if context_window > 0
-            else None
-        )
+        else:
+            self._sessions = None
+
+        # ── v0.5.0 event sink (ADR 0004) ──
+        # Default NullSink preserves zero-overhead behavior when no sink injected.
+        self._event_sink: EventSink = event_sink if event_sink is not None else NullSink()
 
     # ── private helpers ───────────────────────────────────────────
 
@@ -232,6 +347,7 @@ class Cache:
             user_id   = user_id if self.personalized else None,
             now       = time.time(),
         )
+        latency_ms = round((_time.time() - _t0) * 1000, 2)
         try:
             if self._telemetry:
                 import sys
@@ -241,9 +357,27 @@ class Cache:
                             "backend":    self.backend,
                             "hits":       1 if resp is not None else 0,
                             "misses":     0 if resp is not None else 1,
-                            "latency_ms": round((_time.time() - _t0) * 1000, 2),
+                            "latency_ms": latency_ms,
                         })
         except Exception:
+            pass
+
+        # v0.5.0 — structured event sink (additive; defaults to NullSink)
+        try:
+            self._event_sink.emit(CacheEvent(
+                event_type      = "hit" if resp is not None else "miss",
+                tenant_id       = tenant_id,
+                user_id         = user_id,
+                session_id      = session_id,
+                backend_id      = self.backend,
+                embedding_model = self.embedding_model,
+                similarity      = float(sim) if sim is not None else None,
+                latency_ms      = int(latency_ms),
+                context_depth   = depth,
+                timestamp       = _time.time(),
+            ))
+        except Exception:
+            # Sink failures must not break Cache calls
             pass
 
         return resp, sim, depth
@@ -283,6 +417,20 @@ class Cache:
         )
         if session_id and self._sessions:
             self._record_turn(session_id, query, response, raw_vec)
+
+        # v0.5.0 — structured event sink (additive; defaults to NullSink)
+        try:
+            self._event_sink.emit(CacheEvent(
+                event_type      = "set",
+                tenant_id       = tenant_id,
+                user_id         = user_id,
+                session_id      = session_id,
+                backend_id      = self.backend,
+                embedding_model = self.embedding_model,
+                timestamp       = time.time(),
+            ))
+        except Exception:
+            pass
 
     def cached_call(
         self,
@@ -419,6 +567,17 @@ class Cache:
         self._stats = {"hits": 0, "misses": 0, "saved_cost": 0.0}
         if self._sessions:
             self._sessions.clear_all()
+
+        # v0.5.0 — structured event sink (additive; defaults to NullSink)
+        try:
+            self._event_sink.emit(CacheEvent(
+                event_type      = "clear",
+                backend_id      = self.backend,
+                embedding_model = self.embedding_model,
+                timestamp       = time.time(),
+            ))
+        except Exception:
+            pass
 
     def __repr__(self) -> str:
         ctx = f", context_window={self.context_window}" if self.context_window else ""

--- a/sulci/sessions/__init__.py
+++ b/sulci/sessions/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci.sessions — v0.5.0 session store protocols and implementations.
+
+Public API:
+    SessionStore            (protocol)
+    InMemorySessionStore    (default, process-local)
+    RedisSessionStore       (for horizontal scaling)
+"""
+from sulci.sessions.protocol import SessionStore
+from sulci.sessions.memory import InMemorySessionStore
+from sulci.sessions.redis import RedisSessionStore
+
+__all__ = ["SessionStore", "InMemorySessionStore", "RedisSessionStore"]

--- a/sulci/sessions/memory.py
+++ b/sulci/sessions/memory.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sessions/memory.py — InMemorySessionStore (v0.5.0)
+
+Extracted from sulci/context.py to match the SessionStore protocol.
+Behavior is identical to the v0.3.x context.SessionStore class.
+sulci.context.SessionStore still importable via backward-compat shim.
+"""
+from __future__ import annotations
+from collections import defaultdict
+from typing import Optional, List, Sequence
+
+from sulci.sessions.protocol import SessionStore
+
+
+class InMemorySessionStore(SessionStore):
+    """
+    Process-local session store using a dict.
+
+    Appropriate for:
+      - Single-process deployments (notebooks, Streamlit, local dev)
+      - Self-hosted single-gateway configurations
+
+    NOT appropriate for:
+      - Multi-replica gateway (use RedisSessionStore instead)
+      - Long-running processes that may leak memory (use max_total_sessions)
+    """
+
+    def __init__(self, max_total_sessions: Optional[int] = None):
+        """
+        Args:
+            max_total_sessions: If set, evicts the oldest session when
+                                exceeded (LRU-ish). Default None = unbounded.
+        """
+        self._data: dict[str, List[Sequence[float]]] = defaultdict(list)
+        self._max_total_sessions = max_total_sessions
+
+    def get(self, session_id: str) -> List[Sequence[float]]:
+        return list(self._data.get(session_id, []))
+
+    def append(
+        self,
+        session_id: str,
+        vector: Sequence[float],
+        max_turns: int = 8,
+    ) -> None:
+        history = self._data[session_id]
+        history.append(list(vector))
+        if len(history) > max_turns:
+            # Trim from the front — keep most recent max_turns entries
+            del history[:-max_turns]
+
+        if (self._max_total_sessions
+                and len(self._data) > self._max_total_sessions):
+            # Evict the first-inserted session (Python 3.7+ dicts preserve order)
+            oldest_id = next(iter(self._data))
+            del self._data[oldest_id]
+
+    def clear(self, session_id: str) -> None:
+        self._data.pop(session_id, None)
+
+    def summary(self, session_id: Optional[str] = None) -> dict:
+        if session_id is not None:
+            turns = len(self._data.get(session_id, []))
+            return {
+                "sessions": 1 if session_id in self._data else 0,
+                "total_turns": turns,
+                "avg_turns": float(turns),
+            }
+
+        total_sessions = len(self._data)
+        total_turns = sum(len(h) for h in self._data.values())
+        avg_turns = total_turns / total_sessions if total_sessions else 0.0
+        return {
+            "sessions": total_sessions,
+            "total_turns": total_turns,
+            "avg_turns": avg_turns,
+        }

--- a/sulci/sessions/memory.py
+++ b/sulci/sessions/memory.py
@@ -27,17 +27,29 @@ class InMemorySessionStore(SessionStore):
       - Long-running processes that may leak memory (use max_total_sessions)
     """
 
-    def __init__(self, max_total_sessions: Optional[int] = None):
+    def __init__(
+        self,
+        max_total_sessions: Optional[int] = None,
+        tenant_id: Optional[str] = None,
+    ):
         """
         Args:
             max_total_sessions: If set, evicts the oldest session when
                                 exceeded (LRU-ish). Default None = unbounded.
+            tenant_id:          Bind this store to a tenant. When set, all
+                                session_ids are namespaced internally so two
+                                tenants using the same session_id never collide.
+                                Default None = single-tenant (no scoping).
         """
         self._data: dict[str, List[Sequence[float]]] = defaultdict(list)
         self._max_total_sessions = max_total_sessions
+        self._tenant_id = tenant_id
+
+    def _scoped(self, session_id: str) -> str:
+        return f"{self._tenant_id}::{session_id}" if self._tenant_id else session_id
 
     def get(self, session_id: str) -> List[Sequence[float]]:
-        return list(self._data.get(session_id, []))
+        return list(self._data.get(self._scoped(session_id), []))
 
     def append(
         self,
@@ -45,7 +57,7 @@ class InMemorySessionStore(SessionStore):
         vector: Sequence[float],
         max_turns: int = 8,
     ) -> None:
-        history = self._data[session_id]
+        history = self._data[self._scoped(session_id)]
         history.append(list(vector))
         if len(history) > max_turns:
             # Trim from the front — keep most recent max_turns entries
@@ -58,13 +70,14 @@ class InMemorySessionStore(SessionStore):
             del self._data[oldest_id]
 
     def clear(self, session_id: str) -> None:
-        self._data.pop(session_id, None)
+        self._data.pop(self._scoped(session_id), None)
 
     def summary(self, session_id: Optional[str] = None) -> dict:
         if session_id is not None:
-            turns = len(self._data.get(session_id, []))
+            scoped = self._scoped(session_id)
+            turns = len(self._data.get(scoped, []))
             return {
-                "sessions": 1 if session_id in self._data else 0,
+                "sessions": 1 if scoped in self._data else 0,
                 "total_turns": turns,
                 "avg_turns": float(turns),
             }

--- a/sulci/sessions/protocol.py
+++ b/sulci/sessions/protocol.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sessions/protocol.py — SessionStore protocol (v0.5.0)
+
+STABLE API — modifications require superseding ADR per ADR 0005.
+"""
+from __future__ import annotations
+from typing import Protocol, runtime_checkable, Optional, List, Sequence
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    """
+    Per-session conversation history for context-aware caching.
+
+    Implementations shipped in v0.5.0:
+      - InMemorySessionStore — process-local dict (default, zero config)
+      - RedisSessionStore    — Redis Lists for horizontal scaling
+
+    Custom implementations: any class matching this surface.
+    """
+
+    def get(self, session_id: str) -> List[Sequence[float]]:
+        """
+        Return the conversation history for this session as a list of
+        embedding vectors. Most recent last. Empty list if session is new.
+        """
+        ...
+
+    def append(
+        self,
+        session_id: str,
+        vector: Sequence[float],
+        max_turns: int = 8,
+    ) -> None:
+        """
+        Append an embedding vector to this session's history.
+        If len(history) > max_turns, the oldest entries are dropped.
+        """
+        ...
+
+    def clear(self, session_id: str) -> None:
+        """Remove all history for this session. Idempotent."""
+        ...
+
+    def summary(self, session_id: Optional[str] = None) -> dict:
+        """
+        Return stats about the store.
+        If session_id is given, stats for that session only.
+        If None, aggregate stats across all sessions.
+
+        Return shape:
+          {
+            "sessions": int,        # number of distinct session_ids (or 1 if scoped)
+            "total_turns": int,     # total history entries across sessions
+            "avg_turns": float,     # average per session
+          }
+        """
+        ...

--- a/sulci/sessions/redis.py
+++ b/sulci/sessions/redis.py
@@ -38,6 +38,7 @@ class RedisSessionStore(SessionStore):
         redis_client,
         key_prefix: str = "sulci:session:",
         ttl_seconds: Optional[int] = None,
+        tenant_id: Optional[str] = None,
     ):
         try:
             import redis   # noqa: F401
@@ -49,8 +50,11 @@ class RedisSessionStore(SessionStore):
         self._redis = redis_client
         self._prefix = key_prefix
         self._ttl = ttl_seconds
+        self._tenant_id = tenant_id
 
     def _key(self, session_id: str) -> str:
+        if self._tenant_id:
+            return f"{self._prefix}{self._tenant_id}:{session_id}"
         return f"{self._prefix}{session_id}"
 
     def get(self, session_id: str) -> List[Sequence[float]]:
@@ -92,7 +96,8 @@ class RedisSessionStore(SessionStore):
         cursor = 0
         sessions = 0
         total_turns = 0
-        pattern = f"{self._prefix}*"
+        pattern = (f"{self._prefix}{self._tenant_id}:*"
+                   if self._tenant_id else f"{self._prefix}*")
         while True:
             cursor, keys = self._redis.scan(cursor=cursor, match=pattern, count=100)
             for k in keys:

--- a/sulci/sessions/redis.py
+++ b/sulci/sessions/redis.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sessions/redis.py — RedisSessionStore (v0.5.0)
+
+Redis-backed session store for horizontally-scaled deployments.
+Multiple gateway replicas share session history via Redis Lists.
+
+Key schema:
+    sulci:session:{session_id}   — Redis List of JSON-encoded vectors
+
+Install:
+    pip install "sulci[redis]"  (or "sulci[all]")
+"""
+from __future__ import annotations
+import json
+from typing import Optional, List, Sequence
+
+from sulci.sessions.protocol import SessionStore
+
+
+class RedisSessionStore(SessionStore):
+    """
+    Redis-backed session store.
+
+    Each session is a Redis List where each entry is a JSON-encoded vector.
+    LPUSH appends to the front; LTRIM keeps history bounded.
+
+    Args:
+        redis_client: Configured redis.Redis client instance
+        key_prefix:   Prefix for Redis keys (default "sulci:session:")
+        ttl_seconds:  TTL for session keys. Default None = no expiry.
+                      Set to e.g. 86400 for 24-hour session lifetime.
+    """
+
+    def __init__(
+        self,
+        redis_client,
+        key_prefix: str = "sulci:session:",
+        ttl_seconds: Optional[int] = None,
+    ):
+        try:
+            import redis   # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "redis package not installed. "
+                'Install with: pip install "sulci[redis]"'
+            )
+        self._redis = redis_client
+        self._prefix = key_prefix
+        self._ttl = ttl_seconds
+
+    def _key(self, session_id: str) -> str:
+        return f"{self._prefix}{session_id}"
+
+    def get(self, session_id: str) -> List[Sequence[float]]:
+        key = self._key(session_id)
+        # LRANGE returns entries with most-recent-first if we LPUSH.
+        # We store oldest-first by RPUSH, so LRANGE 0 -1 returns chronological.
+        raw = self._redis.lrange(key, 0, -1)
+        if not raw:
+            return []
+        return [json.loads(item) for item in raw]
+
+    def append(
+        self,
+        session_id: str,
+        vector: Sequence[float],
+        max_turns: int = 8,
+    ) -> None:
+        key = self._key(session_id)
+        pipe = self._redis.pipeline()
+        pipe.rpush(key, json.dumps(list(vector)))
+        pipe.ltrim(key, -max_turns, -1)   # Keep last max_turns entries
+        if self._ttl:
+            pipe.expire(key, self._ttl)
+        pipe.execute()
+
+    def clear(self, session_id: str) -> None:
+        self._redis.delete(self._key(session_id))
+
+    def summary(self, session_id: Optional[str] = None) -> dict:
+        if session_id is not None:
+            turns = self._redis.llen(self._key(session_id))
+            return {
+                "sessions": 1 if turns > 0 else 0,
+                "total_turns": turns,
+                "avg_turns": float(turns),
+            }
+
+        # Aggregate — uses SCAN, could be expensive on huge Redis instances
+        cursor = 0
+        sessions = 0
+        total_turns = 0
+        pattern = f"{self._prefix}*"
+        while True:
+            cursor, keys = self._redis.scan(cursor=cursor, match=pattern, count=100)
+            for k in keys:
+                sessions += 1
+                total_turns += self._redis.llen(k)
+            if cursor == 0:
+                break
+
+        avg = total_turns / sessions if sessions else 0.0
+        return {"sessions": sessions, "total_turns": total_turns, "avg_turns": avg}

--- a/sulci/sinks/__init__.py
+++ b/sulci/sinks/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci.sinks — v0.5.0 event sink protocols and implementations.
+
+Public API:
+    CacheEvent          (dataclass)
+    EventSink           (protocol)
+    NullSink            (default no-op)
+    TelemetrySink       (HTTPS POST with field allowlist)
+    RedisStreamSink     (for platform billing pipeline)
+"""
+from sulci.sinks.protocol import CacheEvent, EventSink
+from sulci.sinks.null import NullSink
+from sulci.sinks.telemetry import TelemetrySink
+from sulci.sinks.redis_stream import RedisStreamSink
+
+__all__ = [
+    "CacheEvent", "EventSink",
+    "NullSink", "TelemetrySink", "RedisStreamSink",
+]

--- a/sulci/sinks/null.py
+++ b/sulci/sinks/null.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sinks/null.py — NullSink (v0.5.0)
+
+The default sink used when Cache() is constructed without event_sink=.
+Does nothing. Zero overhead.
+"""
+from sulci.sinks.protocol import CacheEvent, EventSink
+
+
+class NullSink(EventSink):
+    """Default no-op sink. All emits are dropped."""
+
+    def emit(self, event: CacheEvent) -> None:
+        pass
+
+    def flush(self) -> None:
+        pass

--- a/sulci/sinks/protocol.py
+++ b/sulci/sinks/protocol.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sinks/protocol.py — EventSink protocol + CacheEvent (v0.5.0)
+
+STABLE API — modifications require superseding ADR per ADR 0005.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable, Optional, Dict, Any
+
+
+@dataclass
+class CacheEvent:
+    """
+    Emitted by Cache on every hit/miss/set/clear.
+
+    Privacy discipline: sinks shipped with sulci MUST NOT emit query text,
+    response text, or embedding vectors externally. Only the metadata
+    envelope shown below leaves the process. TelemetrySink enforces this
+    via an explicit field allowlist.
+    """
+    event_type: str                             # 'hit' | 'miss' | 'set' | 'clear'
+    tenant_id: Optional[str] = None
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
+    backend_id: Optional[str] = None            # e.g. 'qdrant', 'chroma', 'sulci'
+    embedding_model: Optional[str] = None       # e.g. 'minilm', 'openai'
+    similarity: Optional[float] = None          # for 'hit' events
+    latency_ms: Optional[int] = None            # for 'hit' and 'miss'
+    context_depth: int = 0                      # number of session turns consulted
+    timestamp: Optional[float] = None           # unix timestamp
+    metadata: Dict[str, Any] = field(default_factory=dict)   # extension point
+
+
+@runtime_checkable
+class EventSink(Protocol):
+    """
+    Receives CacheEvent on every cache operation.
+
+    Implementations shipped in v0.5.0:
+      - NullSink         — no-op, default
+      - TelemetrySink    — HTTPS POST to endpoint with field allowlist
+      - RedisStreamSink  — writes to Redis Stream for billing/observability
+
+    Custom implementations: any class matching this surface.
+    """
+
+    def emit(self, event: CacheEvent) -> None:
+        """
+        Handle a cache event. Called on every hit/miss/set/clear.
+
+        MUST NOT raise on delivery failure — degrade gracefully
+        (log and continue). A failing sink must never break the
+        caller's cache operation.
+        """
+        ...
+
+    def flush(self) -> None:
+        """
+        Force-flush any buffered events.
+
+        Called at Cache.__del__ and on explicit user flush.
+        May be a no-op for sinks that don't buffer.
+        """
+        ...

--- a/sulci/sinks/redis_stream.py
+++ b/sulci/sinks/redis_stream.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sinks/redis_stream.py — RedisStreamSink (v0.5.0)
+
+Writes cache events to a Redis Stream for downstream consumers
+(billing pipeline, analytics, etc.). Used by sulci-platform's
+billing infrastructure.
+
+Uses the same allowlist as TelemetrySink — never emits query/response/vectors.
+"""
+from __future__ import annotations
+import json
+import logging
+from dataclasses import asdict
+from typing import Optional
+
+from sulci.sinks.protocol import CacheEvent, EventSink
+from sulci.sinks.telemetry import _ALLOWED_FIELDS, _scrub
+
+log = logging.getLogger(__name__)
+
+
+class RedisStreamSink(EventSink):
+    """
+    Write events to a Redis Stream.
+
+    Args:
+        redis_client: Configured redis.Redis instance
+        stream_key:   Redis Stream name (default "sulci:events")
+        max_length:   Trim stream to this length on each write (approximate)
+    """
+
+    def __init__(
+        self,
+        redis_client,
+        stream_key: str = "sulci:events",
+        max_length: Optional[int] = 1_000_000,
+    ):
+        try:
+            import redis   # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "redis package not installed. "
+                'Install with: pip install "sulci[redis]"'
+            )
+        self._redis = redis_client
+        self._stream = stream_key
+        self._max_length = max_length
+
+    def emit(self, event: CacheEvent) -> None:
+        scrubbed = _scrub(event)  # privacy firewall — same as TelemetrySink
+
+        # Redis stream entries are flat string maps; serialize non-str values
+        entry = {k: (json.dumps(v) if not isinstance(v, (str, int, float, bool, type(None))) else ("" if v is None else str(v)))
+                 for k, v in scrubbed.items()}
+
+        try:
+            if self._max_length:
+                self._redis.xadd(
+                    self._stream, entry,
+                    maxlen=self._max_length, approximate=True,
+                )
+            else:
+                self._redis.xadd(self._stream, entry)
+        except Exception as e:  # noqa: BLE001
+            # Never raise from a sink; caller's cache call must not fail
+            log.debug("RedisStreamSink emit failed: %s", e)
+
+    def flush(self) -> None:
+        # Redis XADD is synchronous — no buffering to flush
+        pass

--- a/sulci/sinks/telemetry.py
+++ b/sulci/sinks/telemetry.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+sulci/sinks/telemetry.py — TelemetrySink (v0.5.0)
+
+HTTPS POST sink with strict field allowlist.
+
+Privacy guarantee: TelemetrySink NEVER sends query text, response text,
+or embedding vectors externally. Only the allowlisted metadata fields
+leave the process. This is enforced in code (not convention) via
+_ALLOWED_FIELDS below.
+"""
+from __future__ import annotations
+import json
+import logging
+import threading
+import time
+from collections import deque
+from dataclasses import asdict
+from typing import Optional
+
+from sulci.sinks.protocol import CacheEvent, EventSink
+
+log = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------
+# PRIVACY-CRITICAL: the only fields ever shipped to external endpoints.
+# Modifying this list requires explicit review; changes could leak data.
+# ----------------------------------------------------------------------
+_ALLOWED_FIELDS = frozenset([
+    "event_type",
+    "tenant_id",
+    "user_id",          # may contain PII; caller's responsibility to anonymize
+    "session_id",       # may contain PII; caller's responsibility to anonymize
+    "backend_id",
+    "embedding_model",
+    "similarity",
+    "latency_ms",
+    "context_depth",
+    "timestamp",
+])
+
+
+def _scrub(event: CacheEvent) -> dict:
+    """
+    Return a dict containing ONLY allowlisted fields.
+    Never includes query, response, embedding, or metadata dict contents.
+
+    This is the privacy firewall. Never modify without careful review.
+    """
+    raw = asdict(event)
+    return {k: v for k, v in raw.items() if k in _ALLOWED_FIELDS}
+
+
+class TelemetrySink(EventSink):
+    """
+    Batch events, POST to a telemetry endpoint over HTTPS.
+
+    Args:
+        endpoint_url:  HTTPS URL to POST batches to
+        api_key:       Optional bearer token
+        batch_size:    Events accumulated before flush (default 100)
+        flush_interval: Seconds before auto-flush even if batch not full
+        timeout_seconds: HTTP timeout per batch
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        api_key: Optional[str] = None,
+        batch_size: int = 100,
+        flush_interval: float = 30.0,
+        timeout_seconds: float = 5.0,
+    ):
+        if not endpoint_url.startswith("https://"):
+            raise ValueError(
+                "TelemetrySink requires HTTPS endpoint. "
+                "Plain HTTP is not acceptable for telemetry."
+            )
+        try:
+            import httpx    # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "httpx required for TelemetrySink. "
+                'Install with: pip install "sulci[cloud]"'
+            )
+        self._endpoint = endpoint_url
+        self._api_key = api_key
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval
+        self._timeout = timeout_seconds
+
+        self._buf: deque = deque()
+        self._lock = threading.Lock()
+        self._last_flush = time.time()
+
+    def emit(self, event: CacheEvent) -> None:
+        scrubbed = _scrub(event)   # privacy firewall
+        with self._lock:
+            self._buf.append(scrubbed)
+            should_flush = (
+                len(self._buf) >= self._batch_size
+                or (time.time() - self._last_flush) > self._flush_interval
+            )
+        if should_flush:
+            self.flush()
+
+    def flush(self) -> None:
+        with self._lock:
+            if not self._buf:
+                return
+            batch = list(self._buf)
+            self._buf.clear()
+            self._last_flush = time.time()
+
+        try:
+            import httpx
+            headers = {"Content-Type": "application/json"}
+            if self._api_key:
+                headers["Authorization"] = f"Bearer {self._api_key}"
+            response = httpx.post(
+                self._endpoint,
+                headers=headers,
+                content=json.dumps({"events": batch}),
+                timeout=self._timeout,
+            )
+            if response.status_code >= 400:
+                log.warning(
+                    "TelemetrySink received %d from endpoint", response.status_code
+                )
+        except Exception as e:  # noqa: BLE001 - must not raise
+            # Drop events on network error. Degrade silently per protocol spec.
+            log.debug("TelemetrySink flush failed: %s", e)

--- a/sulci/tests/compat/conftest.py
+++ b/sulci/tests/compat/conftest.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+sulci/tests/compat/conftest.py
+==============================
+Fixtures for the SessionStore and EventSink conformance suites.
+
+To validate a custom SessionStore or EventSink implementation, add a
+factory entry to the appropriate registry below and run:
+
+    pytest sulci/tests/compat/
+
+Each factory returns either:
+  - A live instance ready to use, OR
+  - None, signaling "not available locally" (missing dep, no server, etc.)
+    in which case parametrized tests for that impl are skipped, not failed.
+
+External implementers can override these fixtures from their own
+conftest.py without modifying this file.
+"""
+from __future__ import annotations
+from typing import Any, Optional, Callable, List, Tuple
+
+import pytest
+
+
+# -----------------------------------------------------------------------------
+# SessionStore registry
+# -----------------------------------------------------------------------------
+
+def _make_in_memory_session() -> Optional[Any]:
+    from sulci.sessions import InMemorySessionStore
+    return InMemorySessionStore()
+
+
+def _make_redis_session() -> Optional[Any]:
+    try:
+        import redis
+    except ImportError:
+        return None
+    try:
+        client = redis.Redis(
+            host="localhost", port=6379, db=15, decode_responses=True
+        )
+        client.ping()
+        client.flushdb()
+    except Exception:
+        return None
+    from sulci.sessions import RedisSessionStore
+    return RedisSessionStore(client, key_prefix="sulci:conformance:session:")
+
+
+SESSION_STORE_FACTORIES: List[Tuple[str, Callable[[], Optional[Any]]]] = [
+    ("InMemorySessionStore", _make_in_memory_session),
+    ("RedisSessionStore",    _make_redis_session),
+]
+
+
+@pytest.fixture(params=SESSION_STORE_FACTORIES, ids=lambda f: f[0])
+def session_store(request):
+    """
+    Yields each registered SessionStore implementation in turn.
+    Skips parametrizations that can't be constructed locally.
+    """
+    name, factory = request.param
+    inst = factory()
+    if inst is None:
+        pytest.skip(f"{name}: not available locally")
+    yield inst
+    # Best-effort cleanup for stateful stores
+    try:
+        if hasattr(inst, "_redis"):
+            inst._redis.flushdb()
+    except Exception:
+        pass
+
+
+# -----------------------------------------------------------------------------
+# EventSink registry
+# -----------------------------------------------------------------------------
+
+def _make_null_sink() -> Optional[Any]:
+    from sulci.sinks import NullSink
+    return NullSink()
+
+
+def _make_telemetry_sink() -> Optional[Any]:
+    try:
+        import httpx  # noqa: F401
+    except ImportError:
+        return None
+    from sulci.sinks import TelemetrySink
+    # HTTPS-only dummy endpoint. The protocol spec requires emit/flush
+    # to never raise on network failure, so unreachable URLs are fine —
+    # the conformance suite explicitly tests this contract.
+    return TelemetrySink(
+        endpoint_url="https://127.0.0.1:1/sulci-conformance-test",
+        batch_size=1,
+        flush_interval=0.01,
+        timeout_seconds=0.1,
+    )
+
+
+def _make_redis_stream_sink() -> Optional[Any]:
+    try:
+        import redis
+    except ImportError:
+        return None
+    try:
+        client = redis.Redis(host="localhost", port=6379, db=15)
+        client.ping()
+    except Exception:
+        return None
+    from sulci.sinks import RedisStreamSink
+    return RedisStreamSink(
+        client, stream_key="sulci:conformance:events", max_length=1000,
+    )
+
+
+EVENT_SINK_FACTORIES: List[Tuple[str, Callable[[], Optional[Any]]]] = [
+    ("NullSink",        _make_null_sink),
+    ("TelemetrySink",   _make_telemetry_sink),
+    ("RedisStreamSink", _make_redis_stream_sink),
+]
+
+
+@pytest.fixture(params=EVENT_SINK_FACTORIES, ids=lambda f: f[0])
+def event_sink(request):
+    """
+    Yields each registered EventSink implementation in turn.
+    Skips parametrizations that can't be constructed locally.
+    """
+    name, factory = request.param
+    inst = factory()
+    if inst is None:
+        pytest.skip(f"{name}: not available locally")
+    yield inst

--- a/sulci/tests/compat/test_event_sink_conformance.py
+++ b/sulci/tests/compat/test_event_sink_conformance.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""Public conformance suite for EventSink implementations."""
+import pytest
+from sulci.sinks import CacheEvent, EventSink
+
+
+@pytest.fixture
+def sample_event():
+    return CacheEvent(
+        event_type="hit",
+        backend_id="test",
+        embedding_model="test",
+        similarity=0.9,
+        latency_ms=10,
+        timestamp=1_700_000_000.0,
+    )
+
+
+class TestEventSinkProtocol:
+    def test_conforms_to_protocol(self, event_sink):
+        assert isinstance(event_sink, EventSink)
+
+
+class TestEmit:
+    def test_emit_accepts_cache_event(self, event_sink, sample_event):
+        event_sink.emit(sample_event)   # Must not raise
+
+    def test_emit_handles_minimal_event(self, event_sink):
+        event_sink.emit(CacheEvent(event_type="miss"))
+
+    def test_emit_handles_various_event_types(self, event_sink):
+        for et in ("hit", "miss", "set", "clear"):
+            event_sink.emit(CacheEvent(event_type=et))
+
+
+class TestFlush:
+    def test_flush_does_not_raise(self, event_sink):
+        event_sink.flush()
+
+    def test_flush_after_emit(self, event_sink, sample_event):
+        event_sink.emit(sample_event)
+        event_sink.flush()
+
+
+class TestNeverRaises:
+    """Critical invariant: cache operations must never fail due to sink errors."""
+
+    def test_emit_does_not_raise_on_normal_input(self, event_sink, sample_event):
+        try:
+            event_sink.emit(sample_event)
+        except Exception as e:
+            pytest.fail(f"emit() raised {e!r}; sinks must never raise from emit()")

--- a/sulci/tests/compat/test_session_store_conformance.py
+++ b/sulci/tests/compat/test_session_store_conformance.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""Public conformance suite for SessionStore implementations."""
+import pytest
+from sulci.sessions import SessionStore
+
+
+@pytest.fixture
+def session_store(request):
+    pytest.skip(
+        "Override `session_store` fixture in your conftest.py. "
+        "Must yield a fresh SessionStore instance."
+    )
+
+
+class TestSessionStoreProtocol:
+    def test_conforms_to_protocol(self, session_store):
+        assert isinstance(session_store, SessionStore)
+
+
+class TestBasicOperations:
+    def test_empty_session_returns_empty_list(self, session_store):
+        assert session_store.get("new-session") == []
+
+    def test_append_then_get(self, session_store):
+        session_store.append("s1", [0.1, 0.2, 0.3])
+        result = session_store.get("s1")
+        assert len(result) == 1
+
+    def test_multiple_appends_return_all(self, session_store):
+        for i in range(5):
+            session_store.append("s1", [float(i)])
+        assert len(session_store.get("s1")) == 5
+
+    def test_max_turns_limits_history(self, session_store):
+        for i in range(10):
+            session_store.append("s1", [float(i)], max_turns=3)
+        assert len(session_store.get("s1")) == 3
+
+    def test_sessions_are_isolated(self, session_store):
+        session_store.append("a", [1.0])
+        session_store.append("b", [2.0])
+        assert len(session_store.get("a")) == 1
+        assert len(session_store.get("b")) == 1
+
+    def test_clear_removes_session(self, session_store):
+        session_store.append("s1", [1.0])
+        session_store.clear("s1")
+        assert session_store.get("s1") == []
+
+    def test_clear_nonexistent_is_idempotent(self, session_store):
+        session_store.clear("never-existed")   # Must not raise
+
+
+class TestSummary:
+    def test_summary_empty_store(self, session_store):
+        s = session_store.summary()
+        assert s["sessions"] == 0
+        assert s["total_turns"] == 0
+
+    def test_summary_counts_sessions(self, session_store):
+        session_store.append("a", [1.0])
+        session_store.append("b", [2.0])
+        s = session_store.summary()
+        assert s["sessions"] == 2
+
+    def test_scoped_summary(self, session_store):
+        session_store.append("a", [1.0])
+        session_store.append("a", [2.0])
+        s = session_store.summary(session_id="a")
+        assert s["total_turns"] == 2

--- a/sulci/tests/compat/test_session_store_conformance.py
+++ b/sulci/tests/compat/test_session_store_conformance.py
@@ -5,14 +5,6 @@ import pytest
 from sulci.sessions import SessionStore
 
 
-@pytest.fixture
-def session_store(request):
-    pytest.skip(
-        "Override `session_store` fixture in your conftest.py. "
-        "Must yield a fresh SessionStore instance."
-    )
-
-
 class TestSessionStoreProtocol:
     def test_conforms_to_protocol(self, session_store):
         assert isinstance(session_store, SessionStore)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -92,6 +92,9 @@ def _run_backend_contract(backend):
     result, _ = backend.search(vec, threshold=0.85, user_id="bob")
     assert result is None
 
+    # 6. Final cleanup — leave no entries behind for shared backends like Redis
+    backend.clear()
+
 
 # ── SQLite ────────────────────────────────────────────────────
 

--- a/tests/test_session_store_injection.py
+++ b/tests/test_session_store_injection.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+tests/test_session_store_injection.py — v0.5.0 Cache(session_store=, event_sink=) tests.
+
+Verifies the B1 adapter contract from ADR 0007:
+  - Default Cache (no session_store kwarg) uses _BuiltinSessionStore — unchanged from v0.4.x
+  - Cache(session_store=InMemorySessionStore()) wraps via _ProtocolAdaptedSessionStore
+  - Returned ContextWindow's user-vector add_turn() round-trips to inner store
+  - EventSink fires on hit/miss/set with the documented field allowlist
+"""
+from unittest.mock import MagicMock
+
+from sulci import Cache
+from sulci.context import SessionStore as LegacySessionStore
+from sulci.sessions import InMemorySessionStore
+from sulci.sinks import CacheEvent, NullSink
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Constructor accepts new kwargs without breaking v0.4.x calls
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestConstructorAcceptsNewKwargs:
+    def test_v04_call_still_works_unchanged(self, tmp_path):
+        """Cache(...) with no session_store/event_sink kwargs preserves v0.4.x behavior."""
+        c = Cache(backend="sqlite", db_path=str(tmp_path), context_window=4)
+        # Internal session manager is the legacy class
+        assert isinstance(c._sessions, LegacySessionStore)
+        # No event sink injected → NullSink default
+        assert isinstance(c._event_sink, NullSink)
+
+    def test_session_store_kwarg_accepted(self, tmp_path):
+        """Cache(session_store=...) accepts any sulci.sessions.SessionStore impl."""
+        store = InMemorySessionStore()
+        c = Cache(
+            backend="sqlite", db_path=str(tmp_path),
+            context_window=4, session_store=store,
+        )
+        # Internal manager is the adapter, not the legacy class
+        assert not isinstance(c._sessions, LegacySessionStore)
+        assert c._sessions._inner is store
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Default path is byte-for-byte unchanged from v0.4.x
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestDefaultPathUnchanged:
+    def test_default_session_store_is_legacy_class(self, tmp_path):
+        """When session_store=None and context_window>0, use _BuiltinSessionStore."""
+        c = Cache(backend="sqlite", db_path=str(tmp_path), context_window=4)
+        assert isinstance(c._sessions, LegacySessionStore)
+
+    def test_no_context_window_means_no_session_store(self, tmp_path):
+        """context_window=0 → _sessions is None (stateless cache)."""
+        c = Cache(backend="sqlite", db_path=str(tmp_path), context_window=0)
+        assert c._sessions is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Injected SessionStore: round-trip through the adapter
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestInjectedSessionStoreRoundTrip:
+    def test_set_pushes_user_vector_to_inner_store(self, tmp_path):
+        """cache.set(session_id=...) triggers inner.append() via the adapter wrapper."""
+        store = InMemorySessionStore()
+        c = Cache(
+            backend="sqlite", db_path=str(tmp_path),
+            context_window=4, session_store=store,
+        )
+        c.set("hello there", "hi back", session_id="user-1")
+        # Inner store now has one user-query vector for this session
+        history = store.get("user-1")
+        assert len(history) == 1
+        assert all(isinstance(v, float) for v in history[0])  # vector of floats
+
+    def test_get_rebuilds_window_from_inner(self, tmp_path):
+        """cache.get(session_id=...) returns a window seeded from inner.get()."""
+        store = InMemorySessionStore()
+        # Pre-seed inner directly
+        store.append("user-2", [0.1] * 384)
+        store.append("user-2", [0.2] * 384)
+        c = Cache(
+            backend="sqlite", db_path=str(tmp_path),
+            context_window=4, session_store=store,
+        )
+        # Adapter rebuilds window with depth=2 from inner's two vectors
+        window = c._sessions.get("user-2")
+        assert window.depth == 2
+
+    def test_clear_context_clears_inner(self, tmp_path):
+        """cache.clear_context(sid) propagates to inner.clear(sid)."""
+        store = InMemorySessionStore()
+        store.append("user-3", [0.1] * 384)
+        c = Cache(
+            backend="sqlite", db_path=str(tmp_path),
+            context_window=4, session_store=store,
+        )
+        c.clear_context("user-3")
+        assert store.get("user-3") == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# EventSink wiring
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestEventSink:
+    def test_default_event_sink_is_null(self, tmp_path):
+        c = Cache(backend="sqlite", db_path=str(tmp_path))
+        assert isinstance(c._event_sink, NullSink)
+
+    def test_emits_on_miss(self, tmp_path):
+        sink = MagicMock()
+        c = Cache(backend="sqlite", db_path=str(tmp_path), event_sink=sink)
+        c.get("nothing in cache yet")
+        # Sink received exactly one CacheEvent with event_type='miss'
+        assert sink.emit.call_count == 1
+        evt = sink.emit.call_args[0][0]
+        assert isinstance(evt, CacheEvent)
+        assert evt.event_type == "miss"
+        assert evt.backend_id == "sqlite"
+
+    def test_emits_on_hit(self, tmp_path):
+        sink = MagicMock()
+        c = Cache(backend="sqlite", db_path=str(tmp_path), event_sink=sink)
+        c.set("hello world", "greeting response")
+        # set + get = two emit calls; second one should be event_type='hit'
+        c.get("hello world")
+        assert sink.emit.call_count >= 2
+        last_evt = sink.emit.call_args_list[-1][0][0]
+        assert last_evt.event_type == "hit"
+        assert last_evt.similarity is not None
+
+    def test_emits_on_set(self, tmp_path):
+        sink = MagicMock()
+        c = Cache(backend="sqlite", db_path=str(tmp_path), event_sink=sink)
+        c.set("query x", "response y", tenant_id="acme")
+        # First emit is the set event
+        first_evt = sink.emit.call_args_list[0][0][0]
+        assert first_evt.event_type == "set"
+        assert first_evt.tenant_id == "acme"
+
+    def test_sink_failure_does_not_break_cache(self, tmp_path):
+        """Per protocol, EventSink failures must never propagate to Cache caller."""
+        bad_sink = MagicMock()
+        bad_sink.emit.side_effect = RuntimeError("sink exploded")
+        c = Cache(backend="sqlite", db_path=str(tmp_path), event_sink=bad_sink)
+        # Must not raise even though the sink raises on every emit
+        c.set("query", "response")
+        result, sim, depth = c.get("query")
+        assert result == "response"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""tests/test_sessions.py — v0.5.0 session store tests."""
+import pytest
+from sulci.sessions import InMemorySessionStore, RedisSessionStore, SessionStore
+
+
+@pytest.fixture
+def sample_vec():
+    return [0.1, 0.2, 0.3, 0.4]
+
+
+class TestInMemorySessionStoreBasics:
+    def test_empty_session_returns_empty_list(self):
+        store = InMemorySessionStore()
+        assert store.get("nonexistent") == []
+
+    def test_append_and_get(self, sample_vec):
+        store = InMemorySessionStore()
+        store.append("s1", sample_vec)
+        assert store.get("s1") == [sample_vec]
+
+    def test_multiple_appends_preserve_order(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        store.append("s1", [2.0])
+        store.append("s1", [3.0])
+        assert store.get("s1") == [[1.0], [2.0], [3.0]]
+
+    def test_max_turns_trims_oldest(self):
+        store = InMemorySessionStore()
+        for i in range(10):
+            store.append("s1", [float(i)], max_turns=3)
+        history = store.get("s1")
+        assert len(history) == 3
+        assert history == [[7.0], [8.0], [9.0]]
+
+    def test_clear_removes_session(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        store.clear("s1")
+        assert store.get("s1") == []
+
+    def test_clear_nonexistent_is_idempotent(self):
+        store = InMemorySessionStore()
+        store.clear("nonexistent")   # Should not raise
+
+    def test_session_isolation(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        store.append("s2", [2.0])
+        assert store.get("s1") == [[1.0]]
+        assert store.get("s2") == [[2.0]]
+
+
+class TestInMemorySummary:
+    def test_global_summary_empty(self):
+        store = InMemorySessionStore()
+        s = store.summary()
+        assert s["sessions"] == 0
+        assert s["total_turns"] == 0
+        assert s["avg_turns"] == 0.0
+
+    def test_global_summary_with_data(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        store.append("s1", [2.0])
+        store.append("s2", [3.0])
+        s = store.summary()
+        assert s["sessions"] == 2
+        assert s["total_turns"] == 3
+        assert s["avg_turns"] == 1.5
+
+    def test_scoped_summary(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        store.append("s1", [2.0])
+        s = store.summary(session_id="s1")
+        assert s["sessions"] == 1
+        assert s["total_turns"] == 2
+
+
+class TestMaxTotalSessionsEviction:
+    def test_evicts_oldest_session_when_limit_exceeded(self):
+        store = InMemorySessionStore(max_total_sessions=2)
+        store.append("s1", [1.0])
+        store.append("s2", [2.0])
+        store.append("s3", [3.0])   # Should evict s1
+        assert store.get("s1") == []
+        assert store.get("s2") == [[2.0]]
+        assert store.get("s3") == [[3.0]]
+
+
+class TestProtocolConformance:
+    def test_in_memory_conforms_to_protocol(self):
+        assert isinstance(InMemorySessionStore(), SessionStore)
+
+
+class TestBackwardCompatShim:
+    def test_sulci_context_SessionStore_still_importable(self):
+        """v0.3.x code: `from sulci.context import SessionStore` must still work."""
+        from sulci.context import SessionStore as ContextSessionStore
+        from sulci.sessions import InMemorySessionStore
+
+        # The shim re-exports InMemorySessionStore as SessionStore
+        store = ContextSessionStore()
+        assert isinstance(store, InMemorySessionStore)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# RedisSessionStore tests — require Redis; skipped if unavailable
+# ═══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def redis_client():
+    try:
+        import redis
+        client = redis.Redis(host="localhost", port=6379, db=15, decode_responses=True)
+        client.ping()
+        client.flushdb()
+        yield client
+        client.flushdb()
+    except (ImportError, Exception):
+        pytest.skip("Redis not available at localhost:6379 db=15")
+
+
+class TestRedisSessionStore:
+    def test_empty_session_returns_empty_list(self, redis_client):
+        store = RedisSessionStore(redis_client)
+        assert store.get("nonexistent") == []
+
+    def test_append_and_get(self, redis_client, sample_vec):
+        store = RedisSessionStore(redis_client)
+        store.append("s1", sample_vec)
+        result = store.get("s1")
+        assert len(result) == 1
+        assert result[0] == sample_vec
+
+    def test_order_preserved_across_appends(self, redis_client):
+        store = RedisSessionStore(redis_client)
+        store.append("s1", [1.0])
+        store.append("s1", [2.0])
+        store.append("s1", [3.0])
+        assert store.get("s1") == [[1.0], [2.0], [3.0]]
+
+    def test_max_turns_enforced(self, redis_client):
+        store = RedisSessionStore(redis_client)
+        for i in range(10):
+            store.append("s1", [float(i)], max_turns=3)
+        history = store.get("s1")
+        assert len(history) == 3
+        assert history == [[7.0], [8.0], [9.0]]
+
+    def test_clear_removes_key(self, redis_client):
+        store = RedisSessionStore(redis_client)
+        store.append("s1", [1.0])
+        store.clear("s1")
+        assert store.get("s1") == []
+
+    def test_ttl_applied_when_configured(self, redis_client):
+        store = RedisSessionStore(redis_client, ttl_seconds=60)
+        store.append("s1", [1.0])
+        ttl = redis_client.ttl(store._key("s1"))
+        assert 0 < ttl <= 60
+
+    def test_protocol_conformance(self, redis_client):
+        store = RedisSessionStore(redis_client)
+        assert isinstance(store, SessionStore)
+
+    def test_cross_instance_visibility(self, redis_client):
+        """Core multi-replica guarantee: two RedisSessionStore instances
+        pointing at the same Redis see each other's data."""
+        store_a = RedisSessionStore(redis_client)
+        store_b = RedisSessionStore(redis_client)
+        store_a.append("s1", [1.0])
+        assert store_b.get("s1") == [[1.0]]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -99,12 +99,13 @@ class TestProtocolConformance:
 class TestBackwardCompatShim:
     def test_sulci_context_SessionStore_still_importable(self):
         """v0.3.x code: `from sulci.context import SessionStore` must still work."""
-        from sulci.context import SessionStore as ContextSessionStore
-        from sulci.sessions import InMemorySessionStore
-
-        # The shim re-exports InMemorySessionStore as SessionStore
-        store = ContextSessionStore()
-        assert isinstance(store, InMemorySessionStore)
+        from sulci.context import SessionStore
+        # Import path preserved; class identity is intentionally NOT asserted
+        # because the new sulci.sessions module is additive, not a replacement.
+        store = SessionStore()
+        # The old class API is preserved
+        assert hasattr(store, "get")
+        assert hasattr(store, "delete")
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -174,3 +175,27 @@ class TestRedisSessionStore:
         store_b = RedisSessionStore(redis_client)
         store_a.append("s1", [1.0])
         assert store_b.get("s1") == [[1.0]]
+
+class TestTenantIsolation:
+    def test_in_memory_tenants_do_not_share_history(self):
+        a = InMemorySessionStore(tenant_id="tenant-A")
+        b = InMemorySessionStore(tenant_id="tenant-B")
+        a.append("user_42", [1.0, 2.0])
+        b.append("user_42", [9.0, 8.0])
+        assert a.get("user_42") == [[1.0, 2.0]]
+        assert b.get("user_42") == [[9.0, 8.0]]
+
+    def test_in_memory_default_tenant_none_unchanged(self):
+        store = InMemorySessionStore()
+        store.append("s1", [1.0])
+        assert store.get("s1") == [[1.0]]
+
+    def test_in_memory_summary_scoped_to_tenant(self):
+        a = InMemorySessionStore(tenant_id="tenant-A")
+        b = InMemorySessionStore(tenant_id="tenant-B")
+        a.append("s1", [1.0])
+        a.append("s2", [2.0])
+        b.append("s1", [9.0])
+        assert a.summary()["sessions"] == 2
+        assert b.summary()["sessions"] == 1
+        

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+tests/test_sinks.py — v0.5.0 event sink tests.
+
+Includes critical privacy tests: verifies TelemetrySink and RedisStreamSink
+NEVER leak query text, response text, or embedding vectors.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from sulci.sinks import CacheEvent, EventSink, NullSink, TelemetrySink, RedisStreamSink
+from sulci.sinks.telemetry import _ALLOWED_FIELDS, _scrub
+
+
+@pytest.fixture
+def sample_event():
+    return CacheEvent(
+        event_type="hit",
+        tenant_id=42,
+        user_id="alice",
+        session_id="sess-123",
+        backend_id="qdrant",
+        embedding_model="minilm",
+        similarity=0.92,
+        latency_ms=15,
+        context_depth=2,
+        timestamp=1_700_000_000.0,
+        metadata={"custom": "data"},
+    )
+
+
+class TestAllowlist:
+    """The privacy firewall. These tests MUST stay green forever."""
+
+    def test_allowlist_contents_are_stable(self):
+        """Explicit pin of allowlist contents. Any change is a privacy review."""
+        assert _ALLOWED_FIELDS == frozenset([
+            "event_type", "tenant_id", "user_id", "session_id",
+            "backend_id", "embedding_model", "similarity", "latency_ms",
+            "context_depth", "timestamp",
+        ])
+
+    def test_metadata_dict_is_not_in_allowlist(self):
+        """The metadata dict has arbitrary user content; must NEVER be shipped."""
+        assert "metadata" not in _ALLOWED_FIELDS
+
+    def test_scrub_excludes_metadata(self, sample_event):
+        scrubbed = _scrub(sample_event)
+        assert "metadata" not in scrubbed
+
+    def test_scrub_preserves_allowlist_fields(self, sample_event):
+        scrubbed = _scrub(sample_event)
+        for field_name in _ALLOWED_FIELDS:
+            assert field_name in scrubbed
+
+    def test_scrub_excludes_any_added_attrs(self):
+        """If a caller sneaks extra attrs onto the event, they must NOT ship."""
+        event = CacheEvent(event_type="hit")
+        # Attempt to inject — this is not supported via dataclass but tests
+        # that our scrubber only emits allowlisted fields regardless.
+        scrubbed = _scrub(event)
+        allowed = set(_ALLOWED_FIELDS)
+        assert set(scrubbed.keys()) <= allowed
+
+
+class TestNullSink:
+    def test_emit_is_noop(self, sample_event):
+        sink = NullSink()
+        sink.emit(sample_event)   # Should not raise
+
+    def test_flush_is_noop(self):
+        NullSink().flush()
+
+    def test_conforms_to_protocol(self):
+        assert isinstance(NullSink(), EventSink)
+
+
+class TestTelemetrySinkValidation:
+    def test_https_required(self):
+        with pytest.raises(ValueError, match="HTTPS"):
+            TelemetrySink(endpoint_url="http://insecure.example.com/events")
+
+    def test_https_accepted(self):
+        sink = TelemetrySink(endpoint_url="https://secure.example.com/events")
+        assert sink is not None
+
+
+class TestTelemetrySinkBatching:
+    def test_does_not_flush_below_batch_size(self, sample_event):
+        with patch("httpx.post") as mock_post:
+            sink = TelemetrySink(
+                endpoint_url="https://example.com/events",
+                batch_size=10,
+                flush_interval=999_999.0,  # Don't time-based flush in test
+            )
+            for _ in range(5):
+                sink.emit(sample_event)
+            assert not mock_post.called
+
+    def test_flushes_when_batch_full(self, sample_event):
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            sink = TelemetrySink(
+                endpoint_url="https://example.com/events",
+                batch_size=3,
+                flush_interval=999_999.0,
+            )
+            for _ in range(3):
+                sink.emit(sample_event)
+            assert mock_post.called
+
+    def test_flush_sends_scrubbed_events(self, sample_event):
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            sink = TelemetrySink(
+                endpoint_url="https://example.com/events",
+                batch_size=1, flush_interval=999_999.0,
+            )
+            sink.emit(sample_event)
+
+            assert mock_post.called
+            sent_body = mock_post.call_args.kwargs["content"]
+
+            # The payload must NOT contain the metadata field
+            assert '"metadata"' not in sent_body
+
+            # The payload MUST contain core allowlisted fields
+            assert '"event_type"' in sent_body
+            assert '"similarity"' in sent_body
+
+    def test_network_error_does_not_raise(self, sample_event):
+        with patch("httpx.post", side_effect=Exception("network down")):
+            sink = TelemetrySink(
+                endpoint_url="https://example.com/events",
+                batch_size=1, flush_interval=999_999.0,
+            )
+            sink.emit(sample_event)   # Must not raise
+            sink.flush()               # Must not raise
+
+
+class TestTelemetrySinkConformance:
+    def test_conforms_to_protocol(self):
+        sink = TelemetrySink(endpoint_url="https://example.com/events")
+        assert isinstance(sink, EventSink)
+
+
+class TestRedisStreamSink:
+    def test_emits_to_stream(self, sample_event):
+        mock_redis = MagicMock()
+        sink = RedisStreamSink(mock_redis, stream_key="test:events")
+        sink.emit(sample_event)
+        assert mock_redis.xadd.called
+
+        # Verify scrubbed contents
+        call_args = mock_redis.xadd.call_args
+        entry = call_args[0][1]
+        assert "metadata" not in entry   # privacy allowlist applied
+        assert entry["event_type"] == "hit"
+
+    def test_network_error_does_not_raise(self, sample_event):
+        mock_redis = MagicMock()
+        mock_redis.xadd.side_effect = Exception("redis down")
+
+        sink = RedisStreamSink(mock_redis)
+        sink.emit(sample_event)   # Must not raise
+
+    def test_conforms_to_protocol(self):
+        mock_redis = MagicMock()
+        sink = RedisStreamSink(mock_redis)
+        assert isinstance(sink, EventSink)


### PR DESCRIPTION
Implements bundle v1.1 Phase 2 (Workstream B). Adds two new public protocols (`SessionStore`, `EventSink`) as additive injection points on `Cache`, plus the `_ProtocolAdaptedSessionStore` bridge that lets injected stores work alongside the legacy `sulci.context.SessionStore` without breakage.

Fully backward-compatible. v0.4.x code runs unchanged.

### What ships in v0.5.0

**New public surface**

- `sulci.sessions` package
  - `SessionStore` — public stable protocol (per ADR 0004)
  - `InMemorySessionStore` — process-local default
  - `RedisSessionStore` — Redis-Lists-backed for horizontal scaling
- `sulci.sinks` package
  - `EventSink` — public stable protocol (per ADR 0004)
  - `CacheEvent` — event dataclass with strict field allowlist
  - `NullSink` — default no-op
  - `TelemetrySink` — HTTPS POST with privacy-firewall scrubbing
  - `RedisStreamSink` — writes scrubbed events to Redis Streams
- `Cache(session_store=..., event_sink=...)` — additive constructor kwargs. Default `None` for both; preserves exact v0.4.x behavior.
- `SyncCache` — alias for `Cache` (naming symmetry with `AsyncCache`)
- Conformance suites for both new protocols, parametrized over all bundled implementations via `sulci/tests/compat/conftest.py`

**Tenant scoping at the session layer**

`InMemorySessionStore` and `RedisSessionStore` accept a `tenant_id=` kwarg. Default `None` preserves single-tenant behavior. When set, two tenants using the same `session_id` no longer share context vectors. Closes FU-1 Scenario B at the session layer; mirrors the v0.4.0 `QdrantBackend(tenant_id=...)` precedent.

**Privacy firewall**

`TelemetrySink` and `RedisStreamSink` enforce a closed-by-default field allowlist (`_ALLOWED_FIELDS` frozenset). The `CacheEvent.metadata` dict is never shipped externally. Query text, response text, and embedding vectors never leave the process via shipped sinks.

**B1 adapter (ADR 0007 deviation from bundle)**

The bundle's original `context.py.patch.md` and `core.py.patch.md` were mutually inconsistent. This PR keeps the legacy `sulci.context.SessionStore` class intact and adds a new internal `_ProtocolAdaptedSessionStore` class that bridges the two protocols when `Cache(session_store=...)` is injected. See ADR 0007 for the full rationale (already merged in `sulci-io/sulci-platform`).

### Compatibility

- 293 existing tests pass + ~95 new tests (sessions, sinks, conformance, injection — see breakdown below).
- `from sulci.context import SessionStore` still returns the legacy class.
- `from sulci import SessionStore` still returns the legacy class (top-level export unchanged for direct importers).
- The new `sulci.sessions.SessionStore` protocol lives at its namespaced path only; new code uses `from sulci.sessions import SessionStore`.
- `AsyncCache` behavior unchanged — wraps `Cache` via `asyncio.to_thread`, kwargs propagate automatically.

### Local verification

`make checkin` is fully green:

- Smoke tests (core, LangChain, LlamaIndex, Async): all PASS
- Per-file pytest runner: 293 passed, 0 failed, 0 errors, 34 skipped (skips are missing-optional-deps: chromadb, faiss-cpu, pymilvus, OpenAI key)
- Examples: 12/12 PASS
- Benchmark: 0 regressions vs `pre-v040-baseline` (commit 35a0c86) — all metrics within tolerance, including the +20.8pp context-aware resolution accuracy that's the v0.2.x marketing headline

The full Redis path is exercised locally via Docker. CI exercises it natively on Linux runners (apt-installed `redis-server` per the updated `tests.yml`).

### Commits in this PR

```
1bd9dc9  Bump version to 0.5.0
7830656  test: clean up _run_backend_contract for shared-state backends
479779e  Phase 2: implement B1 adapter for injected SessionStore + EventSink wiring
d4c05a4  Phase 2: tenant-scope SessionStore + close conformance coverage gap
c717f1e  Phase 2: import sessions + sinks drop-ins from ground-up-v1.1
```

### Test breakdown

New tests added across the branch:

- `tests/test_sessions.py` — InMemorySessionStore + RedisSessionStore basics, eviction, summary, tenant isolation, backward-compat shim (24 tests)
- `tests/test_sinks.py` — allowlist enforcement, NullSink, TelemetrySink validation/batching, RedisStreamSink (15 tests)
- `tests/test_session_store_injection.py` — Cache(session_store=, event_sink=) injection contract; sink-failure-must-not-propagate (12 tests)
- `sulci/tests/compat/test_session_store_conformance.py` — protocol conformance × InMemory + Redis (parametrized; 20 tests)
- `sulci/tests/compat/test_event_sink_conformance.py` — protocol conformance × Null + Telemetry + RedisStream (parametrized; 21 tests)
- `sulci/tests/compat/conftest.py` — fixture infrastructure that parametrizes the conformance suites over bundled implementations while preserving the override path for external implementers

### Pre-existing bug fixed in this PR

`tests/test_backends.py::_run_backend_contract` was leaking entries into shared-daemon backends (Redis specifically). Per-test isolation worked for SQLite (fresh tmp_path) and Qdrant (fresh collection) but not Redis. The leak surfaced as flaky failures in `make checkin` (which runs the per-file runner against a single Redis daemon) but never in GitHub Actions CI (which provisions a fresh Redis service per job).

Fix: 1-line `backend.clear()` at the end of `_run_backend_contract`. Pre-existing bug on `main`; surfaced consistently while validating the v0.5.0 release locally. Folded into this PR rather than a separate one because (a) it's a 1-line fix, (b) leaving `make checkin` known-broken across the v0.5.0 release would degrade the local verification signal for any post-publish hygiene check.

### CI matrix

`.github/workflows/tests.yml` was updated earlier in the branch:

- Matrix: ubuntu-latest × macos-latest × windows-latest × Python 3.9/3.11/3.12 (9 jobs)
- Linux jobs install `redis-server` via apt and exercise full Redis path
- macOS/Windows skip Redis-dependent tests via fixture's graceful fallback (no service container support on those runners)
- Two new test files (`test_sessions.py`, `test_sinks.py`) wired in as explicit pytest invocations
- Conformance step broadened to include `sulci/tests/compat/`

### Related

- ADR 0004 — SessionStore and EventSink protocols (merged on sulci-platform `main`)
- ADR 0007 — Preserve the legacy `sulci.context.SessionStore` class (merged on sulci-platform `main`)
- Bundle: `ground-up-v1.1` Phase 2 / Workstream B

### Reviewer focus

Suggested review order for the largest commit (`479779e`):

1. `sulci/core.py` `_ProtocolAdaptedSessionStore` class (~70 lines) — the bridge between the two protocols. Most of the design choices here are captured in ADR 0007's "Implementation reference" section.
2. `sulci/core.py` `Cache.__init__` — three-branch session-store wiring, event-sink default = NullSink.
3. `sulci/core.py` `Cache.get/set/clear` — CacheEvent emit calls, all wrapped in `try/except` per the EventSink "must not raise" contract.
4. `sulci/__init__.py` — note the deliberate deviation from the bundle's `__init__.py.patch.md` Change 3 (top-level `sulci.SessionStore` continues to be the legacy class, not the new protocol). Reasoning in the commit message and ADR 0007.
5. `tests/test_session_store_injection.py` — locks in the injection contract; especially the sink-failure-isolation test.

### Out of scope

The following land in v0.5.x follow-ups, not this PR:

- Per-user stats gating via the `personalized` flag (FU-14 Option C) — needs cross-team alignment (product/sales/engineering) before committing publicly.
- Test-hygiene improvements beyond the 1-line fix above (e.g., `backend_instance` fixture should clear-on-setup not just teardown; conformance fixtures should namespace test runs to prevent cross-project Redis interference).
- Adaptive per-prompt thresholds (FU-4) — Phase 3 platform-tier work.