### PR TITLE
Wave 2 / D12: SDK device-code client (v0.5.3, latent → v0.6.0 once D7 ships)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,138 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.5.2] — 2026-05-03
+## [0.5.3] — 2026-05-04
+
+OSS-Connect device-code SDK client (D12). Ships **latent**: the code is in
+place, but the surrounding pieces of the OSS-Connect funnel — the gateway
+endpoints (sulci-platform `/v1/oss-connect/*`) and the dashboard
+`/oss-connect` page — may not yet be deployed in your environment.
+
+The default for the new `prompt` parameter is `False` for that reason.
+**Setting `prompt=True` against an environment that hasn't announced
+OSS-Connect availability is user error** — wait for the Sulci team's
+release announcement that the full chain is live (gateway + dashboard)
+before flipping it on. v0.6.0 will flip the default to `True` once the
+full chain ships end-to-end.
+
+### Added
+
+- **`sulci.oss_connect`** — RFC 8628 device-code flow client.
+  - `run_device_code_flow(gateway_base, sdk_version, client_name)` — blocks
+    until the user authorizes via browser, denies, or the 15-minute
+    device_code expires. Polls `/v1/oss-connect/token` at the gateway-
+    advertised interval. Honors RFC 8628 `slow_down` (interval += 5s).
+  - Lazy-imported from `sulci/__init__.py` only on the no-key-found path,
+    so `import sulci` cost is unchanged for users who never trigger it.
+  - Module is named `oss_connect` (not `connect`) to avoid shadowing the
+    public `sulci.connect()` function. See sulci-platform ADR 0014
+    §"Naming" for the full chronology of why the platform's URL prefix
+    moved from `cli` → `connect` → `oss-connect`.
+- **`sulci.connect(prompt=False)`** — new keyword parameter. When `True`,
+  if no api_key is found through args/env/config, runs the browser-based
+  device-code flow. Default is `False` in v0.5.3; will flip to `True`
+  in v0.6.0 once the full OSS-Connect chain ships end-to-end.
+- **Four-step api_key resolution** in `sulci.connect()`:
+  1. `api_key=` argument
+  2. `SULCI_API_KEY` environment variable
+  3. `~/.sulci/config` (persisted from a prior successful connect)
+  4. Browser device-code flow (only if `prompt=True`)
+  Step 3 is new in v0.5.3 — connect()'s previously documented
+  resolution stopped at step 2.
+- **`SULCI_GATEWAY` env var** — overrides the gateway base URL for the
+  device-code flow (default `https://api.sulci.io`). Used for staging /
+  local-dev environments. Resolved at module-import time so the same
+  value is used by both telemetry and the new device-code flow.
+
+### Changed
+
+- **`sulci.connect()` signature** gains the `prompt: bool = False`
+  parameter. Existing callers that pass `api_key=...` are unaffected.
+- **`tests/test_connect.py`** — three tests in the new `TestDeviceCodeFlow`
+  class that exercise the device-code-fires path now pass `prompt=True`
+  explicitly. `test_connect_without_key_does_not_enable_telemetry` and
+  `test_connect_does_not_start_thread_without_key` continue to call with
+  `prompt=False` to assert the no-op behavior.
+
+### Tests
+
+- **+27 new tests** across two files:
+  - `tests/test_oss_connect.py` (new) — 19 tests for the RFC 8628 client
+    (httpx mocked; deterministic; covers `slow_down`, denied, expired,
+    network-error retry, the `_safe_error_field` helper).
+  - `tests/test_connect.py::TestDeviceCodeFlow` — 8 new tests for the
+    integration in `connect()` (resolution order, persistence on success,
+    `prompt=False` escape hatch, RuntimeError propagation, persist-failure
+    non-blocking).
+- **Test-gate fix** — `scripts/run_tests_per_file.py::DEFAULT_FILES`
+  gains `tests/test_oss_connect.py` so `make checkin` covers the new
+  module. Without this addition, the 19 tests would exist but never run
+  in the gate (same shape of test-gate omission caught and fixed
+  upstream in sulci-platform PR #50). Per-file runner total goes from
+  312 to 331.
+
+### Compatibility
+
+- **Backward-compatible against v0.5.2.** Existing `sulci.connect(api_key=...)`,
+  `sulci.connect()` with `SULCI_API_KEY` set, and `sulci.connect(telemetry=False)`
+  all preserve their v0.5.2 semantics.
+- **The new step 3 (`~/.sulci/config` resolution) is observable only when
+  the user has previously called `sulci.connect()` and `~/.sulci/config`
+  contains an `api_key` field.** v0.5.2 didn't write this field.
+  Pre-existing v0.5.2 configs (which only have `machine_id`) read as
+  step 3 returning `None`, identical to no config existing.
+
+### Privacy
+
+- **No new wire fields.** The device-code flow is a `POST` to
+  `/v1/oss-connect/{device-code,token}` with `{sdk_version, client_name,
+  device_code, grant_type}` — no telemetry, no metrics, no user content.
+- **The raw `api_key` returned by the flow is persisted to
+  `~/.sulci/config` (mode 0600)** — same path / mode the v0.5.2
+  `machine_id` already uses. The file is never logged or transmitted.
+
+### Latent feature explainer
+
+In v0.5.3, calling `sulci.connect(prompt=True)` against an environment
+where the gateway hasn't deployed `/v1/oss-connect/*` endpoints will:
+
+  1. Hit a 404 on `POST /v1/oss-connect/device-code`
+  2. Raise `RuntimeError: sulci.connect() failed: could not request device code (HTTPStatusError: ...)`
+  3. Leave `sulci._api_key = None` and telemetry disabled
+
+If the gateway endpoints are deployed BUT the dashboard `/oss-connect`
+page isn't:
+
+  1. The SDK gets a `device_code` and prints `Visit {URL} and enter code: WXYZ-2345`
+  2. The user follows the URL → 404 from the dashboard
+  3. SDK polls for 15 minutes, then raises `RuntimeError: sulci.connect() timed out`
+
+Both failure modes are clearly diagnosable. The default `prompt=False` is
+designed to prevent users from discovering them by accident.
+
+### Closed issues
+
+- sulci-oss #35 (improvement 3) — device-code flow client, originally
+  bundled with v0.5.2's improvements 1+2 but split out per launch-plan
+  Phase Wave 2 sequencing.
+
+### Wave 2 status (updated from v0.5.2 preview)
+
+- ✅ **D12 — sulci-oss device-code client** (this release; latent)
+- ✅ **D4 / D4.5 / D5 — gateway endpoints** (sulci-platform PR #51, pending merge + deploy)
+- 🔲 **D7 — dashboard `/oss-connect` page** (sulci-platform; not yet started)
+- ⏳ **v0.6.0 — promotion to production-ready** (after D7 merges + e2e validated)
+
+### Naming chronology
+
+The flow's URL/file naming went through two rename rounds at design time
+in sulci-platform: `cli` → `connect` → `oss-connect`. The end-state
+naming (`oss-connect` for URLs, `oss_connect` for Python identifiers)
+is what's in this v0.5.3 release. The intermediate names do not appear
+anywhere in the shipped code. Full chronology is in
+`sulci-platform/docs/architecture/adrs/0014-restore-oss-connect-device-code.md`.
+
+---
 
 Connected-OSS telemetry wave 1: per-deployment fingerprinting, `cache.set` aggregation,
 opt-in nudge. Pairs with sulci-platform's already-shipped `/v1/telemetry`,

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -137,8 +137,10 @@ All **212 tests** should be collected across eight test files (205 pass, 7 skipp
 tests/test_core.py                    — 27 tests  (cache.get/set, thresholds, TTL, stats, personalization)
 tests/test_context.py                 — 35 tests  (ContextWindow, SessionStore, integration)
 tests/test_backends.py                —  9 tests  (per-backend contract + persistence; skipped if dep missing)
-tests/test_connect.py                 — 32 tests  (sulci.connect(), _emit(), _flush(), Cache telemetry flag)
+tests/test_connect.py                 — 40 tests  (sulci.connect(), _emit(), _flush(), Cache telemetry flag,
+                                                   v0.5.3: TestDeviceCodeFlow integration)
                                                    requires httpx
+tests/test_oss_connect.py             — 19 tests  (RFC 8628 device-code client; v0.5.3, requires httpx)
 tests/test_cloud_backend.py           — 28 tests  (SulciCloudBackend, Cache(backend='sulci') wiring)
                                                    requires httpx
 tests/test_integrations_langchain.py  — 27 tests  (SulciCache LangChain adapter)     (v0.3.3)
@@ -163,6 +165,9 @@ python -m pytest tests/test_connect.py -v
 
 # v0.5.2 — config / telemetry / nudge tests only
 python -m pytest tests/test_config.py tests/test_telemetry.py tests/test_nudge.py -v
+
+# v0.5.3 — OSS-Connect device-code client tests
+python -m pytest tests/test_oss_connect.py -v
 
 # SulciCloudBackend + Cache wiring tests only
 python -m pytest tests/test_cloud_backend.py -v
@@ -518,15 +523,64 @@ cache.stats()                        # → prints nudge to stderr
 cache.stats()                        # → silent (one-shot)
 ```
 
-### Key resolution order
+### v0.5.3 — OSS-Connect device-code flow (latent)
 
-When `backend="sulci"` is used, the API key is resolved in this order:
+In v0.5.3 `sulci.connect()` gains a `prompt: bool = False` parameter.
+When set to `True`, and no api_key is found through the
+arg/env/`~/.sulci/config` resolution chain, the SDK runs the RFC 8628
+device-code flow against the gateway:
+
+```python
+import sulci
+
+# v0.5.3 default — completely safe everywhere:
+sulci.connect()
+# → falls through args → env → config; if none yield a key, returns silently
+#   (no telemetry enabled, no network call attempted)
+
+# To opt into the browser-based onboarding flow:
+sulci.connect(prompt=True)
+# → if no key found through the first three steps:
+#     [sulci] Visit https://app.sulci.io/oss-connect and enter code: WXYZ-2345
+#     [sulci] Waiting for authorization (Ctrl+C to cancel)...
+#   On success: SDK gets the api_key, writes to ~/.sulci/config (mode 0600)
+#   On user-deny / 15-min timeout: raises RuntimeError
+```
+
+> **`prompt=True` is dangerous in v0.5.3.** The SDK code is in place, but
+> the gateway endpoints (`/v1/oss-connect/{device-code,authorize,token}`)
+> and the dashboard `/oss-connect` page need to be deployed end-to-end
+> for the flow to complete. **Setting `prompt=True` against an
+> environment that hasn't announced OSS-Connect availability is user
+> error** — calls will either 404 immediately or block for 15 minutes
+> waiting for an authorization that can't happen. The Sulci team's
+> v0.6.0 release announcement will mark when the full chain is live;
+> v0.6.0 will also flip the `prompt` default to `True`.
+
+For local dev against a docker-compose gateway, override the gateway URL:
+
+```bash
+export SULCI_GATEWAY=http://localhost:8000
+python -c "import sulci; sulci.connect(prompt=True)"
+```
+
+### Key resolution order (v0.5.3)
+
+When `backend="sulci"` is used, the API key is resolved in this order
+(first match wins):
 
 ```
-1. Explicit api_key= argument to Cache()
+1. Explicit api_key= argument to Cache() or sulci.connect()
 2. SULCI_API_KEY environment variable
-3. Key stored by a prior sulci.connect() call
+3. ~/.sulci/config (persisted from a prior successful sulci.connect() call)
+4. Browser-based OSS-Connect device-code flow — only if prompt=True
 ```
+
+Step 3 is new in v0.5.3 — your first successful
+`sulci.connect(api_key="sk-sulci-...")` persists the key, and subsequent
+`sulci.connect()` calls with no arguments pick it up automatically.
+
+Step 4 is the new device-code flow described above.
 
 ### Run only the connect tests
 

--- a/README.md
+++ b/README.md
@@ -229,13 +229,44 @@ cache = Cache(backend="sulci")    # picks up key from connect() automatically
 `_telemetry_enabled = False` until you explicitly connect. Disable per-instance with
 `Cache(backend="sulci", telemetry=False)`.
 
-**Key resolution order:**
+**Key resolution order** (first match wins):
 
 ```
-1. Explicit api_key= argument to Cache()
+1. Explicit api_key= argument to sulci.connect() or Cache()
 2. SULCI_API_KEY environment variable
-3. Key stored by a prior sulci.connect() call
+3. ~/.sulci/config (persisted by a prior successful sulci.connect() call)
+4. Browser-based OSS-Connect device-code flow — only if prompt=True
 ```
+
+Step 3 (config persistence) ships in **v0.5.3**. After your first successful
+`sulci.connect(api_key="sk-sulci-...")`, the key is persisted to
+`~/.sulci/config` (mode 0600) and subsequent `sulci.connect()` calls with
+no arguments will pick it up automatically.
+
+Step 4 (device-code flow) ships **latent** in v0.5.3. The SDK code is in
+place, but the gateway endpoints and dashboard page need to deploy
+end-to-end before it's usable. The `prompt` parameter defaults to `False`
+in v0.5.3:
+
+```python
+# v0.5.3 default — safe everywhere:
+sulci.connect()
+# - Step 1-3 work normally
+# - Step 4 is skipped (prompt=False default)
+# - If no key found, connect() returns silently (no telemetry enabled)
+
+# Once your environment has OSS-Connect end-to-end deployed
+# (gateway + dashboard), opt in:
+sulci.connect(prompt=True)
+# - First-run: prints "Visit https://app.sulci.io/oss-connect and enter code: WXYZ-2345"
+# - User authorizes via browser → SDK gets api_key and persists to ~/.sulci/config
+# - Subsequent runs: step 3 short-circuits, no browser needed
+```
+
+**v0.6.0** will flip the `prompt` default to `True` once the full chain
+is shipped. **Setting `prompt=True` against an environment that hasn't
+announced OSS-Connect availability is user error** — wait for the
+release announcement.
 
 ---
 
@@ -406,7 +437,32 @@ After 100 cached queries on a `Cache` instance that hasn't been connected, `cach
 export SULCI_QUIET=1   # silences the nudge globally
 ```
 
-Wave 2 preview: `sulci.connect()` will gain a device-code flow in v0.6.0 — no manual API-key paste, browser-confirmed pairing. Lands once the corresponding gateway endpoints ship.
+### v0.5.3 additions
+
+OSS-Connect device-code SDK client (D12). The flow ships **latent** —
+SDK code is in place, but `prompt` defaults to `False` because the
+gateway endpoints and dashboard page need to deploy end-to-end before
+the flow is usable. **v0.6.0 will flip `prompt` to `True` once the
+full chain ships.** Setting `prompt=True` against an environment that
+hasn't announced OSS-Connect availability is user error.
+
+```python
+import sulci
+
+# v0.5.3 default — completely safe:
+sulci.connect(api_key="sk-sulci-...")     # the v0.5.x flow, unchanged
+sulci.connect()                            # falls through args/env/config; no browser
+
+# After the Sulci team announces OSS-Connect availability (v0.6.0):
+sulci.connect(prompt=True)                 # browser-based onboarding
+```
+
+What's new at the SDK level:
+
+- **`sulci.oss_connect`** — RFC 8628 device-code flow client. Lazy-imported only on the no-key-found path so `import sulci` cost is unchanged for users who never trigger it.
+- **Four-step `sulci.connect()` resolution** — `arg → env → ~/.sulci/config → device-code flow`. The third step (config-persisted key) is new in v0.5.3 — your first successful `sulci.connect(api_key=...)` persists the key, and subsequent `sulci.connect()` calls with no arguments pick it up automatically.
+- **`prompt: bool = False`** — keyword parameter. Default flips to `True` in v0.6.0.
+- **`SULCI_GATEWAY` env var** — overrides the gateway base URL (default `https://api.sulci.io`). Used for staging / local-dev. Same value drives both telemetry and the new device-code client.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.2"
+version = "0.6.0"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.6.0"
+version = "0.5.3"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/scripts/run_tests_per_file.py
+++ b/scripts/run_tests_per_file.py
@@ -52,6 +52,7 @@ DEFAULT_FILES = [
     "tests/test_context.py",
     "tests/test_core.py",
     "tests/test_async_cache.py",
+    "tests/test_oss_connect.py",
     "tests/test_qdrant_tenant_isolation.py",
     "tests/test_integrations_langchain.py",
     "tests/test_integrations_llamaindex.py",

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -106,7 +106,7 @@ _flush_thread_started = False
 def connect(
     api_key:   Optional[str] = None,
     telemetry: bool          = True,
-    prompt:    bool          = True,
+    prompt:    bool          = False,
 ) -> None:
     """
     Connect this process to Sulci Cloud.
@@ -123,6 +123,24 @@ def connect(
          409 wrong_plan for any other tier; paid-tier users should use
          the API key from their signup email).
 
+    .. warning::
+       In v0.5.3 the device-code flow ships **latent**: the SDK code
+       is in place, but the gateway endpoints (sulci-platform
+       ``/v1/oss-connect/*``) and the dashboard ``/oss-connect``
+       page may not yet be deployed in your environment. Until
+       both ship, calling ``connect(prompt=True)`` interactively
+       on a missing key will print a "Visit ..." prompt with a URL
+       that 404s and then block for 15 minutes before timing out.
+
+       The default is ``prompt=False`` for that reason. **Setting
+       ``prompt=True`` against an environment that hasn't announced
+       OSS-Connect availability is user error** — wait for the
+       Sulci team's release announcement that the full chain is
+       live (gateway + dashboard) before flipping it on.
+
+       v0.6.0 will flip the default to ``prompt=True`` once the
+       full chain is shipped end-to-end.
+
     Parameters
     ----------
     api_key : str, optional
@@ -131,12 +149,11 @@ def connect(
     telemetry : bool, default True
         Set to False to register your key without enabling telemetry.
         Useful for the sulci backend driver without usage reporting.
-    prompt : bool, default True
-        When True (the default), if no api_key is found through
-        args/env/config, run the browser-based device-code flow to
-        obtain one. Set False in non-interactive environments (CI,
-        headless tests, scripts) where you'd rather have ``connect()``
-        be a no-op than block on a flow that can't complete.
+    prompt : bool, default False (will flip to True in v0.6.0)
+        When True, if no api_key is found through args/env/config,
+        run the browser-based device-code flow to obtain one. The
+        v0.5.3 default is False because OSS-Connect's gateway + dashboard
+        pieces may not yet be deployed; see the warning above.
 
     Examples
     --------

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -88,6 +88,14 @@ _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
 _SDK_VERSION   = __version__   # deprecated alias; new code should use sulci.__version__
 _FLUSH_INTERVAL_SECONDS = 30
 
+# Gateway base URL — read once at import time. Production points at
+# api.sulci.io; staging/local-dev override via SULCI_GATEWAY.
+# Resolved here (not inside `connect()`) so that the v0.6.0 device-code
+# flow and the v0.5.x telemetry pipeline see the same value, and so
+# tests that monkeypatch the env var before importing `sulci` still
+# pick up the override.
+_GATEWAY_BASE = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+
 _event_buffer: list  = []
 _buffer_lock          = threading.Lock()
 _flush_thread_started = False
@@ -98,39 +106,94 @@ _flush_thread_started = False
 def connect(
     api_key:   Optional[str] = None,
     telemetry: bool          = True,
+    prompt:    bool          = True,
 ) -> None:
     """
-    Opt-in gate for Sulci Cloud telemetry and key registration.
+    Connect this process to Sulci Cloud.
+
+    Resolution order for the api_key (first match wins):
+
+      1. ``api_key`` argument
+      2. ``SULCI_API_KEY`` environment variable
+      3. ``~/.sulci/config`` (persisted from a prior successful connect)
+      4. Browser-based device-code flow — only if ``prompt=True`` AND
+         none of the above produced a key. Blocks until the user
+         authorizes via the browser, denies, or the 15-minute device
+         code expires. **OSS-Connect tier only** (the gateway returns
+         409 wrong_plan for any other tier; paid-tier users should use
+         the API key from their signup email).
 
     Parameters
     ----------
     api_key : str, optional
-        Your Sulci Cloud API key (sk-sulci-...).
-        Falls back to SULCI_API_KEY environment variable if not provided.
-        Required for telemetry to be enabled.
+        Your Sulci Cloud API key (sk-sulci-...). If omitted, falls
+        through the resolution order above.
     telemetry : bool, default True
         Set to False to register your key without enabling telemetry.
         Useful for the sulci backend driver without usage reporting.
+    prompt : bool, default True
+        When True (the default), if no api_key is found through
+        args/env/config, run the browser-based device-code flow to
+        obtain one. Set False in non-interactive environments (CI,
+        headless tests, scripts) where you'd rather have ``connect()``
+        be a no-op than block on a flow that can't complete.
 
     Examples
     --------
-    # Typical usage — enables telemetry
-    import sulci
+    # Paid-tier user — paste the key from your welcome email
     sulci.connect(api_key="sk-sulci-...")
 
-    # Key from environment variable
-    # export SULCI_API_KEY="sk-sulci-..."
+    # Or set SULCI_API_KEY env var, then:
     sulci.connect()
 
-    # Register key but disable telemetry
+    # OSS-Connect user — no key in hand, follow the browser prompt
+    sulci.connect()
+
+    # Subsequent runs short-circuit on ~/.sulci/config — no browser
+    sulci.connect()
+
+    # CI / headless: don't try to prompt, just be a no-op if no key
+    sulci.connect(prompt=False)
+
+    # Register key but disable telemetry (key still cached for cache lookups)
     sulci.connect(api_key="sk-sulci-...", telemetry=False)
 
-    # No-op — nothing sent, no key set
-    # (just don't call connect() at all)
+    Raises
+    ------
+    RuntimeError
+        If the device-code flow runs and fails (denied, expired,
+        timeout, network error). Pass ``prompt=False`` to skip the
+        flow entirely if you'd rather have a silent no-op on failure.
     """
     global _api_key, _telemetry_enabled
 
-    _api_key = api_key or os.environ.get("SULCI_API_KEY")
+    # 1. Explicit argument
+    resolved = api_key
+
+    # 2. SULCI_API_KEY env var
+    if not resolved:
+        resolved = os.environ.get("SULCI_API_KEY")
+
+    # 3. Persisted config (~/.sulci/config)
+    if not resolved:
+        resolved = _read_key_from_config()
+
+    # 4. Browser-based device-code flow (D12 — v0.6.0)
+    if not resolved and prompt:
+        # Lazy import: only reached on first-run for an OSS-Connect user.
+        # Avoids paying httpx import cost (and module-level side effects)
+        # for the common case where a key is already available.
+        from sulci import oss_connect as _oss_connect
+        resolved = _oss_connect.run_device_code_flow(
+            gateway_base = _GATEWAY_BASE,
+            sdk_version  = __version__,
+        )
+        # Persist for next invocation. Failure to persist is non-fatal —
+        # the user just gets prompted again next time, which is mildly
+        # annoying but not broken.
+        _persist_key_to_config(resolved)
+
+    _api_key = resolved
 
     # Telemetry is only active when BOTH conditions are true:
     #   1. the caller explicitly passed telemetry=True (the default)
@@ -140,6 +203,34 @@ def connect(
     if _telemetry_enabled:
         _start_flush_thread()
         _emit("startup", {})
+
+
+def _read_key_from_config() -> Optional[str]:
+    """Read api_key from ~/.sulci/config. Tolerant of any failure mode —
+    missing file, malformed JSON, permission denied — all return None
+    so the next resolution step (the device-code flow) can proceed.
+
+    The config module is dependency-free + corruption-tolerant by its
+    own design rules (see sulci/config.py module docstring), but we
+    still wrap with try/except as defense-in-depth.
+    """
+    try:
+        from sulci import config
+        return config.load().get("api_key")
+    except Exception:
+        return None
+
+
+def _persist_key_to_config(api_key: str) -> None:
+    """Persist api_key to ~/.sulci/config. Failures are non-fatal;
+    a config-write failure means the user gets prompted again on the
+    next invocation, which is recoverable.
+    """
+    try:
+        from sulci import config
+        config.update(api_key=api_key)
+    except Exception:
+        pass
 
 
 # ── Internal telemetry helpers ────────────────────────────────────────────────

--- a/sulci/oss_connect.py
+++ b/sulci/oss_connect.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+sulci/oss_connect.py — OSS-Connect device-code flow client (D12 / v0.6.0)
+=========================================================================
+
+Implements the SDK side of the OAuth 2.0 Device Authorization Grant
+(RFC 8628) so that ``sulci.connect()`` with no ``api_key`` can obtain a
+key via a browser handshake instead of forcing the user to copy-paste
+from a welcome email. This is the **first-run UX path** for users on
+the OSS-Connect tier.
+
+The gateway side of this flow is owned by sulci-platform; full API
+contract is at:
+
+    sulci-platform/docs/architecture/specs/oss-connect-device-code-flow.md
+
+Naming
+------
+This module is named ``oss_connect``, NOT ``connect``, because
+``sulci.connect()`` is already a public function defined in
+``sulci/__init__.py``. A ``sulci/connect.py`` submodule would shadow
+the function on any ``import sulci.connect`` (Python's submodule-
+import semantics replace the attribute on the package). See ADR 0014
+§"Naming" for the full chronology.
+
+OSS-Connect-only by enforcement
+-------------------------------
+The gateway returns ``409 wrong_plan`` if the resolving Clerk user is
+on ``free``/``pro``/``business``/``enterprise``. Paid tiers continue to
+use the email + paste flow shipped pre-Wave-2. The SDK surfaces that
+gateway error as a ``RuntimeError`` to the caller; users on paid tiers
+who land here in error will see a message pointing them at their
+welcome-email API key.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from typing import Tuple
+
+# Module-scope import. This module is itself lazy-imported from
+# sulci/__init__.py (only loaded when run_device_code_flow runs), so
+# putting httpx here doesn't affect ``import sulci`` startup time —
+# and it makes the module trivially mockable in tests
+# (``patch("sulci.oss_connect.httpx.post", ...)``).
+import httpx
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+# Standard RFC 8628 §3.4 grant_type. The gateway validates this as a
+# Pydantic Literal so any drift here produces a 422 immediately.
+GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+# Default identifier this SDK presents to the gateway. Future non-Python
+# clients (e.g. a JS SDK) would pass their own value.
+CLIENT_NAME = "sulci-python"
+
+
+# ── Public entry point ────────────────────────────────────────────────────────
+
+def run_device_code_flow(
+    gateway_base: str,
+    sdk_version:  str,
+) -> str:
+    """Run the full device-code flow. Blocks until terminal state.
+
+    Parameters
+    ----------
+    gateway_base : str
+        Base URL of the Sulci gateway, e.g. ``https://api.sulci.io``.
+        No trailing slash. Caller is responsible for resolving env-var
+        overrides (``SULCI_GATEWAY``) before calling.
+    sdk_version : str
+        The SDK's own version string; sent to the gateway for analytics
+        + future client-version-specific behavior.
+
+    Returns
+    -------
+    str
+        The raw ``sk-sulci-...`` API key on success. Caller is
+        responsible for persistence (e.g. ``sulci.config.update(...)``)
+        and for activating it for telemetry.
+
+    Raises
+    ------
+    RuntimeError
+        On any user-visible terminal failure: denied, expired,
+        not-found, network failure during initial request, or 15-minute
+        deadline elapsed without authorization. The exception message
+        is suitable for showing to the user — it's already prefixed
+        ``sulci.connect() failed: ...``.
+
+    Notes
+    -----
+    - This function blocks. The 15-minute deadline is the device_code's
+      TTL on the gateway; we don't extend it client-side.
+    - ``time.sleep(interval)`` runs *before* the first poll. RFC 8628
+      §3.5 specifies the polling interval is the minimum gap between
+      requests; the spec example calls sleep first too.
+    - Transient network errors during polling are swallowed and the
+      poll continues. Only the *initial* device-code request raises on
+      network error — without a device_code we have nothing to retry.
+    """
+    # 1. Request a fresh device_code + user_code pair.
+    try:
+        resp = httpx.post(
+            f"{gateway_base}/v1/oss-connect/device-code",
+            json={"sdk_version": sdk_version, "client_name": CLIENT_NAME},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        raise RuntimeError(
+            f"sulci.connect() failed: could not request device code ({e})"
+        ) from e
+
+    # 2. Tell the user what to do. Two lines: the action, then the
+    #    waiting state. Flush so the prompt appears immediately even
+    #    when stdout is line-buffered behind a pipe.
+    print(
+        f"[sulci] Visit {data['verification_uri']} "
+        f"and enter code: {data['user_code']}"
+    )
+    print("[sulci] Waiting for authorization (Ctrl+C to cancel)...")
+    sys.stdout.flush()
+
+    # 3. Poll /v1/oss-connect/token until terminal state.
+    interval = int(data["interval"])
+    deadline = time.time() + int(data["expires_in"])
+
+    while time.time() < deadline:
+        time.sleep(interval)
+
+        try:
+            poll = httpx.post(
+                f"{gateway_base}/v1/oss-connect/token",
+                json={
+                    "device_code": data["device_code"],
+                    "grant_type":  GRANT_TYPE,
+                },
+                timeout=10,
+            )
+        except Exception:
+            # Transient network error — keep polling. The 15-minute
+            # deadline still applies, so a sustained outage will fail
+            # at the loop boundary with a clear timeout message.
+            continue
+
+        # Branch on RFC 8628 status codes. The gateway emits the bare
+        # OAuth error envelope `{"error": ..., "message": ...}`, NOT
+        # FastAPI's wrapped form — see the spec §"D5 error envelope
+        # shape" and gateway/app/routes/oss_connect.py module comment.
+        sc = poll.status_code
+
+        if sc == 200:
+            body = poll.json()
+            print(f"[sulci] ✓ Connected as {body['email']}")
+            return body["api_key"]
+
+        if sc == 425:
+            # User hasn't authorized yet. Keep polling at the agreed
+            # interval. The gateway's slow_down throttle will catch us
+            # if we ever hit this faster than `interval`, so this is
+            # the safe path.
+            continue
+
+        if sc == 400:
+            err = _safe_error_field(poll)
+            if err == "slow_down":
+                # RFC 8628 §3.5 — the SDK SHOULD increase its interval
+                # by 5 seconds whenever the AS asks it to slow down.
+                interval += 5
+                continue
+            # Any other 400 falls through to the terminal block below.
+
+        if sc in (403, 404, 410):
+            err = _safe_error_field(poll) or "unknown"
+            raise RuntimeError(f"sulci.connect() failed: {err}")
+
+        # Any other status is unexpected; we keep polling rather than
+        # failing fast — this gives the user a chance to recover from
+        # a transient gateway 5xx without blowing up their session.
+        # If it persists, the deadline will eventually fire.
+
+    raise RuntimeError("sulci.connect() timed out — please try again")
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _safe_error_field(response) -> str | None:
+    """Extract the ``error`` field from an httpx response body. Returns
+    None if the body isn't valid JSON or doesn't have an ``error`` field.
+
+    Defensive because a hostile network intermediary could substitute a
+    junk body, and we'd rather print "unknown" than crash the user's
+    interactive ``sulci.connect()`` call.
+    """
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if not isinstance(body, dict):
+        return None
+    val = body.get("error")
+    return val if isinstance(val, str) else None

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -93,11 +93,23 @@ class TestConnect:
         assert sulci._api_key == "sk-sulci-test123"
 
     def test_connect_without_key_does_not_enable_telemetry(self):
-        """connect() with no key and no env var leaves telemetry disabled."""
+        """connect(prompt=False) with no key, no env var, no config file
+        leaves telemetry disabled — the explicit opt-out path for
+        CI/headless environments. As of v0.6.0, the default behavior of
+        ``sulci.connect()`` with no inputs is to invoke the browser-based
+        device-code flow, so this test passes prompt=False to assert the
+        no-flow path. See sulci.oss_connect for the device-code path and
+        the TestDeviceCodeFlow class below for its tests.
+
+        We also patch ``_read_key_from_config`` to return None so a real
+        ``~/.sulci/config`` on the developer's machine doesn't leak into
+        the test and silently provide a key from step 3 of the resolution
+        chain."""
         import sulci
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config", return_value=None):
             os.environ.pop("SULCI_API_KEY", None)
-            sulci.connect()
+            sulci.connect(prompt=False)
         assert sulci._telemetry_enabled is False
         assert sulci._api_key is None
 
@@ -140,10 +152,20 @@ class TestConnect:
         mock_thread.assert_called_once()
 
     def test_connect_does_not_start_thread_without_key(self):
-        """connect() without a key must NOT start the flush thread."""
+        """connect(prompt=False) without a key must NOT start the flush
+        thread. As of v0.6.0 the default behavior is to invoke the
+        device-code flow when no key is found; prompt=False is the
+        explicit opt-out for tests / CI / headless callers that want
+        connect() to be a no-op when there's no key. Also patch
+        ``_read_key_from_config`` so a stale ~/.sulci/config doesn't
+        leak in (same defense as
+        test_connect_without_key_does_not_enable_telemetry above)."""
         import sulci
-        with patch("sulci._start_flush_thread") as mock_thread:
-            sulci.connect(api_key=None)
+        with patch("sulci._start_flush_thread") as mock_thread, \
+             patch("sulci._read_key_from_config", return_value=None), \
+             patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SULCI_API_KEY", None)
+            sulci.connect(api_key=None, prompt=False)
         mock_thread.assert_not_called()
 
     def test_connect_emits_startup_event(self):
@@ -432,3 +454,157 @@ class TestThreadSafety:
         for t in threads: t.join()
 
         assert len(sulci._event_buffer) == 500
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Device-code flow integration with connect() — D12 / v0.6.0
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestDeviceCodeFlow:
+    """Tests for connect()'s wiring to the OSS-Connect device-code flow.
+    Internals of the flow itself are covered in test_oss_connect.py;
+    these tests verify the resolution chain and persistence integration
+    inside connect()."""
+
+    def setup_method(self):
+        _reset_module()
+
+    def test_no_key_anywhere_invokes_device_code_flow(self):
+        """connect() with no api_key, no SULCI_API_KEY, no config →
+        invokes run_device_code_flow and uses its result."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config", return_value=None), \
+             patch("sulci.oss_connect.run_device_code_flow",
+                   return_value="sk-sulci-from-flow") as mock_flow, \
+             patch("sulci._persist_key_to_config") as mock_persist, \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            os.environ.pop("SULCI_API_KEY", None)
+            sulci.connect()
+
+        mock_flow.assert_called_once()
+        # The key from the flow becomes the active api_key.
+        assert sulci._api_key == "sk-sulci-from-flow"
+        # And telemetry is enabled (key was resolved + telemetry=True).
+        assert sulci._telemetry_enabled is True
+        # And the key got persisted for next-time short-circuit.
+        mock_persist.assert_called_once_with("sk-sulci-from-flow")
+
+    def test_config_short_circuits_before_flow(self):
+        """connect() with no api_key, no env var, BUT a key in config →
+        uses the config key and does NOT invoke the device-code flow."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config",
+                   return_value="sk-sulci-from-config"), \
+             patch("sulci.oss_connect.run_device_code_flow") as mock_flow, \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            os.environ.pop("SULCI_API_KEY", None)
+            sulci.connect()
+
+        # Flow was NOT called — config short-circuit hit first.
+        mock_flow.assert_not_called()
+        assert sulci._api_key == "sk-sulci-from-config"
+
+    def test_env_var_short_circuits_before_config_and_flow(self):
+        """SULCI_API_KEY beats config beats device-code flow. Verify the
+        full resolution order by setting BOTH env and config — env wins."""
+        import sulci
+        with patch.dict(os.environ, {"SULCI_API_KEY": "sk-sulci-env-wins"}), \
+             patch("sulci._read_key_from_config",
+                   return_value="sk-sulci-from-config") as mock_config, \
+             patch("sulci.oss_connect.run_device_code_flow") as mock_flow, \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            sulci.connect()
+
+        # Env var wins — config never read, flow never invoked.
+        mock_config.assert_not_called()
+        mock_flow.assert_not_called()
+        assert sulci._api_key == "sk-sulci-env-wins"
+
+    def test_explicit_arg_beats_everything(self):
+        """An explicit api_key= argument takes priority even over env vars
+        and config — the existing v0.5.x contract."""
+        import sulci
+        with patch.dict(os.environ, {"SULCI_API_KEY": "sk-sulci-env"}), \
+             patch("sulci._read_key_from_config",
+                   return_value="sk-sulci-config") as mock_config, \
+             patch("sulci.oss_connect.run_device_code_flow") as mock_flow, \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            sulci.connect(api_key="sk-sulci-explicit")
+
+        mock_config.assert_not_called()
+        mock_flow.assert_not_called()
+        assert sulci._api_key == "sk-sulci-explicit"
+
+    def test_prompt_false_skips_flow_when_no_key(self):
+        """The CI/headless escape hatch: prompt=False and no key
+        anywhere → connect() is a no-op, no network call attempted."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config", return_value=None), \
+             patch("sulci.oss_connect.run_device_code_flow") as mock_flow:
+            os.environ.pop("SULCI_API_KEY", None)
+            sulci.connect(prompt=False)
+
+        mock_flow.assert_not_called()
+        assert sulci._api_key is None
+        assert sulci._telemetry_enabled is False
+
+    def test_prompt_false_still_uses_config_if_present(self):
+        """prompt=False is about the *device-code flow*, not config.
+        If a config-persisted key exists, it should still be used."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config",
+                   return_value="sk-sulci-cached"), \
+             patch("sulci.oss_connect.run_device_code_flow") as mock_flow, \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            os.environ.pop("SULCI_API_KEY", None)
+            sulci.connect(prompt=False)
+
+        mock_flow.assert_not_called()
+        assert sulci._api_key == "sk-sulci-cached"
+        assert sulci._telemetry_enabled is True
+
+    def test_flow_failure_propagates_runtimerror(self):
+        """When the user denies / the code expires / network fails,
+        run_device_code_flow raises RuntimeError. That exception
+        propagates to the caller — passing prompt=False is the only
+        way to suppress."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config", return_value=None), \
+             patch("sulci.oss_connect.run_device_code_flow",
+                   side_effect=RuntimeError("sulci.connect() failed: access_denied")):
+            os.environ.pop("SULCI_API_KEY", None)
+            with pytest.raises(RuntimeError, match="access_denied"):
+                sulci.connect()
+        # State stays clean — no half-configured connection.
+        assert sulci._api_key is None
+        assert sulci._telemetry_enabled is False
+
+    def test_persist_failure_does_not_break_connect(self):
+        """If config.update fails for any reason (disk full, permission
+        denied), connect() should still complete successfully — the
+        only consequence is that the next invocation prompts again."""
+        import sulci
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("sulci._read_key_from_config", return_value=None), \
+             patch("sulci.oss_connect.run_device_code_flow",
+                   return_value="sk-sulci-from-flow"), \
+             patch("sulci.config.update",
+                   side_effect=OSError("disk full")), \
+             patch("sulci._start_flush_thread"), \
+             patch("sulci._emit"):
+            os.environ.pop("SULCI_API_KEY", None)
+            # Should NOT raise.
+            sulci.connect()
+
+        assert sulci._api_key == "sk-sulci-from-flow"
+        assert sulci._telemetry_enabled is True

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -470,8 +470,13 @@ class TestDeviceCodeFlow:
         _reset_module()
 
     def test_no_key_anywhere_invokes_device_code_flow(self):
-        """connect() with no api_key, no SULCI_API_KEY, no config →
-        invokes run_device_code_flow and uses its result."""
+        """connect(prompt=True) with no api_key, no SULCI_API_KEY, no config →
+        invokes run_device_code_flow and uses its result.
+
+        Note: prompt=True must be explicit in v0.5.3 (the default is False
+        for safety while OSS-Connect's gateway+dashboard chain ships).
+        v0.6.0 will flip the default to True.
+        """
         import sulci
         with patch.dict(os.environ, {}, clear=True), \
              patch("sulci._read_key_from_config", return_value=None), \
@@ -481,7 +486,7 @@ class TestDeviceCodeFlow:
              patch("sulci._start_flush_thread"), \
              patch("sulci._emit"):
             os.environ.pop("SULCI_API_KEY", None)
-            sulci.connect()
+            sulci.connect(prompt=True)
 
         mock_flow.assert_called_once()
         # The key from the flow becomes the active api_key.
@@ -584,7 +589,7 @@ class TestDeviceCodeFlow:
                    side_effect=RuntimeError("sulci.connect() failed: access_denied")):
             os.environ.pop("SULCI_API_KEY", None)
             with pytest.raises(RuntimeError, match="access_denied"):
-                sulci.connect()
+                sulci.connect(prompt=True)
         # State stays clean — no half-configured connection.
         assert sulci._api_key is None
         assert sulci._telemetry_enabled is False
@@ -604,7 +609,7 @@ class TestDeviceCodeFlow:
              patch("sulci._emit"):
             os.environ.pop("SULCI_API_KEY", None)
             # Should NOT raise.
-            sulci.connect()
+            sulci.connect(prompt=True)
 
         assert sulci._api_key == "sk-sulci-from-flow"
         assert sulci._telemetry_enabled is True

--- a/tests/test_oss_connect.py
+++ b/tests/test_oss_connect.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+"""
+tests/test_oss_connect.py
+=========================
+Unit tests for the OSS-Connect device-code flow client (D12 / v0.6.0).
+
+The module under test (``sulci.oss_connect``) is a thin RFC 8628 client
+that talks to the gateway's ``/v1/oss-connect/{device-code,token}``
+endpoints. These tests mock httpx so they're deterministic and fast,
+and so they can simulate the various terminal states the gateway can
+return without requiring a live gateway.
+
+Coverage
+--------
+- Happy path: pending → authorized → returns api_key
+- Slow_down: gateway 400 increments the polling interval by 5s
+- Denied: 403 access_denied → RuntimeError with the gateway's error code
+- Expired/not-found: 404 → RuntimeError
+- Initial /device-code request fails → RuntimeError before any polling
+- Transient network error during polling → keeps polling, no exception
+- Deadline elapsed without authorization → RuntimeError("timed out")
+- The error envelope is treated as RFC 8628 unwrapped form
+  (``response.json().get("error")``) — matches gateway's D5 contract
+- _safe_error_field tolerates malformed bodies / non-dict bodies
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# A "device-code" gateway response shape we'll reuse across tests. Mirrors
+# what gateway/app/routes/oss_connect.py:post_device_code returns.
+_DEVICE_CODE_BODY = {
+    "device_code":               "fake-device-code-43-chars-padded-pad-pad-padd",
+    "user_code":                 "WXYZ-2345",
+    "verification_uri":          "https://app.sulci.io/oss-connect",
+    "verification_uri_complete": "https://app.sulci.io/oss-connect?code=WXYZ-2345",
+    "expires_in":                900,
+    "interval":                  5,
+}
+
+
+def _ok(status: int, body: dict | None = None) -> MagicMock:
+    """Build a fake httpx.Response with the given status + JSON body."""
+    r = MagicMock()
+    r.status_code = status
+    r.json = MagicMock(return_value=body or {})
+    # raise_for_status is a no-op on success; raises on >=400.
+    if status >= 400:
+        r.raise_for_status = MagicMock(side_effect=Exception(f"{status} response"))
+    else:
+        r.raise_for_status = MagicMock(return_value=None)
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch):
+    """time.sleep would slow tests down + make them flaky. Replace with
+    a no-op so the polling loop iterates as fast as possible while still
+    respecting the deadline check (which uses time.time, not sleep).
+    """
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_: None)
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+class TestHappyPath:
+
+    def test_pending_then_authorized_returns_api_key(self):
+        """Most common shape of a successful flow: one or more 425s
+        (user hasn't clicked yet) followed by a 200 with the api_key."""
+        from sulci import oss_connect
+
+        device_code_resp = _ok(200, _DEVICE_CODE_BODY)
+        pending_resp     = _ok(425, {"error": "authorization_pending",
+                                     "message": "User has not authorized yet"})
+        authorized_resp  = _ok(200, {
+            "api_key":   "sk-sulci-flow-success-abcdef",
+            "tenant_id": 42,
+            "plan":      "oss_connect",
+            "email":     "kathir@example.com",
+        })
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[device_code_resp, pending_resp, authorized_resp]):
+            result = oss_connect.run_device_code_flow(
+                gateway_base="https://api.sulci.io",
+                sdk_version="0.6.0",
+            )
+
+        assert result == "sk-sulci-flow-success-abcdef"
+
+    def test_first_poll_authorized_short_path(self):
+        """If the user authorizes faster than the SDK's first sleep
+        finishes, the very first poll returns 200. No 425 in between."""
+        from sulci import oss_connect
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[
+                       _ok(200, _DEVICE_CODE_BODY),
+                       _ok(200, {"api_key": "sk-sulci-fast", "tenant_id": 1,
+                                 "plan": "oss_connect", "email": "a@b.c"}),
+                   ]):
+            result = oss_connect.run_device_code_flow(
+                gateway_base="https://api.sulci.io",
+                sdk_version="0.6.0",
+            )
+        assert result == "sk-sulci-fast"
+
+
+# ── Initial device-code request failures ─────────────────────────────────────
+
+class TestInitialRequestFailure:
+
+    def test_device_code_request_network_error_raises(self):
+        """If we can't even get a device_code, fail fast with a clear
+        error — there's nothing to poll for, so retrying inside this
+        function is pointless."""
+        from sulci import oss_connect
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=ConnectionError("DNS lookup failed")):
+            with pytest.raises(RuntimeError, match="could not request device code"):
+                oss_connect.run_device_code_flow(
+                    gateway_base="https://api.sulci.io",
+                    sdk_version="0.6.0",
+                )
+
+    def test_device_code_request_5xx_raises(self):
+        """Same fail-fast behavior for gateway 5xx — the rate-limit /
+        Redis-down paths the gateway documents both surface as 500/429.
+        No partial state to clean up."""
+        from sulci import oss_connect
+
+        bad = _ok(500, {"detail": {"error": "server_error"}})
+        with patch("sulci.oss_connect.httpx.post", side_effect=[bad]):
+            with pytest.raises(RuntimeError, match="could not request device code"):
+                oss_connect.run_device_code_flow(
+                    gateway_base="https://api.sulci.io",
+                    sdk_version="0.6.0",
+                )
+
+
+# ── Slow_down handling ──────────────────────────────────────────────────────
+
+class TestSlowDown:
+
+    def test_slow_down_increments_interval(self):
+        """RFC 8628 §3.5 — when the gateway returns 400 slow_down, the
+        SDK SHOULD increase its polling interval by 5 seconds. We
+        verify by inspecting the recorded sleep durations."""
+        from sulci import oss_connect
+
+        device_code_resp = _ok(200, _DEVICE_CODE_BODY)         # interval=5
+        slow_down_resp   = _ok(400, {"error": "slow_down",
+                                     "message": "Polling too aggressively"})
+        authorized_resp  = _ok(200, {"api_key": "sk-sulci-slowed",
+                                     "tenant_id": 1, "plan": "oss_connect",
+                                     "email": "a@b.c"})
+
+        sleep_durations = []
+
+        def _record_sleep(d):
+            sleep_durations.append(d)
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[device_code_resp, slow_down_resp, authorized_resp]), \
+             patch("sulci.oss_connect.time.sleep", side_effect=_record_sleep):
+            result = oss_connect.run_device_code_flow(
+                gateway_base="https://api.sulci.io",
+                sdk_version="0.6.0",
+            )
+
+        assert result == "sk-sulci-slowed"
+        # Two sleeps total (one before each poll). Second sleep is the
+        # incremented interval (5 → 10 after slow_down).
+        assert sleep_durations == [5, 10]
+
+    def test_other_400_does_not_increment_interval(self):
+        """A 400 with a non-slow_down error code falls through to the
+        terminal error block. Tests that the 400 short-circuit is gated
+        on error == 'slow_down'."""
+        from sulci import oss_connect
+
+        # Construct a 400 with a different error — say, the gateway
+        # rejected the body for some reason (this would normally be 422
+        # but defense-in-depth).
+        weird_400 = _ok(400, {"error": "weird_thing",
+                              "message": "no idea"})
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[_ok(200, _DEVICE_CODE_BODY), weird_400]):
+            # 400 with non-slow_down error doesn't match any terminal
+            # branch, so the loop continues. Eventually the deadline
+            # expires (we mock that immediately by patching time.time).
+            with patch("sulci.oss_connect.time.time",
+                       side_effect=[0, 1, 99999]):  # 99999 > deadline
+                with pytest.raises(RuntimeError, match="timed out"):
+                    oss_connect.run_device_code_flow(
+                        gateway_base="https://api.sulci.io",
+                        sdk_version="0.6.0",
+                    )
+
+
+# ── Terminal error states ───────────────────────────────────────────────────
+
+class TestTerminalErrors:
+
+    @pytest.mark.parametrize("status,error", [
+        (403, "access_denied"),
+        (404, "invalid_token"),
+        (410, "expired_token"),
+    ])
+    def test_terminal_status_raises_runtime_error(self, status, error):
+        """403/404/410 are all terminal — surface as RuntimeError with
+        the gateway's error code in the message."""
+        from sulci import oss_connect
+
+        terminal_resp = _ok(status, {"error": error, "message": "..."})
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[_ok(200, _DEVICE_CODE_BODY), terminal_resp]):
+            with pytest.raises(RuntimeError, match=error):
+                oss_connect.run_device_code_flow(
+                    gateway_base="https://api.sulci.io",
+                    sdk_version="0.6.0",
+                )
+
+    def test_terminal_with_unparseable_body_uses_unknown(self):
+        """If the gateway returns a terminal status but the body isn't
+        parseable JSON, the error message should contain 'unknown'
+        rather than crashing."""
+        from sulci import oss_connect
+
+        # Build a response where .json() raises.
+        bad = MagicMock()
+        bad.status_code = 403
+        bad.json = MagicMock(side_effect=ValueError("not JSON"))
+        bad.raise_for_status = MagicMock(side_effect=Exception("403"))
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[_ok(200, _DEVICE_CODE_BODY), bad]):
+            with pytest.raises(RuntimeError, match="unknown"):
+                oss_connect.run_device_code_flow(
+                    gateway_base="https://api.sulci.io",
+                    sdk_version="0.6.0",
+                )
+
+
+# ── Polling-loop resilience ─────────────────────────────────────────────────
+
+class TestPollingResilience:
+
+    def test_transient_poll_network_error_continues(self):
+        """A network error during polling is transient — the loop
+        keeps going. Only the *initial* device-code request raises on
+        network error; once we have a device_code, the right thing is
+        to keep trying until the 15-minute deadline."""
+        from sulci import oss_connect
+
+        # Sequence: device_code → network error → 425 → authorized
+        device_code_resp = _ok(200, _DEVICE_CODE_BODY)
+        authorized_resp  = _ok(200, {"api_key": "sk-sulci-resilient",
+                                     "tenant_id": 1, "plan": "oss_connect",
+                                     "email": "a@b.c"})
+
+        post_calls = [
+            device_code_resp,                      # 1st: initial request
+            ConnectionError("temporary glitch"),   # 2nd: poll fails
+            _ok(425, {"error": "authorization_pending"}),  # 3rd: pending
+            authorized_resp,                       # 4th: success
+        ]
+
+        with patch("sulci.oss_connect.httpx.post", side_effect=post_calls):
+            result = oss_connect.run_device_code_flow(
+                gateway_base="https://api.sulci.io",
+                sdk_version="0.6.0",
+            )
+        assert result == "sk-sulci-resilient"
+
+
+# ── Deadline / timeout ──────────────────────────────────────────────────────
+
+class TestDeadline:
+
+    def test_deadline_elapsed_raises(self):
+        """If the user never authorizes, the loop exits when the
+        15-minute deadline (expires_in) elapses. We simulate by mocking
+        time.time so the deadline check fails immediately after the
+        first poll."""
+        from sulci import oss_connect
+
+        with patch("sulci.oss_connect.httpx.post",
+                   return_value=_ok(200, _DEVICE_CODE_BODY)) as mocked_post, \
+             patch("sulci.oss_connect.time.time",
+                   side_effect=[0, 99999]):  # 0 = now, 99999 = past deadline
+            with pytest.raises(RuntimeError, match="timed out"):
+                oss_connect.run_device_code_flow(
+                    gateway_base="https://api.sulci.io",
+                    sdk_version="0.6.0",
+                )
+        # Initial request was made; loop exited before any token poll.
+        assert mocked_post.call_count == 1
+
+
+# ── _safe_error_field helper ────────────────────────────────────────────────
+
+class TestSafeErrorField:
+    """The helper that extracts ``error`` from a response body. Defensive
+    against hostile / malformed responses so a bad gateway response never
+    crashes the user's interactive ``sulci.connect()`` call."""
+
+    def test_returns_error_string_when_present(self):
+        from sulci import oss_connect
+        r = MagicMock()
+        r.json = MagicMock(return_value={"error": "access_denied"})
+        assert oss_connect._safe_error_field(r) == "access_denied"
+
+    def test_returns_none_when_body_not_json(self):
+        from sulci import oss_connect
+        r = MagicMock()
+        r.json = MagicMock(side_effect=ValueError("not JSON"))
+        assert oss_connect._safe_error_field(r) is None
+
+    def test_returns_none_when_body_is_list(self):
+        """Hostile body that's valid JSON but not a dict."""
+        from sulci import oss_connect
+        r = MagicMock()
+        r.json = MagicMock(return_value=["not", "a", "dict"])
+        assert oss_connect._safe_error_field(r) is None
+
+    def test_returns_none_when_no_error_field(self):
+        from sulci import oss_connect
+        r = MagicMock()
+        r.json = MagicMock(return_value={"message": "something else"})
+        assert oss_connect._safe_error_field(r) is None
+
+    def test_returns_none_when_error_is_not_string(self):
+        from sulci import oss_connect
+        r = MagicMock()
+        r.json = MagicMock(return_value={"error": 42})
+        assert oss_connect._safe_error_field(r) is None
+
+
+# ── URLs and request shape ──────────────────────────────────────────────────
+
+class TestRequestShape:
+    """Verify the SDK constructs requests the gateway expects."""
+
+    def test_device_code_request_uses_correct_url_and_body(self):
+        """Initial request hits /v1/oss-connect/device-code with
+        sdk_version + client_name."""
+        from sulci import oss_connect
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[
+                       _ok(200, _DEVICE_CODE_BODY),
+                       _ok(200, {"api_key": "k", "tenant_id": 1,
+                                 "plan": "oss_connect", "email": "a@b.c"}),
+                   ]) as mock_post:
+            oss_connect.run_device_code_flow(
+                gateway_base="https://staging.example.com",
+                sdk_version="9.9.9",
+            )
+
+        # First call: device-code request
+        first_call = mock_post.call_args_list[0]
+        assert first_call.args[0] == "https://staging.example.com/v1/oss-connect/device-code"
+        assert first_call.kwargs["json"] == {
+            "sdk_version": "9.9.9",
+            "client_name": "sulci-python",
+        }
+
+    def test_token_poll_uses_correct_url_and_body(self):
+        from sulci import oss_connect
+
+        with patch("sulci.oss_connect.httpx.post",
+                   side_effect=[
+                       _ok(200, _DEVICE_CODE_BODY),
+                       _ok(200, {"api_key": "k", "tenant_id": 1,
+                                 "plan": "oss_connect", "email": "a@b.c"}),
+                   ]) as mock_post:
+            oss_connect.run_device_code_flow(
+                gateway_base="https://staging.example.com",
+                sdk_version="0.6.0",
+            )
+
+        # Second call: token poll
+        poll_call = mock_post.call_args_list[1]
+        assert poll_call.args[0] == "https://staging.example.com/v1/oss-connect/token"
+        assert poll_call.kwargs["json"] == {
+            "device_code": _DEVICE_CODE_BODY["device_code"],
+            "grant_type":  oss_connect.GRANT_TYPE,
+        }
+        # The grant_type literal must match exactly what the gateway's
+        # Pydantic Literal expects.
+        assert oss_connect.GRANT_TYPE == "urn:ietf:params:oauth:grant-type:device_code"


### PR DESCRIPTION
Wave 2 SDK-side delivery for OSS-Connect onboarding (D12).

Companion to sulci-platform#51 which delivers the gateway endpoints
this SDK now talks to.

## What ships

`sulci.connect()` gains browser-based device-code flow (RFC 8628) for
first-run OSS users who don't have an api_key in hand.

**Resolution order (first match wins):**

1. `api_key` argument
2. `SULCI_API_KEY` environment variable
3. `~/.sulci/config` (persisted from a prior successful connect)
4. Browser-based device-code flow — only when `prompt=True` AND none
   of the above produced a key. Blocks until the user authorizes,
   denies, or the 15-minute device_code expires.

**New parameter:** `prompt: bool = True`. Default `True` preserves the
new UX. Set `prompt=False` for CI/headless contexts where blocking on
a browser flow is undesirable — the call becomes a no-op if no key is
found through args/env/config.

## Usage

```python
# OSS-Connect first-run user, no key in hand:
import sulci
sulci.connect()
# Prints: [sulci] Visit https://app.sulci.io/oss-connect and enter code: WXYZ-2345
# Blocks until the user authorizes via the browser, then prints:
# [sulci] ✓ Connected as user@example.com

# Subsequent runs short-circuit on ~/.sulci/config — no browser:
sulci.connect()                            # immediately returns

# Paid-tier user pasting from welcome email — unchanged:
sulci.connect(api_key="sk-sulci-...")

# Or via env var — unchanged:
# export SULCI_API_KEY=sk-sulci-...
sulci.connect()

# CI / headless — explicit no-op if no key:
sulci.connect(prompt=False)
```

## Why `oss_connect` not `connect`

The new module is named `sulci/oss_connect.py`, not `sulci/connect.py`,
because `sulci.connect()` is already a public function in
`sulci/__init__.py`. A `sulci/connect.py` submodule would shadow that
function once anything in the process did `import sulci.connect`,
making `sulci.connect(...)` raise `TypeError: module is not callable`.

Also matches the existing `oss_connect` plan name in the platform.
Full naming chronology in sulci-platform#51's ADR 0014.

## Backwards compatibility

✅ `sulci.connect(api_key=...)` — unchanged behavior
✅ `sulci.connect(api_key=..., telemetry=False)` — unchanged
✅ `sulci.connect()` with `SULCI_API_KEY` env set — unchanged
✅ `sulci.connect()` with no key, no env — **was: no-op; now: triggers device-code flow IF interactive.** Set `prompt=False` to preserve no-op behavior.

The default-`True` `prompt` parameter is a deliberate UX improvement
for the OSS-Connect onboarding case. The escape hatch
(`prompt=False`) is documented in the docstring.

## Test coverage

- `tests/test_oss_connect.py` (new) — 19 tests for the device-code
  flow client (httpx mocked, deterministic, fast)
- `tests/test_connect.py` — 8 new tests in `TestDeviceCodeFlow` class
  covering the integration between `connect()` and `oss_connect`

Existing 32 tests in `test_connect.py` updated to pass `prompt=False`
where needed (the no-key paths that previously expected silent no-op).

## Test-gate hygiene

`scripts/run_tests_per_file.py` `DEFAULT_FILES` list extended to
include `tests/test_oss_connect.py`, so `make checkin` runs the
19 new tests as part of the gate. Without this addition, the tests
would exist but be silently skipped by the per-file runner (same
shape of test-gate omission as fixed for the platform repo in
sulci-platform PR #50 — pattern worth catching consistently).

## Verification

```bash
git checkout main && git pull
git checkout wave2-d12

# Just the new module's tests:
python3 -m pytest tests/test_oss_connect.py -v
# Expected: 19 passed

# Plus the integration tests in test_connect.py (excluding offline-
# incompatible Cache integration block):
python3 -m pytest tests/test_oss_connect.py tests/test_connect.py \
  --deselect tests/test_connect.py::TestCacheIntegration -q
# Expected: 55 passed, 4 deselected

# Full make checkin (per-file runner + examples + benchmark):
make checkin
# Expected: 331 passed (per-file runner), 12/12 examples,
#           benchmark within tolerance vs v0.4.0 baseline
```

## Release sequencing

This PR ships at v0.6.0. The version bump is included in
`pyproject.toml`. Recommended release order:

1. Merge sulci-platform#51 first → deploy gateway → endpoints live
2. Then merge this PR + tag v0.6.0 → publish to PyPI
3. SDK release notes should highlight the new `connect()` UX +
   `prompt` parameter

## Related

- **Companion PR:** sulci-platform#51 (D4/D4.5/D5 gateway endpoints)
- **Spec:** `sulci-platform/docs/architecture/specs/oss-connect-device-code-flow.md`
- **ADR:** `sulci-platform/docs/architecture/adrs/0014-restore-oss-connect-device-code.md`
