### PR TITLE
fix(#36): add plan field to CacheEvent for billing-stream attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,95 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.6] — 2026-05-08 — `plan` field on `CacheEvent` (sulci-oss #36)
+
+Additive field on the v0.5.0 `CacheEvent` dataclass plus a matching
+keyword argument on `Cache.get` / `Cache.set` / `Cache.cached_call`,
+so callers who know a tenant's plan tier at emit time can attribute
+it onto the event without monkey-patching the dataclass or doing a
+join at consume time. Backward-compatible per ADR 0005's
+"additive kwarg with default" rule — pre-0.5.6 callers see no
+behavior change; emitted events default to `plan=None`.
+
+### Added
+
+- **`CacheEvent.plan: Optional[str] = None`** (#36). New field on the
+  privacy-firewalled event surface, sitting alongside `tenant_id`.
+  Carries the customer plan tier (`'free' | 'pro' | 'business' |
+  'enterprise' | 'oss_connect'`) when the caller knows it. Defaults
+  to `None` so users of the OSS library who don't have plan context
+  don't have to thread anything through.
+
+- **`plan: Optional[str] = None`** added as a keyword-only argument
+  to `Cache.get`, `Cache.set`, and `Cache.cached_call`. When supplied,
+  it is forwarded onto the emitted `CacheEvent.plan`. `cached_call`
+  threads it through both its internal `.get()` and `.set()` calls so
+  the miss-then-set path emits two events that both carry plan.
+
+- **`"plan"` added to `_ALLOWED_FIELDS`** in `sulci/sinks/telemetry.py`
+  so it survives the privacy firewall and reaches `TelemetrySink` /
+  `RedisStreamSink` consumers. The allowlist's docstring now
+  articulates the three-criteria rule for future additions: a candidate
+  field must be (a) low-cardinality, (b) already known to the
+  recipient via auth context, and (c) explicitly billing- or
+  routing-relevant. `plan` satisfies all three.
+
+### Why
+
+The sulci-platform billing pipeline reads cache events from a Redis
+stream and routes them by tenant + plan. Pre-0.5.6, `CacheEvent` had
+no plan field, so the gateway emitted events with `plan` recoverable
+only by joining each event back to Postgres at consume time. That
+join was painful enough that two real-world E2E tests in the platform
+(`test_09_billing_events_have_correct_tenant_and_plan` and
+`test_j09_billing_events_carry_pro_plan`) had been failing for weeks
+with `[None, None, None, None, None]`, eating a per-PR bypass-note
+tax on every backend-touching change. Carrying plan on the event
+closes that gap and lets the gate run clean.
+
+### Tests
+
+- `tests/test_core.py::TestCacheEventPlan` (6 tests). Recording-sink
+  fixture verifies `plan` flows from `Cache.get` / `.set` / `.cached_call`
+  onto the emitted `CacheEvent`, that the default-`None` path is
+  unchanged for pre-0.5.6 callers, and that `plan` is keyword-only
+  with default `None` on all three methods (pinning the API shape
+  the same way `tenant_id` / `user_id` / `session_id` are pinned).
+
+- `tests/test_sinks.py` — `TestAllowlist::test_allowlist_contents_are_stable`
+  extended to include `"plan"`. Two new scrubbing tests verify
+  `plan="pro"` and `plan=None` both round-trip through `_scrub`. The
+  canonical `sample_event` fixture now sets `plan="pro"` so all
+  existing scrub-loop tests cover the new field implicitly.
+
+### Privacy review note
+
+Adding any field to `_ALLOWED_FIELDS` is a privacy-relevant change.
+`plan` was reviewed against the rule the docstring now documents:
+
+| Criterion                                     | `plan` satisfies? |
+| --------------------------------------------- | ----------------- |
+| Low-cardinality (closed enum, ~5 values)      | yes               |
+| Already known to recipient via auth context   | yes               |
+| Explicitly billing- or routing-relevant       | yes               |
+
+Adding `plan` doesn't expose anything the receiving service didn't
+already know; it removes a join. The cardinality is bounded; there
+is no PII or free-form content carried.
+
+### Compatibility
+
+- Existing callers (no `plan` kwarg): emit `plan=None`, identical to
+  pre-0.5.6 behavior on the wire.
+- Older sinks that don't know about the new field: `_scrub` is built
+  on `dataclasses.asdict`, so missing the field on an old struct is
+  impossible — the field exists on every `CacheEvent` instance from
+  this version forward.
+- Custom `EventSink` implementations: receive `event.plan` like any
+  other field; no breaking change to the sink API.
+
+---
+
 ## [0.5.5] — 2026-05-07 — telemetry honors `SULCI_GATEWAY` (PR-D)
 
 One-line behavior fix that unblocks staging-gateway smoke tests for the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.5"
+version = "0.5.6"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -347,6 +347,7 @@ class Cache:
         tenant_id:  Optional[str] = None,
         user_id:    Optional[str] = None,
         session_id: Optional[str] = None,
+        plan:       Optional[str] = None,
     ) -> tuple:
         """
         Check cache for a semantically similar query.
@@ -354,6 +355,16 @@ class Cache:
         When ``session_id`` is set and ``context_window > 0``, the lookup
         uses a context-blended embedding so ambiguous queries resolve
         correctly within the current conversation.
+
+        Args:
+            query:      The query string to look up.
+            tenant_id:  Optional tenant identifier for multi-tenant isolation.
+            user_id:    Optional user identifier for personalization.
+            session_id: Optional session identifier for context-aware lookup.
+            plan:       Optional customer plan tier (e.g. 'free', 'pro').
+                        Forwarded onto emitted CacheEvent.plan so downstream
+                        billing/analytics can route by plan without a join.
+                        v0.5.6 (sulci-oss #36); see sinks/protocol.py.
 
         Returns:
             (cached_response, similarity_score, context_depth)
@@ -413,6 +424,7 @@ class Cache:
                 latency_ms      = int(latency_ms),
                 context_depth   = depth,
                 timestamp       = _time.time(),
+                plan            = plan,
             ))
         except Exception:
             # Sink failures must not break Cache calls
@@ -429,6 +441,7 @@ class Cache:
         user_id:    Optional[str]  = None,
         session_id: Optional[str]  = None,
         metadata:   Optional[dict] = None,
+        plan:       Optional[str]  = None,
     ) -> None:
         """
         Store a query-response pair in the cache.
@@ -439,6 +452,9 @@ class Cache:
 
         When ``session_id`` is provided, the turn is also recorded in
         the session window to inform future context-blended lookups.
+
+        ``plan`` (v0.5.6, sulci-oss #36) is forwarded onto the emitted
+        CacheEvent.plan; see ``Cache.get`` for the rationale.
         """
         _t0     = _time.time()
         raw_vec = self._embedder.embed(query)
@@ -488,6 +504,7 @@ class Cache:
                 backend_id      = self.backend,
                 embedding_model = self.embedding_model,
                 timestamp       = time.time(),
+                plan            = plan,
             ))
         except Exception:
             pass
@@ -501,6 +518,7 @@ class Cache:
         user_id:       Optional[str] = None,
         session_id:    Optional[str] = None,
         cost_per_call: float         = 0.005,
+        plan:          Optional[str] = None,
         **llm_kwargs:  Any,
     ) -> dict:
         """
@@ -517,6 +535,9 @@ class Cache:
             user_id:       For personalized per-user caching.
             session_id:    Conversation ID — enables context-aware lookup.
             cost_per_call: Estimated LLM cost per call (for savings stats).
+            plan:          Optional customer plan tier; forwarded onto
+                           the underlying .get/.set calls and thence onto
+                           emitted CacheEvent.plan. v0.5.6 (sulci-oss #36).
             **llm_kwargs:  Forwarded to llm_fn on cache miss.
 
         Returns:
@@ -530,7 +551,7 @@ class Cache:
             }
         """
         t0              = time.perf_counter()
-        hit, sim, depth = self.get(query, tenant_id=tenant_id, user_id=user_id, session_id=session_id)
+        hit, sim, depth = self.get(query, tenant_id=tenant_id, user_id=user_id, session_id=session_id, plan=plan)
         ms              = (time.perf_counter() - t0) * 1000
 
         if hit is not None:
@@ -552,7 +573,7 @@ class Cache:
             }
 
         response = llm_fn(query, **llm_kwargs)
-        self.set(query, response, tenant_id=tenant_id, user_id=user_id, session_id=session_id)
+        self.set(query, response, tenant_id=tenant_id, user_id=user_id, session_id=session_id, plan=plan)
         ms = (time.perf_counter() - t0) * 1000
         # _stats["misses"] is incremented inside .get() above — see #42.
         return {

--- a/sulci/sinks/protocol.py
+++ b/sulci/sinks/protocol.py
@@ -30,6 +30,22 @@ class CacheEvent:
     latency_ms: Optional[int] = None            # for 'hit' and 'miss'
     context_depth: int = 0                      # number of session turns consulted
     timestamp: Optional[float] = None           # unix timestamp
+    # ── v0.5.6 addition (sulci-oss issue #36) ──
+    # Customer plan tier ('free' | 'pro' | 'business' | 'enterprise' |
+    # 'oss_connect'). Populated by callers who know the tenant's plan
+    # at emit time (sulci-platform's gateway passes it from the auth
+    # lookup); defaults to None for users of the OSS library who don't
+    # have plan context. Added per ADR 0005's "additive kwarg with
+    # backward-compatible default" rule — pre-0.5.6 callers see no
+    # behavior change.
+    #
+    # Why the field exists: the sulci-platform billing pipeline reads
+    # cache events from a Redis stream and routes them by tenant +
+    # plan. Without this field, plan attribution required a separate
+    # Postgres lookup per event, which created a join-at-consume-time
+    # burden that two realworld E2E tests caught (test_09 / test_j09).
+    # Carrying plan on the event closes that gap.
+    plan: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)   # extension point
 
 

--- a/sulci/sinks/telemetry.py
+++ b/sulci/sinks/telemetry.py
@@ -26,6 +26,27 @@ log = logging.getLogger(__name__)
 # ----------------------------------------------------------------------
 # PRIVACY-CRITICAL: the only fields ever shipped to external endpoints.
 # Modifying this list requires explicit review; changes could leak data.
+#
+# Rule for adding fields: a candidate must satisfy ALL THREE criteria
+# before it goes in this list. The rule was articulated when `plan` was
+# added in v0.5.6 and is meant to keep this list from drifting toward
+# "anything we find useful":
+#
+#   (a) LOW CARDINALITY — the field's domain is small and bounded
+#       (e.g. an enum, a tier label, a country code). Free-text fields
+#       must NEVER be added; they're indistinguishable from arbitrary
+#       user content.
+#
+#   (b) ALREADY KNOWN TO THE RECIPIENT — the receiving service can
+#       independently derive the value from the auth context it already
+#       has. Adding the field doesn't expose anything the recipient
+#       didn't already know; it just removes a join.
+#
+#   (c) EXPLICITLY BILLING- OR ROUTING-RELEVANT — the field exists
+#       because a downstream consumer needs it for billing attribution,
+#       routing, or rate-limiting. Fields that are merely "nice to
+#       have for analytics" are not enough; they belong in the
+#       customer's own metadata sink, not the privacy-firewalled one.
 # ----------------------------------------------------------------------
 _ALLOWED_FIELDS = frozenset([
     "event_type",
@@ -38,6 +59,13 @@ _ALLOWED_FIELDS = frozenset([
     "latency_ms",
     "context_depth",
     "timestamp",
+    # v0.5.6 — sulci-oss #36. Customer plan tier (free / pro / business /
+    # enterprise / oss_connect). Satisfies all three rules above:
+    # (a) closed enum of ~5 values; (b) recipient already knows the
+    # plan from the API key auth lookup; (c) sulci-platform's billing
+    # pipeline routes events by plan and was previously doing a
+    # per-event Postgres join to recover this.
+    "plan",
 ])
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -369,3 +369,120 @@ class TestTenantId:
                     f"Cache.{method_name}.{partition_kw} must default to None, "
                     f"got {p.default!r}"
                 )
+
+# ─────────────────────────────────────────────────────────────────────
+# v0.5.6 — sulci-oss issue #36: plan attribution on CacheEvent
+# ─────────────────────────────────────────────────────────────────────
+
+
+class _RecordingSink:
+    """Test double that captures every CacheEvent emitted to it.
+
+    Not a MagicMock so the dataclass round-trip is real and field
+    access mirrors what RedisStreamSink / TelemetrySink will see.
+    """
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture
+def recording_cache(tmp_path):
+    """Fresh SQLite-backed Cache with a recording sink wired in."""
+    sink = _RecordingSink()
+    cache = Cache(
+        backend         = "sqlite",
+        threshold       = 0.85,
+        embedding_model = "minilm",
+        ttl_seconds     = None,
+        db_path         = str(tmp_path / "test_db"),
+        event_sink      = sink,
+    )
+    return cache, sink
+
+
+class TestCacheEventPlan:
+    """The fix for sulci-oss #36 / sulci-platform #49.
+
+    Pre-0.5.6 the gateway had no way to attribute billing-stream events
+    to a plan tier; events landed in Redis with plan=None and downstream
+    consumers had to do a per-event Postgres join to recover the plan.
+    These tests pin the new contract.
+    """
+
+    def test_get_passes_plan_to_event(self, recording_cache):
+        cache, sink = recording_cache
+        cache.get("any query", tenant_id="t-1", plan="pro")
+        assert len(sink.events) == 1
+        assert sink.events[0].plan == "pro"
+        # Sanity: existing fields still flow.
+        assert sink.events[0].tenant_id == "t-1"
+        assert sink.events[0].event_type == "miss"  # nothing stored yet
+
+    def test_set_passes_plan_to_event(self, recording_cache):
+        cache, sink = recording_cache
+        cache.set("q", "r", tenant_id="t-1", plan="business")
+        assert len(sink.events) == 1
+        assert sink.events[0].plan == "business"
+        assert sink.events[0].event_type == "set"
+
+    def test_get_without_plan_emits_none(self, recording_cache):
+        """Backward compat: callers who don't pass plan see plan=None.
+
+        This is the shape every pre-0.5.6 caller was running with;
+        it must keep working unchanged.
+        """
+        cache, sink = recording_cache
+        cache.get("any query", tenant_id="t-1")
+        assert len(sink.events) == 1
+        assert sink.events[0].plan is None
+
+    def test_set_without_plan_emits_none(self, recording_cache):
+        cache, sink = recording_cache
+        cache.set("q", "r", tenant_id="t-1")
+        assert sink.events[-1].plan is None
+
+    def test_cached_call_threads_plan_through_get_and_set(self, recording_cache):
+        """cached_call delegates to .get() and (on miss) .set().
+
+        Both emitted events must carry the plan from the cached_call
+        invocation; otherwise gateway code that uses cached_call would
+        still leak plan=None into the stream on miss-then-set paths.
+        """
+        cache, sink = recording_cache
+
+        def stub_llm(query, **_):
+            return "fake llm response"
+
+        cache.cached_call("fresh query", stub_llm, tenant_id="t-1", plan="enterprise")
+
+        # cached_call goes through .get (emits 'miss') then .set (emits 'set').
+        # Both must carry plan='enterprise'.
+        assert len(sink.events) == 2
+        assert all(e.plan == "enterprise" for e in sink.events), \
+            f"cached_call leaked plan: {[e.plan for e in sink.events]}"
+
+    def test_plan_is_keyword_only_on_get_set_cached_call(self):
+        """Lock plan as KEYWORD_ONLY with default None on all three methods.
+
+        Mirrors the existing keyword-only enforcement for
+        tenant_id/user_id/session_id (see
+        TestTenantId.test_cache_signatures_have_keyword_only_partition_kwargs),
+        so a future refactor can't silently drop ``*,`` and let plan
+        slip into positional territory.
+        """
+        import inspect
+        for method_name in ("get", "set", "cached_call"):
+            sig = inspect.signature(getattr(Cache, method_name))
+            p = sig.parameters["plan"]
+            assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"Cache.{method_name}.plan must be KEYWORD_ONLY, got {p.kind}"
+            )
+            assert p.default is None, (
+                f"Cache.{method_name}.plan must default to None, got {p.default!r}"
+            )

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -25,6 +25,7 @@ def sample_event():
         latency_ms=15,
         context_depth=2,
         timestamp=1_700_000_000.0,
+        plan="pro",
         metadata={"custom": "data"},
     )
 
@@ -38,6 +39,9 @@ class TestAllowlist:
             "event_type", "tenant_id", "user_id", "session_id",
             "backend_id", "embedding_model", "similarity", "latency_ms",
             "context_depth", "timestamp",
+            # v0.5.6 — sulci-oss #36. See sinks/telemetry.py for the
+            # three-criteria rule that gates additions to this list.
+            "plan",
         ])
 
     def test_metadata_dict_is_not_in_allowlist(self):
@@ -61,6 +65,21 @@ class TestAllowlist:
         scrubbed = _scrub(event)
         allowed = set(_ALLOWED_FIELDS)
         assert set(scrubbed.keys()) <= allowed
+
+    # ── v0.5.6 (sulci-oss #36) — plan field flows through scrubbing ──
+
+    def test_scrub_preserves_plan_when_set(self):
+        """plan='pro' on the event must reach scrubbed output verbatim."""
+        event = CacheEvent(event_type="hit", plan="pro")
+        scrubbed = _scrub(event)
+        assert scrubbed["plan"] == "pro"
+
+    def test_scrub_preserves_plan_when_none(self):
+        """plan=None (the default) must come through as None — backward-compat."""
+        event = CacheEvent(event_type="hit")
+        scrubbed = _scrub(event)
+        assert "plan" in scrubbed
+        assert scrubbed["plan"] is None
 
 
 class TestNullSink:


### PR DESCRIPTION
Pre-0.5.6 CacheEvent had no `plan` field. The sulci-platform billing
pipeline reads cache events from a Redis stream and routes by tenant
+ plan; without the field, plan attribution required a per-event
Postgres join that two real-world E2E tests in the platform
(test_09_billing_events_have_correct_tenant_and_plan and
test_j09_billing_events_carry_pro_plan) had been failing on for weeks
with [None, None, None, None, None].

This PR adds plan as a backward-compatible Optional field per
ADR 0005's "additive kwarg with default" rule:

  - sulci/sinks/protocol.py: CacheEvent gains
    `plan: Optional[str] = None` before the metadata field.

  - sulci/sinks/telemetry.py: "plan" added to _ALLOWED_FIELDS.
    Allowlist docstring now documents the three-criteria rule for
    additions (low cardinality / recipient already knows /
    billing-relevant); plan satisfies all three.

  - sulci/core.py: Cache.get / .set / .cached_call gain
    `plan: Optional[str] = None` as KEYWORD_ONLY argument.
    cached_call threads it through both delegated calls.
    Cache.clear() does NOT carry plan — instance-wide wipe with
    no per-call plan context.

  - tests/test_sinks.py: allowlist pin extended; 2 new scrub
    tests; sample_event fixture sets plan="pro".

  - tests/test_core.py: new TestCacheEventPlan class (6 tests).
    Recording-sink fixture verifies plan flows from get/set/
    cached_call onto CacheEvent, plus kwarg-only enforcement
    mirroring the existing tenant_id/user_id/session_id pin.

  - pyproject.toml: 0.5.5 → 0.5.6
  - CHANGELOG.md: new [0.5.6] entry with privacy review.

Closes #36

Verified locally:
- pytest tests/test_sinks.py -v: 20 passed (was 18 — 2 new plan tests)
- pytest tests/test_core.py -v: 41 passed (was 35 — 6 new plan tests)
- pytest tests/ -q: 452 passed, 35 skipped (full suite, ~4m13s)

Backward-compat: pre-0.5.6 callers (no plan kwarg) emit
plan=None, identical to current on-the-wire behavior. The
platform-side fix (sulci-platform #49) ships in a paired PR there.
