### PR TITLE
fix(cloud): POST to /v1/cache/{get,set} instead of /v1/get and /v1/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.5.7] — 2026-05-10 — Fix cloud backend URL paths (sulci-oss P0)
+
+Three-string fix to `sulci/backends/cloud.py` aligning the SDK's request
+URLs with the gateway's canonical paths. Pre-0.5.7, the cloud backend
+POSTed to `/v1/get` and `/v1/set`; the gateway has always exposed
+`/v1/cache/get` and `/v1/cache/set`. Every request returned 404, the
+SDK's outer `except Exception:` clause swallowed it, and `cache.get()`
+returned `(None, 0.0)` — a silent dataplane failure across the entire
+managed-cloud tier. Users saw "sulci doesn't seem to be caching anything"
+with nothing in their logs to investigate.
+
+### Fixed
+
+- **`SulciCloudBackend.search()`** (`cloud.py:101`) now POSTs to
+  `/v1/cache/get` rather than `/v1/get`.
+
+- **`SulciCloudBackend.store()`** (`cloud.py:150`) now POSTs to
+  `/v1/cache/set` rather than `/v1/set`.
+
+- **`SulciCloudBackend.upsert()`** (`cloud.py:179`) now POSTs to
+  `/v1/cache/set` rather than `/v1/set`. The delete path at `cloud.py:201`
+  already used `/v1/cache` and was unaffected.
+
+### Added
+
+- **`TestCanonicalGatewayPaths`** in `tests/test_cloud_backend.py`. Four
+  assertions pinning each URL-bearing method (`search`, `store`, `upsert`)
+  to the gateway's canonical path, plus a static-source check that catches
+  the regression case where a new method is added but the URL prefix is
+  forgotten. The class header documents the gateway-side source of truth
+  (`gateway/app/main.py` for the prefix, `gateway/app/routes/cache.py` for
+  the route decorators) so the contract is auditable from the test file.
+
+### Changed
+
+- **`TestSearch.test_sends_correct_payload`** previously asserted
+  `call_args[0][0] == "/v1/get"`, tautologically locking in the bug. Now
+  asserts `"/v1/cache/get"`. The stale docstring on
+  `TestUpsert.test_sends_correct_payload` was also corrected.
+
+### Why this slipped past CI
+
+The pre-0.5.7 unit test asserted the SDK was POSTing to `/v1/get` and was
+passing because the SDK was, in fact, POSTing to `/v1/get`. The test
+verified the wrong contract — what the SDK *did*, rather than what the
+gateway *expected*. The new `TestCanonicalGatewayPaths` class encodes the
+gateway-side contract as a comment block and asserts against it directly,
+so a future drift on either side is caught at the test boundary rather
+than via production telemetry.
+
+### Compatibility
+
+Strictly a bugfix. No public API changes, no payload shape changes, no
+new dependencies. Any caller that was getting silent `(None, 0.0)` cache
+misses against the live gateway will now actually hit the cache.
+
+---
+
 ## [0.5.6] — 2026-05-08 — `plan` field on `CacheEvent` (sulci-oss #36)
 
 Additive field on the v0.5.0 `CacheEvent` dataclass plus a matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.6"
+version = "0.5.7"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -98,7 +98,7 @@ class SulciCloudBackend:
         """
         try:
             resp = self._client.post(
-                "/v1/get",
+                "/v1/cache/get",
                 json={
                     "embedding": embedding,
                     "threshold": threshold,
@@ -147,7 +147,7 @@ class SulciCloudBackend:
             ttl_seconds = max(0, int(expires - _time.time()))
         try:
             self._client.post(
-                "/v1/set",
+                "/v1/cache/set",
                 json={
                     "key":         key,
                     "embedding":   embedding,
@@ -176,7 +176,7 @@ class SulciCloudBackend:
         """
         try:
             self._client.post(
-                "/v1/set",
+                "/v1/cache/set",
                 json={
                     "embedding":   embedding,
                     "query":       query,

--- a/tests/test_cloud_backend.py
+++ b/tests/test_cloud_backend.py
@@ -178,7 +178,7 @@ class TestSearch:
                 user_id="user-42",
             )
         call_kwargs = mock_post.call_args
-        assert call_kwargs[0][0] == "/v1/get"
+        assert call_kwargs[0][0] == "/v1/cache/get"
         body = call_kwargs[1]["json"]
         assert body["threshold"] == 0.85
         assert body["user_id"]   == "user-42"
@@ -204,7 +204,7 @@ class TestSearch:
 class TestUpsert:
 
     def test_sends_correct_payload(self):
-        """upsert() sends embedding, query, response, user_id to /v1/set."""
+        """upsert() sends embedding, query, response, user_id to /v1/cache/set."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"status": "ok"})
@@ -336,3 +336,85 @@ class TestCacheWiring:
         from sulci import Cache
         with pytest.raises(ValueError, match="Unknown backend"):
             Cache(backend="nonexistent")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Canonical gateway paths — regression guard for the v0.5.7 route fix
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# The gateway mounts its cache router at prefix "/v1" and declares the routes
+# as @router.post("/cache/get") and @router.post("/cache/set"), resolving to
+# the canonical URLs:
+#
+#     POST /v1/cache/get
+#     POST /v1/cache/set
+#
+# Source of truth on the platform side:
+#     sulci-platform/gateway/app/main.py          (router include + prefix)
+#     sulci-platform/gateway/app/routes/cache.py  (@router.post decorators)
+#
+# Prior to v0.5.7 the SDK POSTed to "/v1/get" and "/v1/set" — a silent 404
+# swallowed by cloud.py's `except Exception:` clause. These assertions pin the
+# SDK's three URL-bearing methods to the gateway's canonical paths so a future
+# drift on either side gets caught here rather than in production telemetry.
+
+class TestCanonicalGatewayPaths:
+    """Each URL-bearing method must POST to the gateway's canonical path."""
+
+    def test_search_posts_to_v1_cache_get(self):
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({"response": None,
+                                                      "similarity": 0.0})
+                          ) as mock_post:
+            b.search(embedding=[0.0] * 384, threshold=0.85)
+        assert mock_post.call_args[0][0] == "/v1/cache/get", (
+            "search() must POST to /v1/cache/get — gateway exposes that "
+            "canonical path; /v1/get returns 404 and is swallowed silently."
+        )
+
+    def test_store_posts_to_v1_cache_set(self):
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({"status": "ok"})
+                          ) as mock_post:
+            b.store(
+                key       = "abc123",
+                embedding = [0.0] * 384,
+                query     = "hello",
+                response  = "world",
+                metadata  = {"k": "v"},
+            )
+        assert mock_post.call_args[0][0] == "/v1/cache/set", (
+            "store() must POST to /v1/cache/set — gateway exposes that "
+            "canonical path; /v1/set returns 404 and is swallowed silently."
+        )
+
+    def test_upsert_posts_to_v1_cache_set(self):
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({"status": "ok"})
+                          ) as mock_post:
+            b.upsert(
+                embedding = [0.0] * 384,
+                query     = "hello",
+                response  = "world",
+            )
+        assert mock_post.call_args[0][0] == "/v1/cache/set", (
+            "upsert() must POST to /v1/cache/set — gateway exposes that "
+            "canonical path; /v1/set returns 404 and is swallowed silently."
+        )
+
+    def test_no_legacy_paths_in_source(self):
+        """Static check: the SDK source contains zero references to the
+        pre-v0.5.7 paths /v1/get or /v1/set. This catches regressions where
+        a new method is added but the URL prefix is forgotten."""
+        import sulci.backends.cloud as cloud_mod
+        from pathlib import Path
+        src = Path(cloud_mod.__file__).read_text()
+        assert '"/v1/get"' not in src and "'/v1/get'" not in src, (
+            "cloud.py contains legacy '/v1/get' — gateway exposes /v1/cache/get"
+        )
+        assert '"/v1/set"' not in src and "'/v1/set'" not in src, (
+            "cloud.py contains legacy '/v1/set' — gateway exposes /v1/cache/set"
+        )


### PR DESCRIPTION
Closes #57.

## What

Three string replacements in `sulci/backends/cloud.py` aligning the
cloud backend's request URLs with the gateway's canonical paths.

| Location | Before | After |
|---|---|---|
| `cloud.py:101` `search()` | `POST /v1/get` | `POST /v1/cache/get` |
| `cloud.py:150` `store()`  | `POST /v1/set` | `POST /v1/cache/set` |
| `cloud.py:179` `upsert()` | `POST /v1/set` | `POST /v1/cache/set` |

## Why this slipped past CI

The pre-existing `TestSearch.test_sends_correct_payload` asserted
`call_args[0][0] == "/v1/get"` — verifying what the SDK did rather
than what the gateway expected. The new `TestCanonicalGatewayPaths`
class encodes the gateway-side contract (with explicit references
to `gateway/app/main.py` and `gateway/app/routes/cache.py` in the
class docstring) and asserts against it directly.

## Test plan

- `tests/test_cloud_backend.py` — 32 passing locally, 26 passing in the
  sandbox (the 6 `TestCacheWiring` failures there were `huggingface.co`
  network blocks; CI has the model cached and runs all 32 green).
- New `TestCanonicalGatewayPaths` — 4 passing, including a
  static-source check that scans `cloud.py` for leftover `/v1/get` /
  `/v1/set` references.
- External verification: `sulci_flows/examples/flow_2_routemismatch.py`
  auto-flips from exit 1 → exit 0 against the patched SDK.
- Full repo test suite — 456 passed, 35 skipped, 0 failed.
- `make verify` — all four smoke tests pass (core, langchain, llamaindex, async).

## Out of scope (tracked separately)

- The quota-gate bypass on `/v1/cache/*` for non-free plans →
  sulci-io/sulci-platform#102. Masked by this bug until v0.5.7
  ships; load-bearing afterwards.

## Compatibility

Strictly a bugfix. No public API changes, no payload shape changes, no
new dependencies. Any caller currently getting silent `(None, 0.0)`
cache misses against the live gateway will start hitting the cache.