### PR TITLE
v0.5.5: SULCI_GATEWAY now redirects telemetry POSTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.5] — 2026-05-07 — telemetry honors `SULCI_GATEWAY` (PR-D)
+
+One-line behavior fix that unblocks staging-gateway smoke tests for the
+sulci-platform Connected-OSS dashboard tier (LAUNCH-PLAN row C2e). No
+new public API surface; no changes for users running against the
+default `https://api.sulci.io` gateway.
+
+### Fixed
+
+- **`SULCI_GATEWAY` now actually redirects telemetry POSTs** (#51).
+  `_TELEMETRY_URL` is now derived from `_GATEWAY_BASE` instead of being
+  a separate hardcoded literal. Prior to v0.5.5, setting
+  `SULCI_GATEWAY=https://staging.example.com` redirected the v0.6.0
+  device-code flow but silently did NOT redirect the v0.5.x telemetry
+  pipeline — the `_post()` helper still went to `api.sulci.io`. The
+  module comment claimed staging override was supported; the code
+  contradicted it. Now they agree:
+
+  ```python
+  # before (v0.5.4)
+  _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"   # hardcoded
+  _GATEWAY_BASE  = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+
+  # after (v0.5.5)
+  _GATEWAY_BASE  = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+  _TELEMETRY_URL = f"{_GATEWAY_BASE}/v1/telemetry"
+  ```
+
+  Backward-compatible: callers who don't set `SULCI_GATEWAY` see no
+  change (still resolves to `https://api.sulci.io/v1/telemetry`).
+
+### Tests
+
+- New `tests/test_telemetry_gateway_override.py` (6 tests) covering
+  default URL, env override, trailing-slash normalization, localhost
+  for local-dev, and end-to-end verification that `_post()` actually
+  POSTs to the resolved URL — closing the gap that let v0.5.4 ship
+  with a comment that disagreed with the code.
+
+### Out of scope (filed as follow-up)
+
+- `sulci/backends/cloud.py` (the `Cache(backend="sulci")` HTTP backend)
+  still hardcodes `CLOUD_URL = "https://api.sulci.io"` and only honors
+  a programmatic `gateway_url=` kwarg, not `SULCI_GATEWAY`. This is a
+  separate issue and a separate ergonomic gap; tracked as #TBD-2 for a
+  future minor.
+
+---
+
 ## [0.5.4] — 2026-05-04 — D7 enabler bundle (PR-C)
 
 Five paper-cut fixes that land alongside the platform's D7 dashboard

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -564,6 +564,79 @@ export SULCI_GATEWAY=http://localhost:8000
 python -c "import sulci; sulci.connect(prompt=True)"
 ```
 
+> **Note for v0.5.0 - v0.5.4:** this env var only redirects the device-code
+> flow shown above; telemetry POSTs from `connect()` + `Cache.get()` stay
+> pinned to `api.sulci.io` regardless. v0.5.5 fixed that — see the next
+> sub-section.
+
+### v0.5.5 — staging-gateway redirect for telemetry
+
+In v0.5.5 a single `SULCI_GATEWAY` value redirects both the device-code flow
+*and* the telemetry pipeline. This is what makes a published `pip install
+sulci` wheel usable against a non-prod gateway without code changes — e.g.
+pointing it at the Railway staging gateway before DNS cutover.
+
+**Quick verification** that the env var is reaching `_TELEMETRY_URL`:
+
+```bash
+SULCI_GATEWAY=https://staging.example.com python -c "
+import sulci
+print('_GATEWAY_BASE: ', sulci._GATEWAY_BASE)
+print('_TELEMETRY_URL:', sulci._TELEMETRY_URL)
+"
+# v0.5.5 prints:
+#   _GATEWAY_BASE:  https://staging.example.com
+#   _TELEMETRY_URL: https://staging.example.com/v1/telemetry
+#
+# v0.5.4 and earlier print _TELEMETRY_URL still pointing at api.sulci.io
+# regardless of the env var — that's the bug 0.5.5 fixed.
+```
+
+**End-to-end staging smoke** (Connected-OSS dashboard tier, mirrors
+sulci-platform LAUNCH-PLAN row C2e):
+
+```bash
+# In a clean venv so dev imports don't shadow the published wheel
+python -m venv ~/c2e_venv && source ~/c2e_venv/bin/activate
+pip install sulci==0.5.5
+
+export SULCI_GATEWAY=https://gateway-production-de5c.up.railway.app
+export SULCI_API_KEY=sk-sulci-<oss-connect-test-key>   # plan='oss_connect'
+
+python - <<'PY'
+import sulci, time
+print("telemetry destination:", sulci._TELEMETRY_URL)
+
+from sulci import Cache
+sulci.connect()                       # picks up SULCI_API_KEY from env
+c = Cache(backend="sqlite")
+c.set("How do I deploy to AWS?", "Use the AWS CLI...")
+resp, sim, ctx = c.get("How do I deploy to AWS?")
+print(f"hit: sim={sim:.3f}")
+
+# Background flush thread runs every 30s. One full cycle is enough
+# for both the startup event (from connect) and the cache.get event
+# to land on the gateway.
+time.sleep(35)
+PY
+
+# Verify on the gateway side — fingerprint should appear
+curl -H "X-Sulci-Key: $SULCI_API_KEY" \
+  "$SULCI_GATEWAY/v1/analytics/deployments" | python -m json.tool
+```
+
+The fingerprint that lands here is what powers the `ConnectedOssOverview`
+"Active SDKs" stat card and the `DeploymentsTable` row on the customer
+dashboard at `https://sulci-dashboard.vercel.app`.
+
+### Run only the gateway-override tests
+
+```bash
+python -m pytest tests/test_telemetry_gateway_override.py -v
+# 6 tests — default URL, env override, trailing-slash normalization,
+# localhost-for-local-dev, _post() honoring resolved URL (with + without env)
+```
+
 ### Key resolution order (v0.5.3)
 
 When `backend="sulci"` is used, the API key is resolved in this order
@@ -594,6 +667,12 @@ python -m pytest tests/test_connect.py::TestEmit -v
 python -m pytest tests/test_connect.py::TestFlush -v
 python -m pytest tests/test_connect.py::TestCacheIntegration -v
 python -m pytest tests/test_connect.py::TestThreadSafety -v
+
+# v0.5.5 — gateway-URL override coverage (separate file because it
+# requires sys.modules purging + reimport to re-evaluate module-level
+# constants; mixing this fixture pattern into test_connect.py would
+# couple unrelated tests).
+python -m pytest tests/test_telemetry_gateway_override.py -v
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ What's new at the SDK level:
 - **`sulci.oss_connect`** — RFC 8628 device-code flow client. Lazy-imported only on the no-key-found path so `import sulci` cost is unchanged for users who never trigger it.
 - **Four-step `sulci.connect()` resolution** — `arg → env → ~/.sulci/config → device-code flow`. The third step (config-persisted key) is new in v0.5.3 — your first successful `sulci.connect(api_key=...)` persists the key, and subsequent `sulci.connect()` calls with no arguments pick it up automatically.
 - **`prompt: bool = False`** — keyword parameter. Default flips to `True` in v0.6.0.
-- **`SULCI_GATEWAY` env var** — overrides the gateway base URL (default `https://api.sulci.io`). Used for staging / local-dev. Same value drives both telemetry and the new device-code client.
+- **`SULCI_GATEWAY` env var** — overrides the gateway base URL (default `https://api.sulci.io`). Used for staging / local-dev. **In v0.5.5+ a single value drives both telemetry POSTs and the device-code client.** In v0.5.0-v0.5.4 this env var only redirected the device-code flow; telemetry stayed pinned to `api.sulci.io` regardless. See the v0.5.5 additions section below.
 
 ### v0.5.4 additions
 
@@ -475,6 +475,30 @@ What's new at the SDK level:
 - **Examples are idempotent across re-runs.** `basic_usage.py`, `anthropic_example.py`, `context_aware.py`, and `context_aware_example.py` switched from `./sulci_db` (default, polluted the working tree) and hardcoded `/tmp/sulci_ctx_demo*` paths to per-run `tempfile.mkdtemp(prefix="sulci_<demo>_")`. `async_example.py` and `llamaindex_example.py` already used this pattern.
 - **Examples fail fast on rejected API keys.** `anthropic_example.py` and `async_example.py` catch `anthropic.AuthenticationError` and `openai.AuthenticationError` on first call, print a one-line "key rejected — verify at <provider URL>" message, and fall back to mock LLM for the rest of the demo. Previously a stale or wrong key surfaced as a raw `HTTPStatusError` traceback mid-output.
 - **PyPI metadata: `authors` block + `Changelog` URL** in `pyproject.toml`. After the next release, `pip show sulci` surfaces `Author:` and the PyPI sidebar shows the Changelog link.
+
+### v0.5.5 additions
+
+One-line fix that makes `SULCI_GATEWAY` actually redirect telemetry POSTs — closing the comment-vs-code gap that's been silently in place since v0.5.0. No new public API; default behavior unchanged for anyone not setting the env var.
+
+What's new at the SDK level:
+
+- **`SULCI_GATEWAY` redirects telemetry now.** `_TELEMETRY_URL` is derived from `_GATEWAY_BASE` instead of being a separate hardcoded literal. Setting `SULCI_GATEWAY=https://staging.example.com` redirects both the v0.6.0 device-code flow *and* the v0.5.x telemetry pipeline; previously it only redirected the former, contradicting the in-source comment that claimed otherwise. Concretely:
+
+  ```python
+  # v0.5.4
+  SULCI_GATEWAY=https://staging.example.com python -c "import sulci; print(sulci._TELEMETRY_URL)"
+  # → https://api.sulci.io/v1/telemetry              (env var ignored — bug)
+
+  # v0.5.5
+  SULCI_GATEWAY=https://staging.example.com python -c "import sulci; print(sulci._TELEMETRY_URL)"
+  # → https://staging.example.com/v1/telemetry      (env var honored — fixed)
+  ```
+
+  This unblocks staging-gateway smoke tests where the published wheel needs to point at a non-prod gateway (e.g. the Railway staging URL pre-DNS-cutover). See LOCAL_SETUP.md Step 9 for the full local + staging walkthrough.
+
+- **6 new regression tests** in `tests/test_telemetry_gateway_override.py` covering default URL, env override, trailing-slash normalization, localhost-for-local-dev, and end-to-end verification that `_post()` honors the resolved URL.
+
+- **Out-of-scope follow-up.** `sulci/backends/cloud.py` (the `Cache(backend="sulci")` HTTP backend) still hardcodes `CLOUD_URL = "https://api.sulci.io"` and only honors a programmatic `gateway_url=` kwarg, not `SULCI_GATEWAY`. Tracked separately for a future minor — `Cache(backend="sulci")` users today should pass `gateway_url=os.environ["SULCI_GATEWAY"]` explicitly if they want symmetry.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.4"
+version = "0.5.5"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -84,17 +84,22 @@ except PackageNotFoundError:
 _api_key:           Optional[str] = None
 _telemetry_enabled: bool          = False
 
-_TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
-_SDK_VERSION   = __version__   # deprecated alias; new code should use sulci.__version__
-_FLUSH_INTERVAL_SECONDS = 30
-
 # Gateway base URL — read once at import time. Production points at
 # api.sulci.io; staging/local-dev override via SULCI_GATEWAY.
 # Resolved here (not inside `connect()`) so that the v0.6.0 device-code
-# flow and the v0.5.x telemetry pipeline see the same value, and so
+# flow AND the v0.5.x telemetry pipeline see the same value, and so
 # tests that monkeypatch the env var before importing `sulci` still
 # pick up the override.
-_GATEWAY_BASE = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+#
+# v0.5.5 fix (#51): _TELEMETRY_URL is now derived from _GATEWAY_BASE.
+# Prior to v0.5.5, _TELEMETRY_URL was a hardcoded literal, so setting
+# SULCI_GATEWAY redirected the device-code flow but silently did NOT
+# redirect telemetry POSTs — contradicting the comment above and
+# blocking staging-gateway smoke tests.
+_GATEWAY_BASE  = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+_TELEMETRY_URL = f"{_GATEWAY_BASE}/v1/telemetry"
+_SDK_VERSION   = __version__   # deprecated alias; new code should use sulci.__version__
+_FLUSH_INTERVAL_SECONDS = 30
 
 _event_buffer: list  = []
 _buffer_lock          = threading.Lock()
@@ -272,7 +277,9 @@ def _emit(event: str, data: dict) -> None:
 
 def _flush() -> None:
     """
-    Drain the event buffer and POST aggregated batches to api.sulci.io.
+    Drain the event buffer and POST aggregated batches to the configured
+    Sulci gateway (``_TELEMETRY_URL``, derived from ``SULCI_GATEWAY`` —
+    defaults to ``https://api.sulci.io/v1/telemetry``).
 
     v0.5.2: aggregates cache.get and cache.set events separately, sending
     one HTTP call per event type that has events. cache.get carries

--- a/tests/test_telemetry_gateway_override.py
+++ b/tests/test_telemetry_gateway_override.py
@@ -1,0 +1,151 @@
+"""
+tests/test_telemetry_gateway_override.py
+========================================
+Regression tests for the v0.5.5 fix that makes ``SULCI_GATEWAY`` actually
+redirect telemetry POSTs.
+
+Background
+----------
+In v0.5.4 and earlier, ``sulci/__init__.py`` defined::
+
+    _TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"   # hardcoded literal
+    ...
+    _GATEWAY_BASE  = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io")...
+
+The comment above ``_GATEWAY_BASE`` claimed staging/local-dev override
+via ``SULCI_GATEWAY`` — but ``_TELEMETRY_URL`` (which ``_post()`` actually
+uses) was a separate literal that ignored the env var entirely. This
+broke staging smoke tests where the SDK is supposed to send telemetry
+to a non-prod gateway (e.g. the Railway staging URL pre-DNS-cutover).
+
+Fix
+---
+v0.5.5 derives ``_TELEMETRY_URL = f"{_GATEWAY_BASE}/v1/telemetry"`` so a
+single env var redirects both the device-code flow and the telemetry
+pipeline.
+
+Test strategy
+-------------
+``_TELEMETRY_URL`` and ``_GATEWAY_BASE`` are computed at module import
+time, so changing the env var after ``import sulci`` has no effect on
+already-resolved values. Each test purges the ``sulci`` module from
+``sys.modules`` and re-imports it after setting (or clearing) the env
+var, so we observe the values as a freshly-started process would.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from unittest.mock import patch
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _reimport_sulci(monkeypatch, gateway_value):
+    """Re-import ``sulci`` after applying ``SULCI_GATEWAY`` override.
+
+    Parameters
+    ----------
+    monkeypatch
+        pytest's monkeypatch fixture (auto-undoes env edits at teardown).
+    gateway_value
+        Value to set ``SULCI_GATEWAY`` to. Pass ``None`` to delete it
+        and exercise the default-URL path.
+    """
+    if gateway_value is None:
+        monkeypatch.delenv("SULCI_GATEWAY", raising=False)
+    else:
+        monkeypatch.setenv("SULCI_GATEWAY", gateway_value)
+
+    # Purge sulci and any submodule that may have captured the old
+    # module-level constants. Without this, a prior test's import
+    # leaks the cached _GATEWAY_BASE into this one.
+    for name in list(sys.modules):
+        if name == "sulci" or name.startswith("sulci."):
+            del sys.modules[name]
+
+    return importlib.import_module("sulci")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestGatewayBaseAndTelemetryUrl:
+    """Module-level constant resolution from SULCI_GATEWAY."""
+
+    def test_default_when_env_unset(self, monkeypatch):
+        sulci = _reimport_sulci(monkeypatch, gateway_value=None)
+        assert sulci._GATEWAY_BASE  == "https://api.sulci.io"
+        assert sulci._TELEMETRY_URL == "https://api.sulci.io/v1/telemetry"
+
+    def test_env_redirects_both_constants(self, monkeypatch):
+        """The whole point of v0.5.5: one env var, both URLs follow."""
+        sulci = _reimport_sulci(
+            monkeypatch,
+            gateway_value="https://gateway-production-de5c.up.railway.app",
+        )
+        assert sulci._GATEWAY_BASE == (
+            "https://gateway-production-de5c.up.railway.app"
+        )
+        assert sulci._TELEMETRY_URL == (
+            "https://gateway-production-de5c.up.railway.app/v1/telemetry"
+        )
+
+    def test_trailing_slash_normalized(self, monkeypatch):
+        """``rstrip('/')`` on _GATEWAY_BASE prevents double-slash in URL."""
+        sulci = _reimport_sulci(monkeypatch, gateway_value="https://staging.example.com/")
+        assert sulci._GATEWAY_BASE  == "https://staging.example.com"
+        assert sulci._TELEMETRY_URL == "https://staging.example.com/v1/telemetry"
+
+    def test_localhost_for_local_dev(self, monkeypatch):
+        sulci = _reimport_sulci(monkeypatch, gateway_value="http://localhost:8080")
+        assert sulci._TELEMETRY_URL == "http://localhost:8080/v1/telemetry"
+
+
+class TestPostHonorsResolvedUrl:
+    """End-to-end on the function that actually moves bytes."""
+
+    def test_post_sends_to_overridden_url(self, monkeypatch):
+        sulci = _reimport_sulci(
+            monkeypatch,
+            gateway_value="https://staging.example.com",
+        )
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+
+        # _post() does `import httpx` lazily inside the function body,
+        # so patching `httpx.post` in the global namespace is what
+        # _post() will see.
+        with patch("httpx.post") as mock_post:
+            sulci._post({
+                "event":          "cache.get",
+                "ts":             0.0,
+                "fingerprint":    "f" * 24,
+                "sdk_version":    sulci.__version__,
+                "backend":        "sqlite",
+                "hits":           1,
+                "misses":         0,
+                "avg_latency_ms": 0.74,
+            })
+
+        mock_post.assert_called_once()
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "https://staging.example.com/v1/telemetry"
+
+    def test_post_uses_default_when_env_unset(self, monkeypatch):
+        sulci = _reimport_sulci(monkeypatch, gateway_value=None)
+        sulci._api_key           = "sk-sulci-test"
+        sulci._telemetry_enabled = True
+
+        with patch("httpx.post") as mock_post:
+            sulci._post({
+                "event":       "startup",
+                "ts":          0.0,
+                "fingerprint": "f" * 24,
+                "sdk_version": sulci.__version__,
+                "backend":     "",
+            })
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "https://api.sulci.io/v1/telemetry"


### PR DESCRIPTION
# v0.5.5: telemetry honors `SULCI_GATEWAY`

Closes #51 (the issue this PR fixes).
Unblocks [sulci-platform LAUNCH-PLAN row C2e](https://github.com/sulci-io/sulci-platform/blob/main/docs/LAUNCH-PLAN.md).

## What

`_TELEMETRY_URL` is now derived from `_GATEWAY_BASE` instead of being a separate hardcoded literal. A single `SULCI_GATEWAY` env var now redirects both the v0.6.0 device-code flow and the v0.5.x telemetry pipeline — matching what the in-source comment has been claiming since v0.5.0.

```diff
-_TELEMETRY_URL = "https://api.sulci.io/v1/telemetry"
-_SDK_VERSION   = __version__
-_FLUSH_INTERVAL_SECONDS = 30
-
-# Gateway base URL — read once at import time. Production points at
-# api.sulci.io; staging/local-dev override via SULCI_GATEWAY.
-# ...
-_GATEWAY_BASE = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+# Gateway base URL — read once at import time. Production points at
+# api.sulci.io; staging/local-dev override via SULCI_GATEWAY.
+# ...
+# v0.5.5 fix (#51): _TELEMETRY_URL is now derived from _GATEWAY_BASE.
+_GATEWAY_BASE  = os.environ.get("SULCI_GATEWAY", "https://api.sulci.io").rstrip("/")
+_TELEMETRY_URL = f"{_GATEWAY_BASE}/v1/telemetry"
+_SDK_VERSION   = __version__
+_FLUSH_INTERVAL_SECONDS = 30
```

Plus one docstring fix at `_flush()` (line 275) so it no longer claims POSTs go to `api.sulci.io` specifically.

## Why now

C2e in the platform's launch plan is `pip install sulci==0.5.4 → sulci.connect(...) → cache.get() → check /v1/analytics/deployments on Railway gateway`. The Railway gateway is at `gateway-production-de5c.up.railway.app`; `api.sulci.io` doesn't route there until Phase F (DNS cutover, A11). So C2e needs `SULCI_GATEWAY` to redirect telemetry — which v0.5.4 silently doesn't.

The D7 verification (sulci-platform MASTER-TRACKER row #99) didn't catch this because it exercised only the device-code path (D4 → D4.5 → D5), which already honored `_GATEWAY_BASE`. No cache/telemetry calls happened post-D5 in that run, so the gap stayed hidden.

## Backward compatibility

Default URL is unchanged. Callers who don't set `SULCI_GATEWAY` see exactly the same behavior:
```
_TELEMETRY_URL == "https://api.sulci.io/v1/telemetry"   # before and after
```
No public API change. No wire-format change. No new dependency.

## Tests

**New file:** `tests/test_telemetry_gateway_override.py` — 6 tests:

| Test | Asserts |
|---|---|
| `test_default_when_env_unset` | env unset → both constants resolve to `api.sulci.io` |
| `test_env_redirects_both_constants` | `SULCI_GATEWAY=https://staging...` → both follow |
| `test_trailing_slash_normalized` | `SULCI_GATEWAY=https://x.com/` → no double-slash in URL |
| `test_localhost_for_local_dev` | `SULCI_GATEWAY=http://localhost:8080` works |
| `test_post_sends_to_overridden_url` | `_post()` actually POSTs to the resolved URL (mocks `httpx.post`) |
| `test_post_uses_default_when_env_unset` | `_post()` defaults to `api.sulci.io` |

The tests use `importlib` + `sys.modules` purging because both constants are computed at module import time.

**Existing tests:** `pytest tests/test_telemetry.py -v` → 28 passed. No regressions in fingerprint, wire-contract, privacy-invariant, or `_flush()` payload-shape coverage.

## Docs

- **`README.md`** — v0.5.5 additions section (sibling to v0.5.4 / v0.5.3 / v0.5.2). Also fixes the misleading `SULCI_GATEWAY` bullet that's been overpromising since v0.5.0 ("drives both telemetry and the device-code client" — only true v0.5.5+; explicitly version-qualified now).
- **`LOCAL_SETUP.md`** — Step 9 gains an inline v0.5.0–v0.5.4 caveat on the existing `SULCI_GATEWAY=http://localhost:8000` example, plus a new `### v0.5.5 — staging-gateway redirect for telemetry` sub-section with a quick-verification one-liner and an end-to-end staging-smoke walkthrough that mirrors LAUNCH-PLAN row C2e. New test file is also called out under "Run only the connect tests".

## Out of scope

`sulci/backends/cloud.py` has a similar shape — `CLOUD_URL = "https://api.sulci.io"` only honors a programmatic `gateway_url=` constructor arg, not the env var. Filing as a separate issue (`#TBD-2`) so this PR stays single-purpose and reviewer-friendly. C2e doesn't exercise the cloud backend; this PR is sufficient to unblock it.

## Release plan

1. Merge this PR to `main`.
2. Tag `v0.5.5` and let `publish.yml` push to PyPI.
3. Wait ~2 minutes for PyPI to publish.
4. Run C2e against staging:
   ```bash
   SULCI_GATEWAY=https://gateway-production-de5c.up.railway.app \
     pip install --upgrade sulci==0.5.5
   # then the smoke script — see sulci-platform/docs/LAUNCH-PLAN.md row C2e
   ```

## Checklist

- [x] Tests added (6 new, all passing locally)
- [x] Existing tests still pass (28/28)
- [x] CHANGELOG entry under v0.5.5 → **Fixed**
- [x] Version bumped: `pyproject.toml` 0.5.4 → 0.5.5
- [x] In-source comment updated to no longer overstate previous reach
- [x] README v0.5.5 additions section + version-qualified the misleading `SULCI_GATEWAY` bullet
- [x] LOCAL_SETUP Step 9 updated with v0.5.5 sub-section + caveat on the v0.5.3 example
- [x] No public API change (verified — `__all__` unchanged)
- [x] Backward-compatible default behavior (verified by `test_default_when_env_unset`)
