### PR TITLE
release: v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased] — D7 enabler bundle (PR-C)
+## [0.5.4] — 2026-05-04 — D7 enabler bundle (PR-C)
 
 Five paper-cut fixes that land alongside the platform's D7 dashboard
 `/oss-connect` page work. Each one removes friction a freshly OSS-Connect-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.3"
+version = "0.5.4"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }


### PR DESCRIPTION
Version bump + CHANGELOG finalize for the D7 enabler bundle (PR #49). No code changes.