### PR TITLE
PR-C: D7 enabler bundle (#41 #42 #20 #19 #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,122 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased] — D7 enabler bundle (PR-C)
+
+Five paper-cut fixes that land alongside the platform's D7 dashboard
+`/oss-connect` page work. Each one removes friction a freshly OSS-Connect-
+funneled user would otherwise hit in the first five minutes — startup
+visibility, raw-API stats, examples idempotency, key-rejection clarity,
+and PyPI-page metadata. No new public API surface; one observable
+behavior change called out under **Changed**.
+
+### Added
+
+- **POST `event='startup'` from `_flush()`** (#41). When `sulci.connect()`
+  is called the resulting startup event now reaches `/v1/telemetry`
+  instead of being drained on the floor. One POST per flush cycle that
+  contains any startup event (multiple buffered startups collapse to a
+  single dashboard row — startup is a state, not a counter). Backend
+  is sniffed from any non-startup event in the same batch; if the
+  startup ships before any cache traffic it goes out with `backend=""`,
+  which the gateway accepts and the fingerprint dedupes against later
+  rows. Result: a fresh deployment appears on the dashboard before its
+  first cache.get / cache.set, which is what D7's ConnectedOssOverview
+  needs to render.
+
+- **`pyproject.toml` — `authors` block + `Changelog` URL** (#25).
+  `pip show sulci` and the PyPI sidebar now surface
+  `Author: Kathiravan Sengodan` and a direct link to `CHANGELOG.md`.
+  The other `[project.urls]` entries that were already in place
+  (Homepage / Repository / Documentation / Bug Tracker) are unchanged.
+
+### Changed
+
+- **`Cache._stats["hits"]/["misses"]` increment inside `Cache.get()`,
+  not inside `Cache.cached_call()`** (#42). Users who use the raw
+  `.get()` / `.set()` API previously saw `stats() == {"hits": 0,
+  "misses": 0, "total_queries": 0}` regardless of activity, because
+  the counters only fired through `cached_call()`. They now reflect
+  every `.get()` call. `cached_call()` no longer increments them
+  itself — it goes through `.get()` like everyone else, so existing
+  hit/miss counts from `cached_call()`-only callers are identical to
+  before. `saved_cost` stays a `cached_call()`-only metric, since
+  raw `.get()` doesn't know what an LLM call would have cost.
+
+  **Behavior change to flag:** if you have assertions against
+  `stats()` that assumed raw `.get()` was a no-op for stats, those
+  assertions will need to be updated.
+
+### Fixed
+
+- **`examples/` are now idempotent across re-runs** (#19).
+  `basic_usage.py`, `anthropic_example.py`, `context_aware.py`, and
+  `context_aware_example.py` each now use a per-run
+  `tempfile.mkdtemp(prefix="sulci_<demo>_")` for `db_path` instead of
+  inheriting the SQLite backend's default `./sulci_db` (which polluted
+  the repo working tree) or hardcoding `/tmp/sulci_ctx_demo*` (which
+  carried state across runs). `async_example.py` and
+  `llamaindex_example.py` already used this pattern; no change there.
+
+- **`examples/` fail fast with a useful message when an API key is
+  rejected** (#20). `anthropic_example.py` and `async_example.py` now
+  catch `anthropic.AuthenticationError` and `openai.AuthenticationError`
+  on the first real call, print a one-line "key rejected — verify at
+  <provider URL>" message, and fall back to the mock LLM for the rest
+  of the demo. Previously a stale or wrong key surfaced as a raw
+  `HTTPStatusError` traceback mid-output. The integration examples
+  (`langchain_example.py`, `llamaindex_example.py`) already cascade
+  across providers and survive missing-SDK gracefully; extending the
+  same rejection-path coverage to them is a sibling follow-up since
+  their provider-detection structure differs.
+
+### Tests
+
+- **+5 unit tests in `tests/test_telemetry.py::TestFlushIntegration`**
+  for the new startup-event branch:
+  - `test_startup_only_buffer_emits_one_post` — replaces the legacy
+    `test_startup_only_buffer_does_not_post`, which encoded the bug.
+  - `test_startup_with_cache_get_emits_two_posts_sharing_fingerprint`
+    — codifies the dashboard-join invariant (startup + cache.get from
+    the same flush share a fingerprint).
+  - `test_startup_sniffs_backend_from_non_startup_event` — backend
+    propagates from cache.set in the same batch into the startup row.
+  - `test_startup_payload_only_contains_wire_fields` — defense against
+    leaking SDK-internal keys past the gateway's `extra='forbid'`.
+  - `test_multiple_startup_events_collapse_to_one_post` — defensive
+    against any future "connect-after-disconnect" flow that buffers
+    multiple startups.
+- **+4 unit tests in `tests/test_core.py::TestStats`** for the raw
+  `.get()` / `.set()` stats path:
+  - `test_raw_get_miss_increments_misses`
+  - `test_raw_set_then_raw_get_increments_hits`
+  - `test_no_double_counting_via_cached_call` — regression guard for
+    the increment-moved-into-get refactor.
+  - `test_saved_cost_only_from_cached_call` — invariant that raw API
+    use must not contribute to the cost-savings metric.
+
+### Closed issues
+
+- sulci-oss #41 — POST startup events from `_flush()`
+- sulci-oss #42 — `Cache.stats()` reports 0/0 for raw `.get()`/`.set()` users
+- sulci-oss #20 — examples: fail fast on rejected API key with informative message
+- sulci-oss #19 — examples: db_path pollution makes demos non-idempotent
+- sulci-oss #25 — packaging: add `authors` block + `Changelog` URL to pyproject.toml
+
+### Follow-ups not in scope here
+
+- sulci-oss #48 (pre-commit smoke ~8 min on macOS) — not folded in;
+  the fix has design surface of its own (force CPU on macOS vs prewarm
+  cache vs mock embedder for smoke tests) that deserves a dedicated
+  discussion.
+- sulci-platform #55 (un-awaited AsyncMock in `test_oss_connect_authorize`)
+  — platform-side fix; lands separately.
+- Extending the #20 fail-fast pattern through `langchain_example.py` and
+  `llamaindex_example.py`'s multi-provider cascade — kept out of this
+  bundle to avoid touching the provider-detection structure.
+
+---
+
 ## [0.5.3] — 2026-05-04
 
 OSS-Connect device-code SDK client (D12). Ships **latent**: the code is in

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -134,7 +134,7 @@ python -m pytest tests/ -v
 All **212 tests** should be collected across eight test files (205 pass, 7 skipped if optional backend deps not installed):
 
 ```
-tests/test_core.py                    — 27 tests  (cache.get/set, thresholds, TTL, stats, personalization)
+tests/test_core.py                    — 35 tests  (cache.get/set, thresholds, TTL, stats incl. raw-get/set, personalization)
 tests/test_context.py                 — 35 tests  (ContextWindow, SessionStore, integration)
 tests/test_backends.py                —  9 tests  (per-backend contract + persistence; skipped if dep missing)
 tests/test_connect.py                 — 40 tests  (sulci.connect(), _emit(), _flush(), Cache telemetry flag,
@@ -869,7 +869,7 @@ tests/test_integrations_llamaindex.py::TestStats::test_repr_contains_hit_rate PA
     ├── test_cloud_backend.py           — 28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 — 32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 — 35 tests: ContextWindow, SessionStore, integration
-    ├── test_core.py                    — 27 tests: cache.get/set, TTL, stats, personalization
+    ├── test_core.py                    — 35 tests: cache.get/set, TTL, stats incl. raw-get/set, personalization
     ├── test_integrations_langchain.py  — 27 tests: SulciCache LangChain adapter        (v0.3.3)
     ├── test_integrations_llamaindex.py — 29 tests: SulciCacheLLM LlamaIndex wrapper     (v0.3.5)
     ├── test_async_cache.py             — 25 tests: AsyncCache non-blocking wrapper       (v0.3.7)
@@ -878,7 +878,7 @@ tests/test_integrations_llamaindex.py::TestStats::test_repr_contains_hit_rate PA
     ├── test_sinks.py                   — 15 tests: EventSink protocol + privacy allowlist (v0.5.0)
     ├── test_session_store_injection.py — 12 tests: Cache(session_store=, event_sink=)    (v0.5.0)
     ├── test_config.py                  — 20 tests: ~/.sulci/config — load/save/0600 perms (v0.5.2)
-    ├── test_telemetry.py               — 24 tests: fingerprint helper + flush wire shape  (v0.5.2)
+    ├── test_telemetry.py               — 28 tests: fingerprint helper + flush wire shape (incl. startup-events) (v0.5.2 / v0.5.4)
     ├── test_nudge.py                   — 13 tests: 100-query nudge in Cache.stats()       (v0.5.2)
     └── compat/                         —  Backend + Embedder conformance suites
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,18 @@ What's new at the SDK level:
 - **`prompt: bool = False`** — keyword parameter. Default flips to `True` in v0.6.0.
 - **`SULCI_GATEWAY` env var** — overrides the gateway base URL (default `https://api.sulci.io`). Used for staging / local-dev. Same value drives both telemetry and the new device-code client.
 
+### v0.5.4 additions
+
+D7 enabler bundle — five paper-cut fixes that ship alongside sulci-platform's dashboard `/oss-connect` page work. No new public API surface; one observable behavior change called out below.
+
+What's new at the SDK level:
+
+- **Startup events on the wire** — `sulci.connect()`'s `_emit("startup", {})` now reaches `/v1/telemetry` instead of being drained on the floor. One POST per flush cycle that contains any startup event; backend is sniffed from any non-startup event in the same batch (or `""` if cache traffic hasn't started yet — gateway accepts both, fingerprint dedupes the dashboard row). Result: a fresh deployment shows up on the dashboard before its first `cache.get`/`cache.set`.
+- **`Cache.stats()` now reflects raw `.get()`/`.set()` users.** Previously `_stats["hits"]/["misses"]` only incremented inside `cached_call()`, so anyone using the raw API saw `{"hits": 0, "misses": 0}` regardless of activity. The increments moved into `Cache.get()` itself; `cached_call()` no longer increments them (it goes through `.get()`, so existing hit/miss counts from `cached_call()`-only callers are identical to before). `saved_cost` stays a `cached_call()`-only metric. **Behavior change to flag:** assertions that assumed raw `.get()` was a stats no-op need updating.
+- **Examples are idempotent across re-runs.** `basic_usage.py`, `anthropic_example.py`, `context_aware.py`, and `context_aware_example.py` switched from `./sulci_db` (default, polluted the working tree) and hardcoded `/tmp/sulci_ctx_demo*` paths to per-run `tempfile.mkdtemp(prefix="sulci_<demo>_")`. `async_example.py` and `llamaindex_example.py` already used this pattern.
+- **Examples fail fast on rejected API keys.** `anthropic_example.py` and `async_example.py` catch `anthropic.AuthenticationError` and `openai.AuthenticationError` on first call, print a one-line "key rejected — verify at <provider URL>" message, and fall back to mock LLM for the rest of the demo. Previously a stale or wrong key surfaced as a raw `HTTPStatusError` traceback mid-output.
+- **PyPI metadata: `authors` block + `Changelog` URL** in `pyproject.toml`. After the next release, `pip show sulci` surfaces `Author:` and the PyPI sidebar shows the Changelog link.
+
 ---
 
 ## Context-Aware Blending
@@ -592,7 +604,7 @@ No network calls are made unless you explicitly configure `embedding_model="open
     ├── test_cloud_backend.py           —  28 tests: SulciCloudBackend + Cache wiring
     ├── test_connect.py                 —  32 tests: sulci.connect(), _emit(), _flush()
     ├── test_context.py                 —  35 tests: ContextWindow, legacy SessionStore
-    ├── test_core.py                    —  31 tests: cache.get/set, TTL, stats, personalization, tenant_id
+    ├── test_core.py                    —  35 tests: cache.get/set, TTL, stats (incl. raw-get/set), personalization, tenant_id
     ├── test_integrations_langchain.py  —  27 tests: SulciCache LangChain adapter
     ├── test_integrations_llamaindex.py —  29 tests: SulciCacheLLM LlamaIndex wrapper
     ├── test_async_cache.py             —  25 tests: AsyncCache non-blocking wrapper       (v0.3.7)
@@ -601,7 +613,7 @@ No network calls are made unless you explicitly configure `embedding_model="open
     ├── test_sinks.py                   —  15 tests: EventSink protocol + privacy allowlist (v0.5.0)
     ├── test_session_store_injection.py —  12 tests: Cache(session_store=, event_sink=)    (v0.5.0)
     ├── test_config.py                  —  20 tests: ~/.sulci/config — load/save/0600 perms (v0.5.2)
-    ├── test_telemetry.py               —  24 tests: fingerprint helper + flush wire shape  (v0.5.2)
+    ├── test_telemetry.py               —  28 tests: fingerprint helper + flush wire shape (incl. startup-events) (v0.5.2 / v0.5.4)
     ├── test_nudge.py                   —  13 tests: 100-query nudge in Cache.stats()       (v0.5.2)
     └── compat/                         —  Backend + Embedder conformance suites
 

--- a/examples/anthropic_example.py
+++ b/examples/anthropic_example.py
@@ -10,18 +10,22 @@ Requirements:
 Run:
     python examples/anthropic_example.py
 """
-import os, sys
+import os, sys, tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from sulci import Cache
 
 # ── Cache configuration ───────────────────────────────────────────────────
+# Per-run tempdir so the demo is idempotent across runs (issue #19).
+_DB_PATH = os.path.join(tempfile.mkdtemp(prefix="sulci_anthropic_"), "cache")
+
 cache = Cache(
     backend         = "sqlite",   # default-available; works with `pip install "sulci[sqlite]"`
     threshold       = 0.85,
     embedding_model = "minilm",
     ttl_seconds     = 86400,
     personalized    = False,
+    db_path         = _DB_PATH,
     # context-awareness — remove or set context_window=0 for stateless mode
     context_window  = 6,         # remember last 6 turns per session
     query_weight    = 0.70,      # 70% current query, 30% history
@@ -48,15 +52,32 @@ else:
         print("   Get a key at https://console.anthropic.com/\n")
         call_claude = _make_mock_call_claude()
     else:
-        _client = anthropic.Anthropic()
+        _client    = anthropic.Anthropic()
+        _mock_call = _make_mock_call_claude()
+
+        # #20 — fail fast (with a useful message) the first time a real
+        # call is rejected. Subsequent calls fall back to mock so the
+        # rest of the demo still completes; otherwise an expired or
+        # invalid key produced a raw HTTPStatusError stack trace mid-run.
+        _key_state = {"rejected": False}
 
         def call_claude(query: str, model: str = "claude-sonnet-4-20250514") -> str:
-            msg = _client.messages.create(
-                model      = model,
-                max_tokens = 1024,
-                messages   = [{"role": "user", "content": query}],
-            )
-            return msg.content[0].text
+            if _key_state["rejected"]:
+                return _mock_call(query)
+            try:
+                msg = _client.messages.create(
+                    model      = model,
+                    max_tokens = 1024,
+                    messages   = [{"role": "user", "content": query}],
+                )
+                return msg.content[0].text
+            except anthropic.AuthenticationError:
+                print()
+                print("⚠  ANTHROPIC_API_KEY rejected by Anthropic (HTTP 401).")
+                print("   Verify your key at https://console.anthropic.com/settings/keys")
+                print("   Falling back to mock LLM for the rest of this demo.\n")
+                _key_state["rejected"] = True
+                return _mock_call(query)
 
         print("✓ Anthropic client ready\n")
 

--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -58,6 +58,26 @@ print("── API key detection ────────────────
 print(f"  OPENAI_API_KEY    : {'✓ found' if _has_openai    else '✗ not set'}")
 print(f"  ANTHROPIC_API_KEY : {'✓ found' if _has_anthropic else '✗ not set'}")
 
+# Mock LLM body — defined first so the real-provider blocks below can fall
+# back to it on AuthenticationError without redefining the responses (#20).
+def _mock_call(query: str) -> str:
+    q = query.lower()
+    if "semantic" in q or "cache" in q:
+        return "Semantic caching stores LLM responses indexed by meaning, not exact text."
+    if "async" in q or "asyncio" in q or "fastapi" in q:
+        return "AsyncCache wraps sulci.Cache with asyncio.to_thread() so the event loop is never blocked."
+    if "langchain" in q:
+        return "LangChain is a framework for building LLM-powered applications."
+    if "cap" in q or "distributed" in q:
+        return "The CAP theorem: Consistency, Availability, Partition tolerance — pick two."
+    if "example" in q or "show" in q:
+        return "cache = AsyncCache(backend='sqlite'); response, sim, depth = await cache.aget(query)."
+    if "different" in q or "standard" in q:
+        return "Unlike sync Cache.get(), AsyncCache.aget() yields the event loop — other requests proceed."
+    if "benefit" in q or "advantage" in q:
+        return "Benefits: non-blocking I/O, higher FastAPI throughput, compatible with all async frameworks."
+    return f"[Mock] Answer to: {query[:60]}"
+
 _call_llm   = None
 _using_mock = False
 
@@ -66,12 +86,26 @@ if _has_openai:
     try:
         import openai
         _oa_client = openai.OpenAI()
+        _oa_state  = {"rejected": False}
         def _call_llm(query: str) -> str:
-            resp = _oa_client.chat.completions.create(
-                model    = "gpt-4o-mini",
-                messages = [{"role": "user", "content": query}],
-            )
-            return resp.choices[0].message.content
+            # #20 — once the key is rejected, fall back to mock so the rest of
+            # the demo still runs (instead of raising AuthenticationError every
+            # call).
+            if _oa_state["rejected"]:
+                return _mock_call(query)
+            try:
+                resp = _oa_client.chat.completions.create(
+                    model    = "gpt-4o-mini",
+                    messages = [{"role": "user", "content": query}],
+                )
+                return resp.choices[0].message.content
+            except openai.AuthenticationError:
+                print()
+                print("⚠  OPENAI_API_KEY rejected by OpenAI (HTTP 401).")
+                print("   Verify your key at https://platform.openai.com/api-keys")
+                print("   Falling back to mock LLM for the rest of this demo.\n")
+                _oa_state["rejected"] = True
+                return _mock_call(query)
         print("  → Using: OpenAI gpt-4o-mini\n")
     except ImportError:
         print("  ✗ openai not installed — run: pip install openai")
@@ -81,13 +115,24 @@ if _call_llm is None and _has_anthropic:
     try:
         import anthropic
         _ant_client = anthropic.Anthropic()
+        _ant_state  = {"rejected": False}
         def _call_llm(query: str) -> str:
-            msg = _ant_client.messages.create(
-                model      = "claude-haiku-4-5-20251001",
-                max_tokens = 1024,
-                messages   = [{"role": "user", "content": query}],
-            )
-            return msg.content[0].text
+            if _ant_state["rejected"]:
+                return _mock_call(query)
+            try:
+                msg = _ant_client.messages.create(
+                    model      = "claude-haiku-4-5-20251001",
+                    max_tokens = 1024,
+                    messages   = [{"role": "user", "content": query}],
+                )
+                return msg.content[0].text
+            except anthropic.AuthenticationError:
+                print()
+                print("⚠  ANTHROPIC_API_KEY rejected by Anthropic (HTTP 401).")
+                print("   Verify your key at https://console.anthropic.com/settings/keys")
+                print("   Falling back to mock LLM for the rest of this demo.\n")
+                _ant_state["rejected"] = True
+                return _mock_call(query)
         print("  → Using: Anthropic claude-haiku-4-5-20251001\n")
     except ImportError:
         print("  ✗ anthropic not installed — run: pip install anthropic")
@@ -96,23 +141,7 @@ if _call_llm is None and _has_anthropic:
 if _call_llm is None:
     _using_mock = True
     print("  → Using: mock LLM (no API key — set OPENAI_API_KEY or ANTHROPIC_API_KEY)\n")
-    def _call_llm(query: str) -> str:
-        q = query.lower()
-        if "semantic" in q or "cache" in q:
-            return "Semantic caching stores LLM responses indexed by meaning, not exact text."
-        if "async" in q or "asyncio" in q or "fastapi" in q:
-            return "AsyncCache wraps sulci.Cache with asyncio.to_thread() so the event loop is never blocked."
-        if "langchain" in q:
-            return "LangChain is a framework for building LLM-powered applications."
-        if "cap" in q or "distributed" in q:
-            return "The CAP theorem: Consistency, Availability, Partition tolerance — pick two."
-        if "example" in q or "show" in q:
-            return "cache = AsyncCache(backend='sqlite'); response, sim, depth = await cache.aget(query)."
-        if "different" in q or "standard" in q:
-            return "Unlike sync Cache.get(), AsyncCache.aget() yields the event loop — other requests proceed."
-        if "benefit" in q or "advantage" in q:
-            return "Benefits: non-blocking I/O, higher FastAPI throughput, compatible with all async frameworks."
-        return f"[Mock] Answer to: {query[:60]}"
+    _call_llm = _mock_call
 
 
 # ── Chat class ────────────────────────────────────────────────────────────────

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -8,17 +8,22 @@ Run:
     pip install "sulci[sqlite]"
     python examples/basic_usage.py
 """
-import sys, os
+import sys, os, tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from sulci import Cache
 
 # ── 1. Create a cache ─────────────────────────────────────────
+# Use a per-run tempdir so re-running the example is idempotent
+# (no db_path pollution accumulates across runs — issue #19).
+_DB_PATH = os.path.join(tempfile.mkdtemp(prefix="sulci_basic_"), "cache")
+
 cache = Cache(
     backend         = "sqlite",     # zero infra — just a local file
     threshold       = 0.85,         # 85% similarity required for a hit
     embedding_model = "minilm",     # free local model, downloads once
     ttl_seconds     = 3600,         # cache for 1 hour
+    db_path         = _DB_PATH,
 )
 
 # ── 2. Define your LLM function ───────────────────────────────

--- a/examples/context_aware.py
+++ b/examples/context_aware.py
@@ -12,7 +12,7 @@ Run:
     pip install "sulci[sqlite]"
     python examples/context_aware.py
 """
-import sys, os
+import sys, os, tempfile
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from sulci import Cache
@@ -34,6 +34,9 @@ def mock_llm(query: str) -> str:
 
 
 # ── Cache configured with a 6-turn context window ─────────────────────────
+# Per-run tempdir so the demo is idempotent across runs (issue #19).
+_DB_PATH = os.path.join(tempfile.mkdtemp(prefix="sulci_ctx_"), "cache")
+
 cache = Cache(
     backend        = "sqlite",
     threshold      = 0.78,      # slightly lower to catch follow-up queries
@@ -41,6 +44,7 @@ cache = Cache(
     query_weight   = 0.70,      # 70% current query, 30% history
     context_decay  = 0.60,      # moderate decay — recent turns matter most
     ttl_seconds    = 3600,
+    db_path        = _DB_PATH,
 )
 
 

--- a/examples/context_aware_example.py
+++ b/examples/context_aware_example.py
@@ -12,8 +12,13 @@ Run:
     pip install "sulci[sqlite]"
     python examples/context_aware_example.py
 """
+import os, tempfile
 
 from sulci import Cache
+
+# Per-run tempdirs so the demo is idempotent across runs (issue #19).
+_DB_PATH_1 = os.path.join(tempfile.mkdtemp(prefix="sulci_ctx_demo_"),  "cache")
+_DB_PATH_2 = os.path.join(tempfile.mkdtemp(prefix="sulci_ctx_demo2_"), "cache")
 
 # ── Fake LLM (no API key needed for this demo) ─────────────────────────
 call_count = 0
@@ -46,7 +51,7 @@ def separator(title: str):
 
 separator("1. Setup: seed the cache with known Q&A pairs")
 
-cache = Cache(backend="sqlite", threshold=0.82, context_window=6, db_path="/tmp/sulci_ctx_demo")
+cache = Cache(backend="sqlite", threshold=0.82, context_window=6, db_path=_DB_PATH_1)
 cache.clear()
 
 # Seed specific Q&A pairs the cache will return
@@ -96,7 +101,7 @@ for session_id, first_query in test_cases:
 
 separator("3. Manual context injection (pre-seeding a session)")
 
-cache2 = Cache(backend="sqlite", context_window=4, db_path="/tmp/sulci_ctx_demo2")
+cache2 = Cache(backend="sqlite", context_window=4, db_path=_DB_PATH_2)
 cache2.clear()
 cache2.set("What is the retry logic for Redis connections?",
            "Use exponential backoff: 1s, 2s, 4s, 8s. Max 3 retries.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description     = "The AI native context-aware semantic cache for LLM apps — P
 readme          = "README.md"
 license         = { file = "LICENSE" }
 requires-python = ">=3.9"
+authors         = [
+    { name = "Kathiravan Sengodan" },
+]
 keywords        = [
     "sulci-cache", "ai-native", "ai-cache", "context-aware-semantic-cache",
     "context-aware", "semantic-cache", "llm", "ai", "anthropic", "openai",
@@ -67,6 +70,7 @@ dev = [
 Homepage      = "https://sulci.io"
 Repository    = "https://github.com/sulci-io/sulci-oss"
 Documentation = "https://github.com/sulci-io/sulci-oss#readme"
+Changelog     = "https://github.com/sulci-io/sulci-oss/blob/main/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/sulci-io/sulci-oss/issues"
 
 [tool.setuptools.packages.find]

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -286,10 +286,14 @@ def _flush() -> None:
     ``/v1/analytics/deployments`` dashboard tile group events by
     deployment.
 
-    Startup events (emitted by :func:`connect`) are currently drained
-    but not sent — the legacy emit pipe does not include a ``startup``
-    POST path. Tracked as a follow-up; the gateway TelemetryEvent model
-    accepts ``event='startup'`` so the gap is purely SDK-side.
+    Startup events (emitted by :func:`connect`) are POSTed once per
+    flush cycle that contains any startup event. Backend is sniffed
+    from any non-startup event in the same batch so the row joins
+    cleanly with later cache.get/cache.set rows on the dashboard; if
+    no get/set has happened yet (the typical case for the first flush
+    after :func:`connect`), the startup goes out with ``backend=""``.
+    The gateway accepts an empty backend, and the fingerprint alone is
+    enough to dedupe the deployment row once cache traffic begins.
 
     Never raises — all exceptions are swallowed silently.
 
@@ -353,6 +357,33 @@ def _flush() -> None:
             "hits":           len(set_events),   # see "cache.set semantics" above
             "misses":         0,
             "avg_latency_ms": avg_latency,
+            "sdk_version":    _SDK_VERSION,
+            "python_version": _python_version(),
+            "fingerprint":    fingerprint,
+        })
+
+    # Forward startup events (#41). One POST per flush cycle that contains
+    # any startup event — multiple buffered startups in a single cycle
+    # collapse to a single row on the dashboard, which is what we want
+    # ("deployment alive" is a state, not a counter).
+    #
+    # Backend is unknown at startup time (Cache is typically instantiated
+    # AFTER sulci.connect()), so we sniff it from any non-startup event
+    # in the same batch. If no get/set has fired yet, backend goes out
+    # as "" — gateway accepts empty backend, and the fingerprint dedupes
+    # the deployment row once real traffic begins.
+    if any(e.get("event") == "startup" for e in batch):
+        sniffed_backend = next(
+            (e["backend"] for e in batch
+             if e.get("event") != "startup" and e.get("backend")),
+            "",
+        )
+        _post({
+            "event":          "startup",
+            "backend":        sniffed_backend,
+            "hits":           0,
+            "misses":         0,
+            "avg_latency_ms": 0.0,
             "sdk_version":    _SDK_VERSION,
             "python_version": _python_version(),
             "fingerprint":    fingerprint,

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -218,10 +218,11 @@ class Cache:
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
         # ── v0.5.2 nudge counter (D15) ──
-        # Tracks queries observed by THIS instance (raw .get() calls).
-        # Used by .stats() to decide whether to print the one-shot nudge
-        # toward sulci.connect() at 100 queries. Distinct from
-        # _stats["hits"]/["misses"] which only count cached_call() flow.
+        # Tracks queries observed by THIS instance, used by .stats() to
+        # decide whether to print the one-shot nudge toward sulci.connect()
+        # at 100 queries. Kept separate from _stats["hits"]/["misses"]
+        # because the nudge is a one-shot trigger, not a cumulative metric
+        # — collapsing the two would re-fire the nudge after .clear().
         self._query_count = 0
 
         # ── v0.5.0 session-store wiring (ADR 0007) ──
@@ -370,6 +371,18 @@ class Cache:
             now       = time.time(),
         )
         latency_ms = round((_time.time() - _t0) * 1000, 2)
+
+        # #42 — count every .get() call so users who use the raw .get()/.set()
+        # API (not just cached_call()) see non-zero stats(). Previously these
+        # counters only incremented inside cached_call(), which left raw users
+        # seeing {"hits": 0, "misses": 0} regardless of activity. cached_call()
+        # no longer increments these itself — it goes through .get() like
+        # everyone else, so there's no double-counting.
+        if resp is not None:
+            self._stats["hits"]   += 1
+        else:
+            self._stats["misses"] += 1
+
         try:
             if self._telemetry:
                 import sys
@@ -521,7 +534,9 @@ class Cache:
         ms              = (time.perf_counter() - t0) * 1000
 
         if hit is not None:
-            self._stats["hits"]       += 1
+            # _stats["hits"] is incremented inside .get() — see #42 note there.
+            # cached_call() owns saved_cost since it's the only path that knows
+            # cost_per_call.
             self._stats["saved_cost"] += cost_per_call
             # Record turn even on hits so future queries see this exchange
             if session_id and self._sessions:
@@ -539,7 +554,7 @@ class Cache:
         response = llm_fn(query, **llm_kwargs)
         self.set(query, response, tenant_id=tenant_id, user_id=user_id, session_id=session_id)
         ms = (time.perf_counter() - t0) * 1000
-        self._stats["misses"] += 1
+        # _stats["misses"] is incremented inside .get() above — see #42.
         return {
             "response":      response,
             "source":        "llm",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -200,6 +200,63 @@ class TestStats:
         assert s["hits"]   == 0
         assert s["misses"] == 0
 
+    # ── #42: raw .get()/.set() users now see non-zero stats() ───────
+
+    def test_raw_get_miss_increments_misses(self, cache):
+        """Raw .get() on an empty cache increments misses (issue #42)."""
+        cache.get("anything")
+        s = cache.stats()
+        assert s["misses"]        == 1
+        assert s["hits"]          == 0
+        assert s["total_queries"] == 1
+
+    def test_raw_set_then_raw_get_increments_hits(self, tmp_path):
+        """set() + get() flow shows the hit in stats() (issue #42)."""
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "raw_stats_db"))
+        cache.set("What is Python programming language?", "Python is great.")
+        resp, sim, _ = cache.get("What is the Python programming language?")
+        assert resp is not None, (
+            "Sanity: paraphrase should hit at threshold=0.85; "
+            f"got sim={sim}"
+        )
+        s = cache.stats()
+        assert s["hits"]   == 1
+        assert s["misses"] == 0
+
+    def test_no_double_counting_via_cached_call(self, tmp_path):
+        """cached_call() goes through .get() but mustn't double-count.
+
+        Regression guard for the #42 fix: when we moved the increment
+        into .get(), we removed the matching increments from
+        cached_call() — this test fails if either side is restored.
+        """
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "double_count_db"))
+        # First call: miss → llm → set. Total .get() invocations: 1.
+        cache.cached_call("What is Python programming language?",
+                          lambda q: "Python is great.")
+        # Second call: hit. Total .get() invocations: 2.
+        cache.cached_call("What is the Python programming language?",
+                          lambda q: "should not be called")
+        s = cache.stats()
+        assert s["misses"] == 1
+        assert s["hits"]   == 1
+        # If either path double-counted, total would be 3 or 4.
+        assert s["total_queries"] == 2
+
+    def test_saved_cost_only_from_cached_call(self, tmp_path):
+        """saved_cost stays a cached_call()-only metric (issue #42).
+
+        Raw .get() doesn't know what an LLM call would have cost, so
+        it must not contribute to saved_cost. Only cached_call() does.
+        """
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      db_path=str(tmp_path / "raw_savings_db"))
+        cache.set("a question", "an answer")
+        cache.get("a question")  # exact hit, but raw — no saved_cost
+        assert cache.stats()["saved_cost"] == 0.0
+
 
 # ── Threshold behaviour ───────────────────────────────────────
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -15,7 +15,8 @@ D13 coverage:
   - _flush() emits BOTH posts when both event types are buffered
   - _flush() drops embedding_model/threshold/context_window from wire payload
     (they live in the buffer for fingerprint computation, not for the wire)
-  - _flush() handles startup events without crashing (currently dropped)
+  - _flush() POSTs startup events (#41) — sniffs backend from any
+    non-startup event in the batch, falls back to "" if none
 """
 from __future__ import annotations
 
@@ -280,12 +281,15 @@ class TestFlushIntegration:
         fp_c = flush_with_backend("chroma")
         assert fp_q != fp_c
 
-    def test_startup_only_buffer_does_not_post(self, tmp_home):
-        """Startup events alone don't trigger a POST (legacy gap, see _flush docstring).
+    def test_startup_only_buffer_emits_one_post(self, tmp_home):
+        """A startup-only batch now produces exactly one POST (issue #41).
 
-        If this test starts failing because we now POST startup events,
-        update the test rather than the production code only — verify
-        the gateway accepts the new payload first.
+        Replaces the legacy ``test_startup_only_buffer_does_not_post``:
+        the gateway TelemetryEvent model has always accepted
+        ``event='startup'`` — only the SDK was dropping it on the floor.
+        With #41 fixed, ``sulci.connect()``'s ``_emit("startup", {})``
+        now reaches the dashboard so a fresh deployment shows up before
+        any cache traffic happens.
         """
         sulci._api_key           = "sk-sulci-test"
         sulci._telemetry_enabled = True
@@ -294,7 +298,108 @@ class TestFlushIntegration:
         ]
         with patch("httpx.post") as mock_post:
             sulci._flush()
-        assert mock_post.call_count == 0
+        assert mock_post.call_count == 1
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["event"]          == "startup"
+        # No cache.get/set in batch → no backend to sniff. Empty string
+        # is the documented contract; gateway accepts it.
+        assert payload["backend"]        == ""
+        assert payload["hits"]           == 0
+        assert payload["misses"]         == 0
+        assert payload["avg_latency_ms"] == 0.0
+        assert payload["fingerprint"]    is not None
+        assert len(payload["fingerprint"]) == 24
+
+    def test_startup_with_cache_get_emits_two_posts_sharing_fingerprint(self, tmp_home):
+        """startup + cache.get in same batch → 2 POSTs, joined fingerprint.
+
+        This is the dashboard-join invariant for #41: when a startup
+        event ships alongside cache.get/set events, both rows must
+        carry the same fingerprint so the deployments view collapses
+        them onto one row.
+        """
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+        sulci._event_buffer = [
+            {"event": "startup", "ts": time.time()},
+            {"event": "cache.get", "hits": 1, "misses": 0, "latency_ms": 10.0,
+             "backend": "qdrant", "embedding_model": "minilm",
+             "threshold": 0.85, "context_window": 0, "ts": time.time()},
+        ]
+        with patch("httpx.post") as mock_post:
+            sulci._flush()
+        assert mock_post.call_count == 2
+        events = {call.kwargs["json"]["event"] for call in mock_post.call_args_list}
+        assert events == {"cache.get", "startup"}
+        fingerprints = {call.kwargs["json"]["fingerprint"] for call in mock_post.call_args_list}
+        assert len(fingerprints) == 1, (
+            "startup and cache.get from the same flush must share a fingerprint "
+            "so the dashboard joins them onto one deployment row"
+        )
+
+    def test_startup_sniffs_backend_from_non_startup_event(self, tmp_home):
+        """When the batch has cache.get/set, startup uses that backend (#41).
+
+        Lets the dashboard show backend on the deployment row from
+        the very first flush rather than displaying ``backend=""``
+        until cache traffic catches up in a later flush.
+        """
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+        sulci._event_buffer = [
+            {"event": "startup", "ts": time.time()},
+            {"event": "cache.set", "latency_ms": 5.0, "backend": "qdrant",
+             "embedding_model": "minilm", "threshold": 0.85,
+             "context_window": 0, "ts": time.time()},
+        ]
+        with patch("httpx.post") as mock_post:
+            sulci._flush()
+        startup_payloads = [
+            c.kwargs["json"] for c in mock_post.call_args_list
+            if c.kwargs["json"]["event"] == "startup"
+        ]
+        assert len(startup_payloads) == 1
+        assert startup_payloads[0]["backend"] == "qdrant"
+
+    def test_startup_payload_only_contains_wire_fields(self, tmp_home):
+        """Defense against startup payload accidentally leaking SDK keys (#41).
+
+        Mirrors test_payloads_only_contain_wire_fields for the new
+        startup branch — the gateway's ``extra='forbid'`` would 422
+        the batch if we leaked anything.
+        """
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+        sulci._event_buffer = [
+            {"event": "startup", "ts": time.time()},
+        ]
+        with patch("httpx.post") as mock_post:
+            sulci._flush()
+        payload = mock_post.call_args.kwargs["json"]
+        assert set(payload.keys()).issubset(tel.WIRE_FIELDS), (
+            f"startup payload contains non-wire keys: "
+            f"{set(payload.keys()) - tel.WIRE_FIELDS}"
+        )
+
+    def test_multiple_startup_events_collapse_to_one_post(self, tmp_home):
+        """If the buffer somehow has >1 startup event, we POST once (#41).
+
+        Defensive: ``connect()`` only emits one startup per process,
+        but a future caller (or a connect()-after-disconnect flow)
+        might buffer multiple. Treat startup as a state, not a
+        counter — emit once per flush.
+        """
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+        sulci._event_buffer = [
+            {"event": "startup", "ts": time.time()},
+            {"event": "startup", "ts": time.time()},
+            {"event": "startup", "ts": time.time()},
+        ]
+        with patch("httpx.post") as mock_post:
+            sulci._flush()
+        assert mock_post.call_count == 1
+        assert mock_post.call_args.kwargs["json"]["event"] == "startup"
 
 
 # ── Privacy guarantees ────────────────────────────────────────────────────────


### PR DESCRIPTION
# PR-C — D7 enabler bundle (oss #41 #42 #20 #19 #25)

**Suggested branch:** `feat/d7-enabler-bundle`
**Closes:** #41, #42, #20, #19, #25

---

## Why these five together

Each issue removes a paper cut a freshly OSS-Connect-funneled user would
otherwise hit in the first five minutes — startup visibility, raw-API
stats, examples idempotency, key-rejection clarity, PyPI metadata. They
are the SDK-side prerequisites for sulci-platform's D7 (`/oss-connect`
dashboard page); shipping D7 without them would mean a user pastes a key,
sees an empty deployment row (no startup event), zero stats (raw `.get()`
users), or a confusing examples experience.

This is one commit-set, not five — they share testing infrastructure
(monkey-patched `httpx.post`, fake-embedder fixture pattern) and a
single CHANGELOG entry, and there is no benefit to splitting them
across PRs.

## What ships

### Telemetry — startup events on the wire (#41)

`sulci/__init__.py::_flush()` now POSTs `event='startup'` once per flush
cycle that contains any startup event. Backend is sniffed from any
non-startup event in the same batch (typical case: startup goes out
with `backend=""` on the first flush, then later flushes carry the
real backend; gateway accepts both, fingerprint dedupes the row).

The retro-flagged "drained but not sent" gap closes here. Gateway-side
already accepted `event='startup'` per the v0.5.2 schema.

**Files:** `sulci/__init__.py` (logic + docstring), `tests/test_telemetry.py`
(legacy `test_startup_only_buffer_does_not_post` inverted; +4 new tests
covering fingerprint-join with cache.get, backend sniffing, wire-field
allowlist on the new branch, multi-startup collapse).

### Stats — count every `.get()`, not just `cached_call()` (#42)

`Cache._stats["hits"]/["misses"]` increments move into `Cache.get()`.
`cached_call()` still owns `saved_cost` (it's the only path that knows
`cost_per_call`). No double-counting because `cached_call()` calls
`get()` exactly once per invocation.

**Behavior change to flag in review:** assertions that assumed raw
`.get()` was a stats no-op will need updating. CHANGELOG calls this out
under **Changed**.

**Files:** `sulci/core.py` (the increment move + an updated `_query_count`
docstring that no longer claims `_stats` is `cached_call()`-only),
`tests/test_core.py::TestStats` (+4 new tests; existing 5 still pass).

### Examples — idempotent and friendly to bad keys (#19, #20)

- **#19:** `basic_usage.py`, `anthropic_example.py`, `context_aware.py`,
  `context_aware_example.py` each switched from the SQLite default
  `./sulci_db` (which polluted the working tree) or hardcoded
  `/tmp/sulci_ctx_demo*` paths (which carried state across runs) to
  per-run `tempfile.mkdtemp(prefix="sulci_<demo>_")`. `async_example.py`
  and `llamaindex_example.py` already used this pattern.
- **#20:** `anthropic_example.py` and `async_example.py` now wrap the
  real-LLM call in a try/except for `anthropic.AuthenticationError` /
  `openai.AuthenticationError`. On rejection: print a one-line "key
  rejected — verify at <provider URL>" message, set a one-shot flag,
  fall back to mock for the rest of the demo. Replaces the prior
  behavior of crashing with a raw `HTTPStatusError` traceback mid-run.
  `langchain_example.py` and `llamaindex_example.py` are deferred —
  see "Out of scope" below.

### Packaging — `pip show` and PyPI sidebar (#25)

`pyproject.toml` gains an `authors = [{ name = "Kathiravan Sengodan" }]`
block and a `Changelog` URL in `[project.urls]`. Existing URLs unchanged.
After the next PyPI publish, `pip show sulci` surfaces `Author:` and
the PyPI project page sidebar shows the Changelog link.

## Test results

Sandbox can't download MiniLM (HF egress blocked, same as v0.5.2/v0.5.3
retros). What ran here:

- `tests/test_telemetry.py` — **28/28 pass** (5 new for #41, all 4
  pre-existing FlushIntegration tests still pass).
- `tests/test_config.py`, `tests/test_nudge.py`,
  `tests/test_oss_connect.py` — **79/79 pass, 1 skipped** (no
  regressions from the `_flush()` change).
- `tests/test_connect.py` (non-Cache-integration) — **115/119 pass**;
  the 4 fails are the same pre-existing `TestCacheIntegration::*`
  tests that need a real MiniLM (documented in the v0.5.2 retro).
- The new `tests/test_core.py::TestStats` cases for #42 were verified
  out-of-band with a fake-embedder harness (deterministic 8-dim
  hash-derived vectors); all 4 new + 5 pre-existing TestStats cases
  pass against the modified core. The harness was discarded — the
  PR-shipped tests use the same `Cache(backend="sqlite", db_path=...)`
  pattern as the surrounding tests, so they'll resolve to identical
  behavior under a real local checkout with the MiniLM model present.

Verification command for the reviewer locally:

```
pip install -e ".[sqlite,dev]"
pytest tests/test_telemetry.py tests/test_core.py::TestStats -v
```

## Out of scope (deliberate)

- **#48** — pre-commit smoke ~8 min on macOS. Not folded in. The fix
  has design surface of its own (force CPU on macOS vs prewarm the
  HF cache vs swap to a mock embedder for smoke); it deserves its
  own discussion and isn't on D7's critical path.
- **#55** (sulci-platform) — un-awaited AsyncMock in
  `test_oss_connect_authorize`. Platform-side fix; lands in the
  platform repo separately.
- **#20 fail-fast pattern in `langchain_example.py` /
  `llamaindex_example.py`.** These already cascade across providers
  and survive missing-SDK gracefully. Extending the rejection-path
  coverage cleanly through their provider-detection structure is its
  own touch and would muddy this bundle's diff. Tracked as a
  follow-up.

## Reviewer checklist

- [ ] CHANGELOG entry reads correctly under `[Unreleased]`
- [ ] `pyproject.toml` parses (`python -c "import tomllib;
      tomllib.loads(open('pyproject.toml').read())"`) ✓ checked
- [ ] `make smoke` passes with the new `tempfile.mkdtemp()` example paths
- [ ] `pytest tests/test_telemetry.py` passes (28 tests, 5 new)
- [ ] `pytest tests/test_core.py::TestStats` passes locally (9 tests, 4 new)
- [ ] No `_stats["hits"]` / `_stats["misses"]` increments remain in
      `cached_call()` (confirm via `git diff`)
- [ ] D7 dashboard work in sulci-platform can pick up startup-events on
      `/v1/analytics/deployments` once this lands + ships to PyPI
