### PR TITLE
feat: Cache.__init__ accepts native Embedder + Backend instances (#34 C1c+C1d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+> v0.6.0 work-in-progress. Three coordinated PRs under sulci-oss umbrella
+> [#63](https://github.com/sulci-io/sulci-oss/issues/63) — bringing
+> sulci-oss into compliance with canonical architecture v3. Each PR
+> appends to this section; the release PR consolidates and renames it
+> to `## [0.6.0]`.
+
+### Added
+
+- `Cache.__init__` now accepts pre-constructed `Embedder` and `Backend`
+  protocol instances on the existing `embedding_model=` and `backend=`
+  parameters. Previously these accepted only string identifiers
+  (`"minilm"`, `"qdrant"`, etc.); injecting custom or platform-managed
+  instances required subclassing `Cache` and overriding
+  `_load_embedder` / `_load_backend` — the workaround the platform
+  ships today as `LibraryBackedCache(sulci.Cache)`. After this change,
+  `Cache(embedding_model=my_embedder, backend=my_backend)` works
+  natively, and the subclass workaround can retire. Closes sulci-oss
+  #34 sub-issues C1c (Embedder instance injection) and C1d (Backend
+  instance injection).
+
+### Changed
+
+- Type signatures loosened on two `Cache.__init__` parameters:
+  `backend: str` → `backend: Union[str, Backend]` and
+  `embedding_model: str` → `embedding_model: Union[str, Embedder]`.
+  Fully backward-compatible — every existing string-based caller works
+  unchanged. The `_load_embedder` / `_load_backend` dispatchers gained
+  an `isinstance(x, str)` short-circuit at the top; non-string inputs
+  are returned as-is.
+
+### Tests
+
+- New `TestInstanceInjection` class in `tests/test_core.py` (7 tests)
+  covers: instance pass-through identity, mixed string+instance kwargs,
+  string-path regression (mocked MiniLM to keep offline-runnable),
+  end-to-end `embed()` / `search()` / `store()` round-trips proving
+  injected instances are actually used by `Cache.get` / `Cache.set`.
+
+---
+
 ## [0.5.7] — 2026-05-10 — Fix cloud backend URL paths (sulci-oss P0)
 
 Three-string fix to `sulci/backends/cloud.py` aligning the SDK's request

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -15,7 +15,7 @@ import time
 import hashlib
 import importlib
 import time as _time
-from typing import Optional, Callable, Any
+from typing import Optional, Callable, Any, Union
 
 from sulci.context import ContextWindow
 from sulci.context import SessionStore as _BuiltinSessionStore
@@ -23,6 +23,12 @@ from sulci.context import SessionStore as _BuiltinSessionStore
 # v0.5.0 — sessions and sinks protocols (additive; see ADR 0004 + ADR 0007)
 from sulci.sessions import SessionStore as SessionStoreProtocol
 from sulci.sinks import EventSink, NullSink, CacheEvent
+
+# v0.6.0 — Backend + Embedder protocols for instance injection in Cache.__init__
+# (sulci-oss #34 C1c + C1d, umbrella #63). Used only in type hints + isinstance
+# dispatch; runtime behavior is duck-typed against the protocol's methods.
+from sulci.embeddings.protocol import Embedder
+from sulci.backends.protocol   import Backend
 
 
 # ── v0.5.2 nudge state (D15) ──────────────────────────────────────────────────
@@ -187,12 +193,12 @@ class Cache:
 
     def __init__(
         self,
-        backend:         str           = "chroma",
-        threshold:       float         = 0.85,
-        embedding_model: str           = "minilm",
-        ttl_seconds:     Optional[int] = 86400,
-        personalized:    bool          = False,
-        db_path:         str           = "./sulci_db",
+        backend:         Union[str, Backend]  = "chroma",
+        threshold:       float                = 0.85,
+        embedding_model: Union[str, Embedder] = "minilm",
+        ttl_seconds:     Optional[int]        = 86400,
+        personalized:    bool                 = False,
+        db_path:         str                  = "./sulci_db",
         # context-awareness
         context_window:  int           = 0,
         query_weight:    float         = 0.70,
@@ -253,14 +259,30 @@ class Cache:
 
     # ── private helpers ───────────────────────────────────────────
 
-    def _load_embedder(self, name: str):
+    def _load_embedder(self, name_or_instance):
+        # v0.6.0 (sulci-oss #34 C1c) — accept a pre-constructed Embedder
+        # instance directly. We duck-type rather than runtime-validate against
+        # the Embedder protocol; the failure surface is the first .embed() /
+        # .embed_batch() call, which is the same shape any wrong-typed value
+        # would produce. Any non-str is treated as an instance.
+        if not isinstance(name_or_instance, str):
+            return name_or_instance
+        name = name_or_instance
         if name == "openai":
             from sulci.embeddings.openai import OpenAIEmbedder
             return OpenAIEmbedder()
         from sulci.embeddings.minilm import MiniLMEmbedder
         return MiniLMEmbedder(name)
 
-    def _load_backend(self, name: str, db_path: str, api_key: Optional[str] = None, gateway_url: str = ""):
+    def _load_backend(self, name_or_instance, db_path: str, api_key: Optional[str] = None, gateway_url: str = ""):
+        # v0.6.0 (sulci-oss #34 C1d) — accept a pre-constructed Backend
+        # instance directly. db_path / api_key / gateway_url are ignored when
+        # an instance is supplied, since the caller has already configured the
+        # backend with its own connection params. Same duck-typing rationale
+        # as _load_embedder above.
+        if not isinstance(name_or_instance, str):
+            return name_or_instance
+        name = name_or_instance
         # sulci cloud backend — special construction, needs api_key not db_path
         if name == "sulci":
             import os, sys

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -486,3 +486,216 @@ class TestCacheEventPlan:
             assert p.default is None, (
                 f"Cache.{method_name}.plan must default to None, got {p.default!r}"
             )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# v0.6.0 — Cache.__init__ accepts native Embedder + Backend protocol instances
+# (sulci-oss #34 C1c + C1d, umbrella #63)
+#
+# Mirrors the test_session_store_injection.py pattern from v0.5.0 (ADR 0007):
+# verifies that passing a pre-constructed instance through the existing
+# `embedding_model=` / `backend=` parameters is honored end-to-end, while
+# the string-based dispatch path is unchanged.
+#
+# These tests do NOT instantiate MiniLM — they use fake protocol-shaped
+# objects, which is the whole point of the feature (decouple Cache from
+# the registry of named embedders/backends).
+# ═══════════════════════════════════════════════════════════════════════════
+
+class _FakeEmbedder:
+    """Minimal Embedder-protocol-shaped fake.
+
+    Returns a deterministic 4-d vector per query — small enough to keep
+    fixtures readable, large enough that cosine-similarity is well-defined.
+    """
+    dimension = 4
+
+    def __init__(self):
+        self.embed_calls       = []
+        self.embed_batch_calls = []
+
+    def embed(self, text: str) -> list[float]:
+        self.embed_calls.append(text)
+        # Deterministic but non-trivial: hash → 4 floats in [0,1)
+        h = hash(text)
+        return [((h >> (i * 8)) & 0xFF) / 255.0 for i in range(4)]
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.embed_batch_calls.append(list(texts))
+        return [self.embed(t) for t in texts]
+
+
+class _FakeBackend:
+    """Minimal Backend-protocol-shaped fake.
+
+    In-memory store keyed by `key`. Search returns the first stored entry
+    above threshold — deterministic given the FakeEmbedder above.
+    """
+    ENFORCES_TENANT_ISOLATION = False
+
+    def __init__(self):
+        self._entries     = []           # list of (embedding, response, metadata)
+        self.search_calls = []
+        self.store_calls  = []
+        self.clear_calls  = 0
+
+    def search(self, *, embedding, threshold, tenant_id=None, user_id=None, now=None):
+        self.search_calls.append({
+            "embedding": list(embedding),
+            "threshold": threshold,
+            "tenant_id": tenant_id,
+            "user_id":   user_id,
+        })
+        # Trivial: return the most recently stored response if any exists.
+        # Real similarity scoring would happen here in a non-fake backend;
+        # for injection tests we only care that .search was reached.
+        if self._entries:
+            emb, resp, meta = self._entries[-1]
+            return (resp, 1.0)
+        return (None, 0.0)
+
+    def store(self, *, key, query, response, embedding,
+              tenant_id=None, user_id=None, expires=None, metadata=None):
+        self.store_calls.append({
+            "key":       key,
+            "query":     query,
+            "response":  response,
+            "embedding": list(embedding),
+            "tenant_id": tenant_id,
+            "user_id":   user_id,
+        })
+        self._entries.append((embedding, response, metadata or {}))
+
+    def clear(self):
+        self.clear_calls += 1
+        self._entries.clear()
+
+
+class TestInstanceInjection:
+    """v0.6.0 — Cache.__init__ accepts pre-constructed Embedder/Backend instances."""
+
+    # ── default-path regression: existing string-based callers unchanged ──
+
+    def test_string_paths_still_work(self, tmp_path):
+        """Default Cache(backend='sqlite', embedding_model='minilm') path resolves
+        the string dispatch identically to v0.5.x. We mock MiniLMEmbedder here
+        to keep the test offline-runnable — the purpose is to verify that the
+        STRING IS DISPATCHED through _load_embedder (i.e., not stored as-is
+        and not skipped), not to verify the MiniLM model itself loads."""
+        from unittest.mock import patch, MagicMock
+        fake_embedder_class = MagicMock()
+        fake_embedder_class.return_value = MagicMock()
+        with patch("sulci.embeddings.minilm.MiniLMEmbedder", fake_embedder_class):
+            c = Cache(
+                backend         = "sqlite",
+                embedding_model = "minilm",
+                db_path         = str(tmp_path / "db"),
+            )
+        # _load_embedder dispatched through the string registry
+        fake_embedder_class.assert_called_once_with("minilm")
+        # User-visible field preserves the original string argument
+        assert c.embedding_model == "minilm"
+        assert c.backend         == "sqlite"
+        # _embedder is the materialized instance (the mock), not the string
+        assert not isinstance(c._embedder, str)
+        assert not isinstance(c._backend,  str)
+
+    # ── new path: instance injection ──
+
+    def test_embedder_instance_passes_through(self, tmp_path):
+        """Cache(embedding_model=<Embedder instance>) honors the instance directly —
+        no MiniLM load, identity-equal to what we passed in."""
+        fake = _FakeEmbedder()
+        c = Cache(
+            backend         = "sqlite",
+            embedding_model = fake,
+            db_path         = str(tmp_path / "db"),
+        )
+        # Identity check — not a copy, not a wrapper
+        assert c._embedder is fake
+        # User-visible field preserves the original argument
+        assert c.embedding_model is fake
+
+    def test_backend_instance_passes_through(self, tmp_path):
+        """Cache(backend=<Backend instance>) honors the instance directly —
+        no SQLite filesystem touch, identity-equal to what we passed in."""
+        fake = _FakeBackend()
+        c = Cache(
+            backend         = fake,
+            embedding_model = _FakeEmbedder(),   # also fake so no MiniLM
+            db_path         = "/nonexistent/path/that/would/fail/if/touched",
+        )
+        assert c._backend is fake
+        assert c.backend  is fake
+
+    def test_both_instances_injected_together(self, tmp_path):
+        """The gateway's use case: inject both protocol instances simultaneously.
+        Mirrors what `LibraryBackedCache(sulci.Cache)` does today via subclass
+        override of `_load_embedder` + `_load_backend` — but now without the
+        subclass workaround."""
+        emb = _FakeEmbedder()
+        be  = _FakeBackend()
+        c = Cache(
+            backend         = be,
+            embedding_model = emb,
+            db_path         = "/nonexistent/should/not/be/touched",
+        )
+        assert c._embedder is emb
+        assert c._backend  is be
+
+    def test_mixed_string_and_instance(self, tmp_path):
+        """One string + one instance — both dispatch paths in the same call."""
+        be = _FakeBackend()
+        # Backend = instance; embedding_model = string would trigger MiniLM,
+        # so use the opposite mix: string backend ('sqlite'), instance embedder.
+        emb = _FakeEmbedder()
+        c = Cache(
+            backend         = "sqlite",
+            embedding_model = emb,
+            db_path         = str(tmp_path / "db"),
+        )
+        # Backend materialized from string
+        assert not isinstance(c._backend, str)
+        # Embedder is the injected instance
+        assert c._embedder is emb
+
+    # ── end-to-end: injected instances are actually USED by Cache.get/set ──
+
+    def test_injected_embedder_is_called_on_set_and_get(self, tmp_path):
+        """Cache.set() and .get() route through the injected embedder's .embed().
+        Identity check via call-recording, not just storage."""
+        emb = _FakeEmbedder()
+        be  = _FakeBackend()
+        c = Cache(
+            backend         = be,
+            embedding_model = emb,
+            db_path         = "/nonexistent",
+        )
+        # set() must call embedder.embed() on the query
+        c.set("how do I deploy to AWS?", "use ECS or Fargate")
+        assert "how do I deploy to AWS?" in emb.embed_calls
+        # get() must also call embedder.embed() on the query
+        c.get("how do I deploy to AWS?")
+        # at least one embed call per operation
+        assert len(emb.embed_calls) >= 2
+
+    def test_injected_backend_is_called_on_set_and_get(self, tmp_path):
+        """Cache.set() routes to backend.store(); Cache.get() routes to
+        backend.search(). Verifies the engine actually delegates to the
+        injected backend rather than constructing a parallel one."""
+        emb = _FakeEmbedder()
+        be  = _FakeBackend()
+        c = Cache(
+            backend         = be,
+            embedding_model = emb,
+            db_path         = "/nonexistent",
+        )
+        c.set("question", "answer")
+        c.get("question")
+        # store() was reached
+        assert len(be.store_calls) == 1
+        assert be.store_calls[0]["query"]    == "question"
+        assert be.store_calls[0]["response"] == "answer"
+        # search() was reached
+        assert len(be.search_calls) == 1
+


### PR DESCRIPTION
Loosen embedding_model and backend parameter types from str to
Union[str, protocol-instance], adding an isinstance(x, str) short-circuit
in _load_embedder and _load_backend. Non-string inputs are returned as-is
and used directly, mirroring the v0.5.0 session_store= injection pattern
from ADR 0007.

Closes sulci-oss #34 sub-issues C1c (Embedder instance injection) and
C1d (Backend instance injection). PR 1 of three coordinated PRs under
v0.6.0 umbrella #63 — canonical-architecture-v3 alignment.

Backward-compatible: every existing string-based caller is unchanged.
Platform-side LibraryBackedCache(sulci.Cache) subclass can retire as a
follow-up once this lands.

Tests: 7 new tests in TestInstanceInjection class covering instance
pass-through identity, mixed string+instance kwargs, string-path
regression (with MiniLM mocked so it stays offline-runnable), and
end-to-end embed/search/store round-trips proving injected instances
are actually used by Cache.get/Cache.set.

CHANGELOG: introduces ## [Unreleased] section convention. Subsequent
v0.6.0 PRs (PR 2 for #62, PR 3 for docs) append bullets here; release
PR consolidates and renames to ## [0.6.0].

Full suite verified: 463 passed / 35 skipped / 0 failed against real
MiniLM in 12m03s. make checkin green (smoke tests, per-file runner,
examples runner, benchmark verifier). Benchmark numbers identical to
pre-change baseline — no engine perturbation.
