### PR TITLE
v0.5.1 — Test hygiene and CI alignment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.1] — 2026-04-28
+
+### Added
+
+- `RedisBackend(key_prefix=...)` constructor kwarg.
+  - Defaults to `"sulci:"` (matches v0.4.x behavior — no breaking change for existing callers).
+  - Replaces three previously-hardcoded `"sulci:*"` literals in `_key()`, the SCAN match pattern in `search()`, and the keys-glob in `clear()`.
+  - Production callers can now pick a custom prefix to coexist with other Redis-using processes on a shared daemon (e.g., `RedisBackend(key_prefix="acme:cache:")`).
+
+### Changed
+
+- **CI matrix** — Python 3.10 now tested in `tests.yml` and `publish.yml`. Previously: `[3.9, 3.11, 3.12]`. Now: `[3.9, 3.10, 3.11, 3.12]`. Aligns CI coverage with `pyproject.toml` classifiers (which already claimed 3.10 support).
+- `LOCAL_SETUP.md` Python-version hint reflects the new matrix.
+
+### Fixed
+
+- **Test fixtures (`backend_instance` in `tests/compat/conftest.py`)**: now clear state on setup, not just teardown. Defends against state leaked by any test that crashed before reaching teardown. SQLite/Qdrant fixtures get fresh `tmp_path`/collection per call so the setup clear is a no-op for them; matters for Redis where the daemon is shared across tests.
+- **Test fixtures (`event_sink` in `sulci/tests/compat/conftest.py`)**: `RedisStreamSink` writes to a persistent Redis stream key that the fixture had no teardown for. Two changes: factory now `DEL`s the test stream key on construction; fixture now has a teardown that `DEL`s the stream when the implementation has a Redis client.
+- **Redis test namespacing**: All Redis-backed tests now use a session-scoped key prefix (`sulci:test:<8-char-uuid>:`) instead of the production-default `sulci:`. Tests SCAN/MATCH only their own session's keys; sulci-platform's runtime data on the same Redis daemon is now safe during `make checkin` execution. Two concurrent `make checkin` runs against the same Redis no longer interfere.
+
+### Verified
+
+`make checkin` runs cleanly with sulci-platform Docker Compose stack active. No platform state corruption; no test-result corruption from platform writes.
+
+### Compatibility
+
+- **Fully backward-compatible.** All v0.5.0 code continues to work unchanged.
+- The new `RedisBackend(key_prefix=...)` kwarg is purely additive; the default value matches v0.5.0 behavior. Honors the ADR 0005 protocol-stability commitment via additive-extension.
+- 390 existing tests pass; no test count change in v0.5.1 (no new test files, only fixture and CI infrastructure changes).
+
+### Closed issues
+
+- #28 — Fixture: clear-on-setup pattern for backend_instance
+- #29 — Namespace conformance test runs to prevent cross-project Redis interference
+- #30 — Decide on Python 3.10 in CI matrix (Option A — added to both matrices)
+
+### Phase 3 readiness
+
+All four v0.5.1 blockers needed for Phase 3 entry are now closed: three in this release plus sulci-platform#12 (Dependabot triage). See `sulci-platform/docs/roadmap/PHASE-3-WORKSTREAM-C.md` for the gating list.
+
+---
+
 ## [0.5.0] — 2026-04-27
 
 ### Added

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -40,7 +40,7 @@ source .venv/bin/activate
 
 # confirm you're inside the venv
 which python        # should show .venv/bin/python
-python --version    # should be 3.9, 3.11, or 3.12  (tested in CI; 3.10 likely works but isn't gated)
+python --version    # should be 3.9, 3.10, 3.11, or 3.12  (all four are tested in CI)
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.0"
+version = "0.5.1"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/backends/redis.py
+++ b/sulci/backends/redis.py
@@ -29,8 +29,9 @@ class RedisBackend:
 
     def __init__(
         self,
-        db_path: str = "./sulci_db",
-        url:     str = "redis://localhost:6379",
+        db_path:    str = "./sulci_db",
+        url:        str = "redis://localhost:6379",
+        key_prefix: str = "sulci:",
     ):
         try:
             import redis as redis_lib
@@ -39,10 +40,15 @@ class RedisBackend:
                 "redis not found.\n"
                 "Install with: pip install \"sulci[redis]\""
             )
-        self._redis = redis_lib.from_url(url, decode_responses=False)
+        self._redis  = redis_lib.from_url(url, decode_responses=False)
+        # Namespace prefix for all keys this instance writes/reads. Default
+        # "sulci:" matches v0.4.x behavior. Tests and multi-tenant deployments
+        # can pass a unique prefix (e.g. "sulci:test:abc12345:") to coexist
+        # on a shared Redis daemon without cross-instance interference.
+        self._prefix = key_prefix
 
     def _key(self, k: str) -> str:
-        return f"sulci:{k}"
+        return f"{self._prefix}{k}"
 
     def _pack(self, vec: list[float]) -> bytes:
         return struct.pack(f"{len(vec)}f", *vec)
@@ -88,7 +94,7 @@ class RedisBackend:
         best_resp = None
         cursor    = 0
         while True:
-            cursor, keys = self._redis.scan(cursor, match="sulci:*", count=200)
+            cursor, keys = self._redis.scan(cursor, match=f"{self._prefix}*", count=200)
             for rkey in keys:
                 try:
                     data = self._redis.hgetall(rkey)
@@ -112,6 +118,6 @@ class RedisBackend:
         return None, best_sim
 
     def clear(self) -> None:
-        keys = self._redis.keys("sulci:*")
+        keys = self._redis.keys(f"{self._prefix}*")
         if keys:
             self._redis.delete(*keys)

--- a/sulci/tests/compat/conftest.py
+++ b/sulci/tests/compat/conftest.py
@@ -110,6 +110,10 @@ def _make_redis_stream_sink() -> Optional[Any]:
     try:
         client = redis.Redis(host="localhost", port=6379, db=15)
         client.ping()
+        # Defensive setup clean — drop the test stream if a prior run
+        # left entries behind. Redis stream keys persist; without this,
+        # tests asserting "fresh stream behaviour" can see leftover state.
+        client.delete("sulci:conformance:events")
     except Exception:
         return None
     from sulci.sinks import RedisStreamSink
@@ -136,3 +140,10 @@ def event_sink(request):
     if inst is None:
         pytest.skip(f"{name}: not available locally")
     yield inst
+    # Best-effort cleanup for stateful sinks. NullSink and TelemetrySink
+    # are in-memory; only Redis-backed sinks leak state across tests.
+    try:
+        if hasattr(inst, "_redis"):
+            inst._redis.delete("sulci:conformance:events")
+    except Exception:
+        pass

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -176,6 +176,14 @@ def backend_instance(backend_class) -> Any:
     inst = _try_construct_backend(backend_class)
     if inst is None:
         pytest.skip(f"{backend_class.__name__}: no local construction available")
+    # Defensive setup clear — guards against state leaked by an earlier
+    # test that crashed before reaching teardown. SQLite/Qdrant get a
+    # fresh tmp_path/collection each fixture call, so this is mostly a
+    # no-op for them; matters for Redis where the daemon is shared.
+    try:
+        inst.clear()
+    except Exception:
+        pass
     yield inst
     # Best-effort cleanup
     try:

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -16,6 +16,18 @@ import tempfile
 from typing import Any, Optional, Type
 
 import pytest
+import uuid
+
+
+# -----------------------------------------------------------------------------
+# Per-pytest-session UUID prefix for Redis-backed test fixtures.
+# -----------------------------------------------------------------------------
+# Prevents cross-project Redis interference: tests namespace their keys
+# under "sulci:test:<run-id>:*" instead of plain "sulci:*", so they
+# never collide with sulci-platform's runtime services or other test
+# runs against the same Redis daemon. See sulci-io/sulci-oss#29.
+TEST_RUN_ID     = uuid.uuid4().hex[:8]
+TEST_KEY_PREFIX = f"sulci:test:{TEST_RUN_ID}:"
 
 
 # -----------------------------------------------------------------------------
@@ -105,7 +117,7 @@ def _try_construct_backend(cls: Type) -> Optional[Any]:
             return None
         # Requires a running redis-server on localhost. Probe and skip if absent.
         try:
-            instance = cls()
+            instance = cls(key_prefix=TEST_KEY_PREFIX)
             instance._redis.ping()  # connection check
             return instance
         except Exception:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,6 +9,12 @@ Run SQLite only:   pytest tests/test_backends.py -v -k sqlite
 Run Chroma only:   pytest tests/test_backends.py -v -k chroma
 """
 import pytest
+import uuid
+
+# Per-pytest-session UUID prefix for Redis-backed test fixtures. See
+# tests/compat/conftest.py and sulci-io/sulci-oss#29 for context.
+_TEST_RUN_ID     = uuid.uuid4().hex[:8]
+_TEST_KEY_PREFIX = f"sulci:test:{_TEST_RUN_ID}:"
 import sys, os, time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -203,7 +209,7 @@ class TestRedisBackend:
         """Requires local Redis on localhost:6379."""
         from sulci.backends.redis import RedisBackend
         try:
-            backend = RedisBackend(url="redis://localhost:6379")
+            backend = RedisBackend(url="redis://localhost:6379", key_prefix=_TEST_KEY_PREFIX)
             backend._redis.ping()
         except Exception:
             pytest.skip("No local Redis instance available")


### PR DESCRIPTION
Closes #28, #29, #30. Bundled into one release because all three are test-hygiene infrastructure under the same theme; CI runs once at the end.

## What ships

**CI matrix alignment (#30)**
Python 3.10 added to both `tests.yml` and `publish.yml` matrices, bringing CI in line with `pyproject.toml` classifiers (which already claimed 3.10 support). Previously: `[3.9, 3.11, 3.12]`. Now: `[3.9, 3.10, 3.11, 3.12]`. `LOCAL_SETUP.md` Python-version hint refreshed to match.

**Fixture clear-on-setup (#28)**
- `tests/compat/conftest.py` — `backend_instance` now clears state on setup before yield, in addition to existing teardown clear. Defends against state leaked by tests that crash before reaching teardown.
- `sulci/tests/compat/conftest.py` — `event_sink` now has a teardown that `DEL`s the test stream key when the impl has a Redis client. Factory `_make_redis_stream_sink()` now `DEL`s the stream key on construction too.
- `session_store` fixture in the same file already cleared defensively (verified during patch authoring; no change needed).

**Redis test namespacing (#29)**
- `sulci/backends/redis.py` — `RedisBackend.__init__` gains `key_prefix: str = "sulci:"` kwarg (additive, defaults match v0.5.0 behavior). Three previously-hardcoded `"sulci:*"` literals (`_key()`, SCAN match pattern, clear keys glob) replaced with `f"{self._prefix}*"`.
- `tests/compat/conftest.py` and `tests/test_backends.py` — module-scoped `TEST_RUN_ID = uuid.uuid4().hex[:8]` and `TEST_KEY_PREFIX = f"sulci:test:{TEST_RUN_ID}:"`. Passed to RedisBackend constructor in test fixtures.

After this lands, sulci-oss tests SCAN/MATCH only their own session's keys. sulci-platform's runtime data on the same Redis daemon is no longer corrupted by sulci-oss test execution.

## API stability

The new `RedisBackend(key_prefix=...)` kwarg is purely additive with v0.4.x default. Honors the ADR 0005 protocol-stability commitment via additive-extension. Existing callers don't change.

## Local verification

`make checkin` is fully green with the patch applied. Two specific scenarios from the issues' acceptance criteria explicitly tested:

**Issue #28 (clear-on-setup):**
```bash
# Pre-pollute Redis db=15 with leftover state
redis-cli -p 6379 -n 15 SET "sulci:test:leftover" "from-prior-run"
redis-cli -p 6379 -n 15 XADD "sulci:conformance:events" '*' leftover yes

# Run conformance suite
pytest tests/compat/ sulci/tests/compat/ -v
# Result: 114 passed, 29 skipped, 0 failed

# Confirm fixtures cleaned up the leftover state
redis-cli -p 6379 -n 15 KEYS '*'
# Result: (empty array)
```

**Issue #29 (cross-project isolation):**
```bash
# Pre-populate Redis with platform-shape keys (sulci:cache:*)
redis-cli -p 6379 SET "sulci:cache:platform-data-1" "should-survive"
redis-cli -p 6379 SET "sulci:cache:platform-data-2" "should-survive"

# Run full test suite
pytest tests/ sulci/tests/ -v --timeout=60
# Result: 390 passed, 34 skipped, 0 failed

# Confirm platform-shape keys survived (tests didn't touch them)
redis-cli -p 6379 GET "sulci:cache:platform-data-1"
# Result: "should-survive"

# Confirm test-shape keys cleaned up after themselves
redis-cli -p 6379 KEYS "sulci:test:*"
# Result: (empty array)
```

Both demonstrate the issues' behaviors are now fixed, not just claimed-fixed.

## Commits

```
55704cc  Bump version to 0.5.1
631c6c5  docs: add v0.5.1 CHANGELOG entry
dcf25f2  test+lib: namespace Redis tests with per-pytest-session UUID (closes #29)
c3b5c43  test: clear fixtures defensively on setup (closes #28)
44a13c8  ci: add Python 3.10 to test + publish matrices
```

## Reviewer focus

Smaller and more mechanical than #27. Two genuine review points:

1. **`sulci/backends/redis.py` `key_prefix` kwarg** — treat this as a public API addition. Default value preserves v0.5.0 behavior; the new optional parameter is additive. Verify the kwarg ordering doesn't break any tests that pass positional args (none should, but worth a glance).

2. **`TEST_KEY_PREFIX` scope** — module-scoped UUID generation runs once per pytest session, then every fixture call within that session gets the same prefix. Two concurrent `pytest` invocations against the same Redis daemon get different prefixes (different uuids per process). Verify this matches your mental model.

Test infrastructure changes (clear-on-setup, event_sink teardown) are mechanical.

## Phase 3 readiness

Three of the four v0.5.1 blockers close with this PR. The fourth (sulci-platform#12 — Dependabot triage) is a separate repo and a separate work item. Phase 3 entry conditions per `sulci-platform/docs/roadmap/PHASE-3-WORKSTREAM-C.md`:

- [x] sulci-oss#28 — Fixture clear-on-setup
- [x] sulci-oss#29 — Redis test namespacing
- [x] sulci-oss#30 — Python 3.10 in CI
- [ ] sulci-platform#12 — Dependabot triage

When all four close, Phase 3 begins per `sulci-platform/docs/runbooks/PHASE-3-RUNBOOK.md`.

## Out of scope for this PR

These remain in the v0.5.1 backlog but didn't make the cut:

- `examples/session_store_injection.py` (sulci-oss#31) — useful-to-have but not blocking.
- `personalized` flag repurposing per FU-14 Option C (sulci-oss#32) — strategic, needs cross-team alignment.

Both can land independently after this merges.