### PR TITLE
feat: cloud transport short-circuits local embedding, sends canonical payload (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   #34 sub-issues C1c (Embedder instance injection) and C1d (Backend
   instance injection).
 
+- `SulciCloudBackend` gained `remote_get(query, threshold, ...)` and
+  `remote_set(query, response, ...)` methods that send the canonical
+  `{query, threshold, user_id, session_id}` and
+  `{query, response, user_id, session_id, ttl_seconds}` wire payloads
+  matching the gateway's `CacheGetRequest` / `CacheSetRequest` pydantic
+  models exactly. `Cache.get` / `Cache.set` detect a cloud transport
+  (via `hasattr(backend, "remote_get")` set once at `__init__` as
+  `self._is_remote_transport`) and route through these methods directly,
+  skipping `self._embedder.embed()` entirely — the gateway-side library
+  does the embedding via its injected `EmbedServiceEmbedder`. Closes
+  sulci-oss #62 (`SulciCloudBackend` violates ADR 0008).
+
 ### Changed
 
 - Type signatures loosened on two `Cache.__init__` parameters:
@@ -38,6 +50,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   an `isinstance(x, str)` short-circuit at the top; non-string inputs
   are returned as-is.
 
+- **Behavior change for `Cache(backend="sulci")` users.** Pre-v0.6.0,
+  `Cache.get` embedded queries locally and sent the embedding to the
+  gateway, which 422-rejected the payload (the SDK silently swallowed
+  it and returned `(None, 0.0)` — Issue #62). After v0.6.0, the SDK
+  sends the raw query string and the gateway-side library does the
+  embedding. **Net effect: cloud-tier customers see actual cache hits
+  for the first time since v0.3.0.** Self-hosted backends (chroma,
+  qdrant, faiss, redis, sqlite, milvus) are unaffected — they continue
+  to receive `embedding` and do local ANN search.
+
+### Removed
+
+- `SulciCloudBackend.search()`, `.store()`, and `.upsert()` methods
+  have been removed. These previously implemented the `Backend`
+  protocol's vector-search shape, but the cloud backend was never
+  actually a backend in that sense — it's a transport for the entire
+  `Cache.get/set` call. The methods sent malformed payloads (Issue #62)
+  and have never worked end-to-end against the live gateway since
+  v0.3.0; any caller using them directly was already getting silent
+  failures. Use `remote_get(query, threshold, ...)` and
+  `remote_set(query, response, ...)` instead (or call via `Cache.get` /
+  `Cache.set`, which now route automatically).
+
 ### Tests
 
 - New `TestInstanceInjection` class in `tests/test_core.py` (7 tests)
@@ -45,6 +80,28 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   string-path regression (mocked MiniLM to keep offline-runnable),
   end-to-end `embed()` / `search()` / `store()` round-trips proving
   injected instances are actually used by `Cache.get` / `Cache.set`.
+
+- New `TestRemoteGet` (9 tests) and `TestRemoteSet` (3 tests) in
+  `tests/test_cloud_backend.py` replace the pre-v0.6.0 `TestSearch` and
+  `TestUpsert` classes — same error-swallow / payload-shape coverage,
+  on the new method names + canonical payload contract.
+
+- New `TestCloudTransportShortCircuit` class (8 tests) verifies
+  `Cache.get` / `Cache.set` route through `remote_get` / `remote_set`
+  when the backend is a cloud transport, never touching the local
+  embedder. Uses fake transports + fake embedders so it runs offline.
+
+- `TestCanonicalGatewayPaths` extended (7 tests, up from 4) with
+  **payload-contract round-trip assertions** — vendored copies of the
+  gateway's `CacheGetRequest` / `CacheSetRequest` pydantic models live
+  at `_GatewayContractModels` in the test file, pinned to
+  `sulci-platform:shared/models.py` via a sync-comment. Every SDK
+  payload is now `model_validate()`-checked against these copies, so
+  any future field drift fails CI loudly rather than silently 422'ing
+  in production (the failure mode that kept Issue #62 alive since
+  v0.3.0). This extends the v0.5.7 URL-pinning lesson — "tests must
+  assert what the gateway expects, not what the SDK does" — from URLs
+  to JSON payloads.
 
 ---
 

--- a/sulci/backends/cloud.py
+++ b/sulci/backends/cloud.py
@@ -13,11 +13,27 @@ Zero infrastructure for the user. One parameter change from self-hosted:
     # After
     cache = Cache(backend="sulci", api_key="sk-sulci-...", threshold=0.85)
 
-All public methods match the contract expected by Cache in core.py:
-    search(embedding, threshold, user_id, now) -> (response|None, similarity)
-    upsert(embedding, query, response, user_id, ttl_seconds)
-    delete_user(user_id)
-    clear()
+v0.6.0 transport contract (sulci-oss #62, umbrella #63)
+-------------------------------------------------------
+SulciCloudBackend is a **transport** for the entire `Cache.get/set` call,
+not a `Backend` protocol implementer in the vector-search sense. The
+gateway-side library (LibraryBackedCache) does ALL the engine work:
+embedding via the embed-service container, ANN search in managed Qdrant,
+event-stream emit for billing.
+
+Public methods:
+    remote_get(query, threshold, user_id, session_id)
+        -> (response|None, similarity, context_depth)
+    remote_set(query, response, user_id, session_id, ttl_seconds)
+    delete_user(user_id)   # currently silent no-op; sulci-platform #103
+    clear()                # currently silent no-op; sulci-platform #103
+
+Pre-v0.6.0 (search/store/upsert) embedded queries locally and sent
+`{embedding, ...}` to the gateway — a parallel-implementation pattern that
+ADR 0008 explicitly retired (archived at `archive/parallel-impl-final`,
+tag `parallel-impl-final-v0.5.5`, commit a4e4ad0). Cache.get/set now
+detects this transport via `hasattr(backend, "remote_get")` and bypasses
+local embedding entirely.
 """
 
 import httpx
@@ -75,35 +91,40 @@ class SulciCloudBackend:
 
     # ── Public interface — matches local backend contract ─────────────────────
 
-    def search(
+    def remote_get(
         self,
-        embedding:  list,
+        query:      str,
         threshold:  float,
         *,
-        tenant_id:  Optional[str] = None,
         user_id:    Optional[str] = None,
-        now:        Optional[float] = None,
+        session_id: Optional[str] = None,
     ) -> tuple:
         """
-        Semantic lookup via cloud API.
+        Forward a cache lookup to the Sulci Cloud gateway as a TRANSPORT
+        operation — the gateway-side library does the embedding, ANN
+        search, and event emit.
 
-        Tenant isolation is enforced server-side by the gateway based on
-        the api_key (which maps 1:1 to a tenant). The `tenant_id` kwarg
-        is forwarded to the gateway for logging and for the rare cases
-        where one api_key is authorized across multiple tenants.
+        v0.6.0 (sulci-oss #62) — renamed from `search()`. Wire payload is
+        now `{query, threshold, user_id, session_id}` matching the
+        gateway's CacheGetRequest pydantic model exactly. Pre-v0.6.0 the
+        SDK sent `{embedding, tenant_id, ...}` which the gateway rejected
+        as 422 (silently swallowed by the outer except clause below).
+        Tenant isolation is enforced server-side from the api_key auth
+        context; tenant_id is no longer sent on the wire.
 
         Returns:
-            (response, similarity) where response is None on miss.
-            Falls back to (None, 0.0) on any network error — never raises.
+            (response, similarity, context_depth)
+            response is None on miss.
+            Falls back to (None, 0.0, 0) on any network error — never raises.
         """
         try:
             resp = self._client.post(
                 "/v1/cache/get",
                 json={
-                    "embedding": embedding,
-                    "threshold": threshold,
-                    "tenant_id": tenant_id,
-                    "user_id":   user_id,
+                    "query":      query,
+                    "threshold":  threshold,
+                    "user_id":    user_id,
+                    "session_id": session_id,
                 },
             )
             resp.raise_for_status()
@@ -111,77 +132,49 @@ class SulciCloudBackend:
             return (
                 data.get("response"),
                 float(data.get("similarity", 0.0)),
+                int(data.get("context_depth", 0)),
             )
         except httpx.TimeoutException:
             # Timeout — treat as cache miss, never crash
-            return None, 0.0
+            return None, 0.0, 0
         except Exception:
             # Any other error — treat as cache miss, never crash
-            return None, 0.0
+            return None, 0.0, 0
 
-    def store(
+    def remote_set(
         self,
-        key: str,
-        query: str,
-        response: str,
-        embedding: list,
-        *,
-        tenant_id: Optional[str] = None,
-        user_id: Optional[str] = None,
-        expires: Optional[float] = None,
-        metadata: Optional[dict] = None,
-    ) -> None:
-        """
-        Store a cache entry in the cloud (Backend protocol method).
-
-        Translates the protocol's (key, expires) parameters to the cloud
-        API's (ttl_seconds) shape and forwards to /v1/set. Fire-and-forget
-        — silently ignores all errors per the Backend protocol contract.
-
-        Note: `key` and `metadata` are sent to the gateway for record-
-        keeping but the cloud API does not currently use them for lookup.
-        """
-        import time as _time
-        ttl_seconds: Optional[int] = None
-        if expires:
-            ttl_seconds = max(0, int(expires - _time.time()))
-        try:
-            self._client.post(
-                "/v1/cache/set",
-                json={
-                    "key":         key,
-                    "embedding":   embedding,
-                    "query":       query,
-                    "response":    response,
-                    "tenant_id":   tenant_id,
-                    "user_id":     user_id,
-                    "ttl_seconds": ttl_seconds,
-                    "metadata":    metadata,
-                },
-            )
-        except Exception:
-            pass
-
-    def upsert(
-        self,
-        embedding:   list,
         query:       str,
         response:    str,
+        *,
         user_id:     Optional[str] = None,
+        session_id:  Optional[str] = None,
         ttl_seconds: Optional[int] = None,
     ) -> None:
         """
-        Store a cache entry in the cloud.
-        Fire-and-forget — silently ignores all errors.
+        Forward a cache write to the Sulci Cloud gateway as a TRANSPORT
+        operation. The gateway-side library handles embedding, Qdrant
+        upsert, and the `cache.set` billing event.
+
+        v0.6.0 (sulci-oss #62) — replaces both `store()` and `upsert()`.
+        Wire payload is `{query, response, user_id, session_id, ttl_seconds}`
+        matching the gateway's CacheSetRequest pydantic model exactly.
+        The pre-v0.6.0 split between `store(key, embedding, query, response,
+        tenant_id, metadata, ...)` and `upsert(embedding, query, response, ...)`
+        was an artifact of the Backend protocol's vector-search shape; with
+        the cloud as a TRANSPORT (not a backend), a single canonical method
+        suffices.
+
+        Fire-and-forget — silently ignores all errors. The user's app must
+        never crash on a failed cache write.
         """
         try:
             self._client.post(
                 "/v1/cache/set",
                 json={
-                    "embedding":   embedding,
                     "query":       query,
                     "response":    response,
                     "user_id":     user_id,
+                    "session_id":  session_id,
                     "ttl_seconds": ttl_seconds,
                 },
             )
@@ -189,14 +182,26 @@ class SulciCloudBackend:
             pass   # Never crash the user's app on a failed write
 
     def delete_user(self, user_id: str) -> None:
-        """Delete all cache entries for a given user_id."""
+        """Delete all cache entries for a given user_id.
+
+        Currently a silent no-op against the live gateway — the route
+        `DELETE /v1/cache/user/{user_id}` does not yet exist on the
+        gateway side. Tracked as sulci-platform #103. GDPR-adjacent;
+        this method's contract is preserved for forward compatibility
+        but the actual deletion happens only after #103 ships.
+        """
         try:
             self._client.delete(f"/v1/user/{user_id}")
         except Exception:
             pass
 
     def clear(self) -> None:
-        """Clear all cache entries for this tenant."""
+        """Clear all cache entries for this tenant.
+
+        Currently a silent no-op against the live gateway — the route
+        `DELETE /v1/cache/clear` does not yet exist on the gateway
+        side. Tracked as sulci-platform #103.
+        """
         try:
             self._client.delete("/v1/cache")
         except Exception:

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -223,6 +223,24 @@ class Cache:
         self._embedder = self._load_embedder(embedding_model)
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
+        # v0.6.0 (sulci-oss #62, umbrella #63) — cloud-transport detection.
+        # When self._backend is the cloud transport (SulciCloudBackend), the
+        # gateway-side library does ALL engine work (embed + search + emit);
+        # the SDK is a thin transport. Cache.get/set short-circuits local
+        # embedding when this flag is set.
+        #
+        # Capability-based detection (hasattr) rather than isinstance against
+        # SulciCloudBackend avoids importing httpx at module load — the cloud
+        # backend's import is lazy via _load_backend, and that property must
+        # be preserved for self-hosted users who don't need httpx (sulci-oss
+        # #60). Any backend that implements `remote_get` + `remote_set` is
+        # treated as a transport; this future-proofs against alternative
+        # transports (custom impls, internal forks).
+        self._is_remote_transport = (
+            hasattr(self._backend, "remote_get") and
+            hasattr(self._backend, "remote_set")
+        )
+
         # ── v0.5.2 nudge counter (D15) ──
         # Tracks queries observed by THIS instance, used by .stats() to
         # decide whether to print the one-shot nudge toward sulci.connect()
@@ -395,14 +413,28 @@ class Cache:
         """
         _t0 = _time.time()
         self._query_count += 1
-        vec, depth = self._context_vec(query, session_id)
-        resp, sim  = self._backend.search(
-            embedding = vec,
-            threshold = self.threshold,
-            tenant_id = tenant_id,
-            user_id   = user_id if self.personalized else None,
-            now       = time.time(),
-        )
+        if self._is_remote_transport:
+            # v0.6.0 (sulci-oss #62) — cloud transport short-circuit.
+            # The gateway-side library does the embedding, ANN search, and
+            # billing event emit. The SDK forwards the raw query string and
+            # the gateway-computed context_depth comes back in the response.
+            # self._embedder is NOT called; self._context_vec is NOT called.
+            resp, sim, depth = self._backend.remote_get(
+                query      = query,
+                threshold  = self.threshold,
+                user_id    = user_id if self.personalized else None,
+                session_id = session_id,
+            )
+        else:
+            # Self-hosted path — library is the engine in-process.
+            vec, depth = self._context_vec(query, session_id)
+            resp, sim  = self._backend.search(
+                embedding = vec,
+                threshold = self.threshold,
+                tenant_id = tenant_id,
+                user_id   = user_id if self.personalized else None,
+                now       = time.time(),
+            )
         latency_ms = round((_time.time() - _t0) * 1000, 2)
 
         # #42 — count every .get() call so users who use the raw .get()/.set()
@@ -478,21 +510,38 @@ class Cache:
         ``plan`` (v0.5.6, sulci-oss #36) is forwarded onto the emitted
         CacheEvent.plan; see ``Cache.get`` for the rationale.
         """
-        _t0     = _time.time()
-        raw_vec = self._embedder.embed(query)
-        key     = hashlib.sha256(query.encode()).hexdigest()[:16]
-        expires = time.time() + self.ttl_seconds if self.ttl_seconds else None
-        self._backend.store(
-            key       = key,
-            query     = query,
-            response  = response,
-            embedding = raw_vec,
-            tenant_id = tenant_id,
-            user_id   = user_id if self.personalized else None,
-            expires   = expires,
-            metadata  = metadata or {},
-        )
-        if session_id and self._sessions:
+        _t0 = _time.time()
+        if self._is_remote_transport:
+            # v0.6.0 (sulci-oss #62) — cloud transport short-circuit.
+            # The gateway-side library handles embedding, Qdrant upsert, and
+            # the cache.set billing event. session_id is forwarded so the
+            # gateway-side context window updates; local self._sessions is
+            # not touched (it would track stale turn state since this Cache
+            # instance has no engine-state).
+            self._backend.remote_set(
+                query       = query,
+                response    = response,
+                user_id     = user_id if self.personalized else None,
+                session_id  = session_id,
+                ttl_seconds = self.ttl_seconds,
+            )
+            raw_vec = None   # not computed locally; session-window record skipped below
+        else:
+            # Self-hosted path — library is the engine in-process.
+            raw_vec = self._embedder.embed(query)
+            key     = hashlib.sha256(query.encode()).hexdigest()[:16]
+            expires = time.time() + self.ttl_seconds if self.ttl_seconds else None
+            self._backend.store(
+                key       = key,
+                query     = query,
+                response  = response,
+                embedding = raw_vec,
+                tenant_id = tenant_id,
+                user_id   = user_id if self.personalized else None,
+                expires   = expires,
+                metadata  = metadata or {},
+            )
+        if session_id and self._sessions and raw_vec is not None:
             self._record_turn(session_id, query, response, raw_vec)
 
         # Telemetry — legacy emit pipe (sulci.connect()).

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -51,7 +51,22 @@ BACKEND_CLASSES = [
         _import_or_none("sulci.backends.redis",  "RedisBackend"),
         _import_or_none("sulci.backends.qdrant", "QdrantBackend"),
         _import_or_none("sulci.backends.milvus", "MilvusBackend"),
-        _import_or_none("sulci.backends.cloud",  "SulciCloudBackend"),
+        # v0.6.0 (sulci-oss #62, umbrella #63) — SulciCloudBackend is
+        # deliberately NOT in this list. It is a TRANSPORT for the entire
+        # Cache.get/set call, not a Backend protocol implementer in the
+        # vector-search sense. It exposes remote_get / remote_set rather
+        # than search / store / clear, and Cache.get/set detects it via
+        # `hasattr(backend, "remote_get")` (see Cache._is_remote_transport).
+        #
+        # The transport surface is covered by tests in
+        # tests/test_cloud_backend.py:
+        #   - TestRemoteGet, TestRemoteSet — method shape + payload
+        #   - TestCanonicalGatewayPaths   — wire-contract pydantic round-trip
+        #   - TestCloudTransportShortCircuit — Cache.get/set routing
+        #
+        # If a second transport implementation emerges, consider adding a
+        # parallel TRANSPORT_CLASSES registry here with a dedicated
+        # transport-conformance suite.
     ]
     if cls is not None
 ]
@@ -132,12 +147,6 @@ def _try_construct_backend(cls: Type) -> Optional[Any]:
             return cls(db_path=tempfile.mkdtemp(prefix="sulci_compat_"))
         except Exception:
             return None
-
-    if name == "SulciCloudBackend":
-        # Cloud needs a running gateway — out of scope for local conformance.
-        # Construction succeeds with a fake key for structural checks only;
-        # behavioral checks will skip because we never get a working instance.
-        return None
 
     return None
 

--- a/tests/test_cloud_backend.py
+++ b/tests/test_cloud_backend.py
@@ -48,6 +48,51 @@ def mock_response(data: dict, status: int = 200):
     return resp
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Vendored gateway pydantic models — wire-contract source of truth
+# ──────────────────────────────────────────────────────────────────────────────
+# These are EXACT COPIES of the gateway's request/response models, vendored
+# here so sulci-oss CI can verify the SDK's wire payload matches what the
+# gateway expects without depending on the platform repo at test time.
+#
+# Source of truth (keep in sync):
+#   sulci-platform:shared/models.py
+#
+# When the gateway adds/removes/renames a field on CacheGetRequest /
+# CacheGetResponse / CacheSetRequest, update these copies AND the SDK's
+# remote_get / remote_set methods in the same PR. The TestCanonicalGatewayPaths
+# class below uses model_validate() to round-trip the SDK's payload through
+# these models, so any drift fails CI loudly rather than silently 422'ing
+# in production (which is exactly how Issue #62 stayed live for ~14 months).
+
+from typing import Optional as _Optional
+from pydantic import BaseModel as _BaseModel
+
+
+class _GatewayContractModels:
+    """Wire-contract anchor — DO NOT mutate at test time."""
+
+    class CacheGetRequest(_BaseModel):
+        query:      str
+        threshold:  float          = 0.85
+        user_id:    _Optional[str] = None
+        session_id: _Optional[str] = None
+
+    class CacheGetResponse(_BaseModel):
+        response:      _Optional[str]
+        similarity:    float
+        context_depth: int           = 0
+        cache_hit:     bool
+        latency_ms:    float
+
+    class CacheSetRequest(_BaseModel):
+        query:       str
+        response:    str
+        user_id:     _Optional[str] = None
+        session_id:  _Optional[str] = None
+        ttl_seconds: _Optional[int] = None
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Construction
 # ══════════════════════════════════════════════════════════════════════════════
@@ -99,90 +144,107 @@ class TestConstruction:
 # search()
 # ══════════════════════════════════════════════════════════════════════════════
 
-class TestSearch:
+class TestRemoteGet:
+    """v0.6.0 (sulci-oss #62) — renamed from TestSearch.
 
-    def test_returns_response_and_similarity_on_hit(self):
+    Covers the cloud transport's lookup method. Wire payload is now
+    `{query, threshold, user_id, session_id}` — matching the gateway's
+    `CacheGetRequest` pydantic model — rather than the pre-v0.6.0
+    `{embedding, tenant_id, ...}` shape which the gateway 422-rejected.
+    """
+
+    def test_returns_response_similarity_and_depth_on_hit(self):
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({
-                              "response":   "cached answer",
-                              "similarity": 0.91,
+                              "response":      "cached answer",
+                              "similarity":    0.91,
+                              "context_depth": 2,
                           })):
-            result = b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-            )
-        assert result == ("cached answer", 0.91)
+            result = b.remote_get(query="what is sulci?", threshold=0.85)
+        assert result == ("cached answer", 0.91, 2)
 
     def test_returns_none_on_miss(self):
         """Cloud returns response=null on miss."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({
-                              "response":   None,
-                              "similarity": 0.0,
+                              "response":      None,
+                              "similarity":    0.0,
+                              "context_depth": 0,
                           })):
-            response, sim = b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-            )
+            response, sim, depth = b.remote_get(query="x", threshold=0.85)
         assert response is None
         assert sim == 0.0
+        assert depth == 0
+
+    def test_missing_context_depth_defaults_to_zero(self):
+        """Gateway may omit context_depth (pre-v0.6.0 response shape).
+        Cloud transport must default to 0 rather than KeyError."""
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({
+                              "response":   "answer",
+                              "similarity": 0.9,
+                              # context_depth absent
+                          })):
+            _, _, depth = b.remote_get(query="x", threshold=0.85)
+        assert depth == 0
 
     def test_timeout_returns_miss_never_raises(self):
-        """TimeoutException must be swallowed — treated as cache miss."""
         b = make_backend()
         with patch.object(b._client, "post",
                           side_effect=httpx.TimeoutException("timed out")):
-            response, sim = b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-            )
-        assert response is None
-        assert sim == 0.0
+            result = b.remote_get(query="x", threshold=0.85)
+        assert result == (None, 0.0, 0)
 
     def test_generic_exception_returns_miss_never_raises(self):
-        """Any unexpected error must be swallowed."""
         b = make_backend()
         with patch.object(b._client, "post",
                           side_effect=RuntimeError("network down")):
-            response, sim = b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-            )
-        assert response is None
-        assert sim == 0.0
+            result = b.remote_get(query="x", threshold=0.85)
+        assert result == (None, 0.0, 0)
 
     def test_http_error_returns_miss_never_raises(self):
-        """HTTP 5xx must be swallowed."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({}, status=500)):
-            response, sim = b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-            )
-        assert response is None
-        assert sim == 0.0
+            result = b.remote_get(query="x", threshold=0.85)
+        assert result == (None, 0.0, 0)
 
-    def test_sends_correct_payload(self):
-        """search() sends embedding, threshold, user_id to /v1/get."""
+    def test_sends_canonical_payload(self):
+        """remote_get() sends {query, threshold, user_id, session_id} —
+        matching CacheGetRequest exactly. Critically, does NOT send
+        `embedding` or `tenant_id` (the pre-v0.6.0 wrong-payload bug)."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"response": None,
                                                       "similarity": 0.0})
                           ) as mock_post:
-            b.search(
-                embedding=[0.1] * 384,
-                threshold=0.85,
-                user_id="user-42",
+            b.remote_get(
+                query      = "what is sulci?",
+                threshold  = 0.85,
+                user_id    = "user-42",
+                session_id = "sess-7",
             )
         call_kwargs = mock_post.call_args
         assert call_kwargs[0][0] == "/v1/cache/get"
         body = call_kwargs[1]["json"]
-        assert body["threshold"] == 0.85
-        assert body["user_id"]   == "user-42"
-        assert len(body["embedding"]) == 384
+        # Required + optional fields per CacheGetRequest
+        assert body["query"]      == "what is sulci?"
+        assert body["threshold"]  == 0.85
+        assert body["user_id"]    == "user-42"
+        assert body["session_id"] == "sess-7"
+        # Pre-v0.6.0 wrong-payload guard: these MUST NOT be on the wire
+        assert "embedding" not in body, (
+            "remote_get must NOT send 'embedding' — the gateway does its own "
+            "embedding via the injected EmbedServiceEmbedder. Pre-v0.6.0 SDK "
+            "sent embedding here and the gateway 422-rejected it (Issue #62)."
+        )
+        assert "tenant_id" not in body, (
+            "remote_get must NOT send 'tenant_id' — tenant identity comes "
+            "from the gateway's auth context (X-Sulci-Key → api_keys lookup)."
+        )
 
     def test_similarity_cast_to_float(self):
         """Similarity from API (may be int) is always returned as float."""
@@ -192,56 +254,82 @@ class TestSearch:
                               "response":   "answer",
                               "similarity": 1,    # int from API
                           })):
-            _, sim = b.search(embedding=[0.1] * 384, threshold=0.85)
+            _, sim, _ = b.remote_get(query="x", threshold=0.85)
         assert isinstance(sim, float)
         assert sim == 1.0
+
+    def test_context_depth_cast_to_int(self):
+        """context_depth from API (may be str/float) is always returned as int."""
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({
+                              "response":      "answer",
+                              "similarity":    0.9,
+                              "context_depth": "3",   # gateway might return str
+                          })):
+            _, _, depth = b.remote_get(query="x", threshold=0.85)
+        assert isinstance(depth, int)
+        assert depth == 3
 
 
 # ══════════════════════════════════════════════════════════════════════════════
 # upsert()
 # ══════════════════════════════════════════════════════════════════════════════
 
-class TestUpsert:
+class TestRemoteSet:
+    """v0.6.0 (sulci-oss #62) — replaces TestUpsert (and TestStore, both
+    consolidated into the single `remote_set` method).
 
-    def test_sends_correct_payload(self):
-        """upsert() sends embedding, query, response, user_id to /v1/cache/set."""
+    Wire payload is now `{query, response, user_id, session_id, ttl_seconds}` —
+    matching the gateway's `CacheSetRequest` pydantic model — rather than the
+    pre-v0.6.0 `{key, embedding, query, response, tenant_id, metadata, ...}`
+    shape which the gateway 422-rejected.
+    """
+
+    def test_sends_canonical_payload(self):
+        """remote_set() sends {query, response, user_id, session_id,
+        ttl_seconds} — matching CacheSetRequest exactly. Critically, does
+        NOT send embedding, key, tenant_id, or metadata (the pre-v0.6.0
+        wrong-payload bug)."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"status": "ok"})
                           ) as mock_post:
-            b.upsert(
-                embedding   = [0.1] * 384,
+            b.remote_set(
                 query       = "what is sulci?",
                 response    = "semantic cache",
                 user_id     = "user-42",
+                session_id  = "sess-7",
                 ttl_seconds = 3600,
             )
-        body = mock_post.call_args[1]["json"]
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == "/v1/cache/set"
+        body = call_kwargs[1]["json"]
+        # Required + optional fields per CacheSetRequest
         assert body["query"]       == "what is sulci?"
         assert body["response"]    == "semantic cache"
         assert body["user_id"]     == "user-42"
+        assert body["session_id"]  == "sess-7"
         assert body["ttl_seconds"] == 3600
+        # Pre-v0.6.0 wrong-payload guard
+        for forbidden in ("embedding", "key", "tenant_id", "metadata"):
+            assert forbidden not in body, (
+                f"remote_set must NOT send '{forbidden}' — see Issue #62. "
+                f"The gateway-side library generates these server-side."
+            )
 
     def test_failure_is_silent(self):
-        """upsert() must never raise — fire and forget."""
+        """remote_set() must never raise — fire and forget."""
         b = make_backend()
         with patch.object(b._client, "post",
                           side_effect=Exception("network error")):
-            b.upsert(
-                embedding=[0.1] * 384,
-                query="test",
-                response="answer",
-            )   # must not raise
+            b.remote_set(query="test", response="answer")   # must not raise
 
     def test_timeout_is_silent(self):
         b = make_backend()
         with patch.object(b._client, "post",
                           side_effect=httpx.TimeoutException("timeout")):
-            b.upsert(
-                embedding=[0.1] * 384,
-                query="test",
-                response="answer",
-            )   # must not raise
+            b.remote_set(query="test", response="answer")   # must not raise
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -359,51 +447,129 @@ class TestCacheWiring:
 # drift on either side gets caught here rather than in production telemetry.
 
 class TestCanonicalGatewayPaths:
-    """Each URL-bearing method must POST to the gateway's canonical path."""
+    """v0.6.0 (sulci-oss #62) — each URL-bearing method must POST to the
+    gateway's canonical path AND send a payload that round-trips through
+    the gateway's pydantic request model.
 
-    def test_search_posts_to_v1_cache_get(self):
+    v0.5.7 introduced URL-only assertions (pinning `/v1/cache/get` etc.)
+    after #57 silently 404'd for ~14 months. Issue #62 then revealed that
+    fixing the URLs wasn't enough — the SDK's payload still didn't match
+    the gateway's `CacheGetRequest` / `CacheSetRequest` models, so every
+    post-v0.5.7 request 422'd instead. This test class now extends the
+    URL pins with full payload-shape pins.
+
+    See `_GatewayContractModels` at module scope for the vendored model
+    definitions — they're copies of `sulci-platform:shared/models.py`,
+    pinned here so sulci-oss CI doesn't need the platform repo to verify
+    the wire contract.
+    """
+
+    def test_remote_get_posts_to_v1_cache_get(self):
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"response": None,
                                                       "similarity": 0.0})
                           ) as mock_post:
-            b.search(embedding=[0.0] * 384, threshold=0.85)
+            b.remote_get(query="hello", threshold=0.85)
         assert mock_post.call_args[0][0] == "/v1/cache/get", (
-            "search() must POST to /v1/cache/get — gateway exposes that "
+            "remote_get() must POST to /v1/cache/get — gateway exposes that "
             "canonical path; /v1/get returns 404 and is swallowed silently."
         )
 
-    def test_store_posts_to_v1_cache_set(self):
+    def test_remote_set_posts_to_v1_cache_set(self):
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"status": "ok"})
                           ) as mock_post:
-            b.store(
-                key       = "abc123",
-                embedding = [0.0] * 384,
-                query     = "hello",
-                response  = "world",
-                metadata  = {"k": "v"},
-            )
+            b.remote_set(query="hello", response="world")
         assert mock_post.call_args[0][0] == "/v1/cache/set", (
-            "store() must POST to /v1/cache/set — gateway exposes that "
+            "remote_set() must POST to /v1/cache/set — gateway exposes that "
             "canonical path; /v1/set returns 404 and is swallowed silently."
         )
 
-    def test_upsert_posts_to_v1_cache_set(self):
+    def test_remote_get_payload_round_trips_through_CacheGetRequest(self):
+        """The wire payload sent to /v1/cache/get must be parseable by the
+        gateway's `CacheGetRequest` pydantic model — every required field
+        present, no extra forbidden fields, all field types compatible.
+
+        This is the regression guard for Issue #62. Before v0.6.0 the SDK
+        sent `{embedding, tenant_id, threshold, user_id}`, which the gateway
+        422-rejected because:
+          - `query` (required) was missing
+          - `embedding` was not in the model
+          - `tenant_id` was not in the model (auth context provides it)
+        """
+        from pydantic import ValidationError
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({"response": None,
+                                                      "similarity": 0.0})
+                          ) as mock_post:
+            b.remote_get(
+                query      = "what is sulci?",
+                threshold  = 0.85,
+                user_id    = "user-42",
+                session_id = "sess-7",
+            )
+        body = mock_post.call_args[1]["json"]
+        # This will raise ValidationError if the SDK's payload doesn't
+        # round-trip through the gateway's request schema.
+        parsed = _GatewayContractModels.CacheGetRequest.model_validate(body)
+        # Sanity: the parsed model has the SDK's values
+        assert parsed.query      == "what is sulci?"
+        assert parsed.threshold  == 0.85
+        assert parsed.user_id    == "user-42"
+        assert parsed.session_id == "sess-7"
+
+    def test_remote_set_payload_round_trips_through_CacheSetRequest(self):
+        """Symmetric to the GET test — payload must parse as CacheSetRequest."""
         b = make_backend()
         with patch.object(b._client, "post",
                           return_value=mock_response({"status": "ok"})
                           ) as mock_post:
-            b.upsert(
-                embedding = [0.0] * 384,
-                query     = "hello",
-                response  = "world",
+            b.remote_set(
+                query       = "what is sulci?",
+                response    = "semantic cache",
+                user_id     = "user-42",
+                session_id  = "sess-7",
+                ttl_seconds = 3600,
             )
-        assert mock_post.call_args[0][0] == "/v1/cache/set", (
-            "upsert() must POST to /v1/cache/set — gateway exposes that "
-            "canonical path; /v1/set returns 404 and is swallowed silently."
-        )
+        body = mock_post.call_args[1]["json"]
+        parsed = _GatewayContractModels.CacheSetRequest.model_validate(body)
+        assert parsed.query       == "what is sulci?"
+        assert parsed.response    == "semantic cache"
+        assert parsed.user_id     == "user-42"
+        assert parsed.session_id  == "sess-7"
+        assert parsed.ttl_seconds == 3600
+
+    def test_minimal_remote_get_payload_round_trips(self):
+        """Optional fields default correctly when omitted — confirms the
+        gateway accepts a minimal `{query, threshold}` payload."""
+        b = make_backend()
+        with patch.object(b._client, "post",
+                          return_value=mock_response({"response": None,
+                                                      "similarity": 0.0})
+                          ) as mock_post:
+            b.remote_get(query="x", threshold=0.85)
+        body = mock_post.call_args[1]["json"]
+        parsed = _GatewayContractModels.CacheGetRequest.model_validate(body)
+        assert parsed.query == "x"
+        assert parsed.user_id    is None
+        assert parsed.session_id is None
+
+    def test_no_legacy_method_names_in_source(self):
+        """Static check: the SDK source has no references to the
+        pre-v0.6.0 methods `search`, `store`, `upsert` on the cloud
+        transport — they were renamed to `remote_get` / `remote_set`."""
+        import sulci.backends.cloud as cloud_mod
+        from pathlib import Path
+        src = Path(cloud_mod.__file__).read_text()
+        for legacy in ("def search(", "def store(", "def upsert("):
+            assert legacy not in src, (
+                f"cloud.py contains legacy method `{legacy[4:-1]}` — "
+                f"v0.6.0 renamed to remote_get / remote_set "
+                f"(see sulci-oss #62)."
+            )
 
     def test_no_legacy_paths_in_source(self):
         """Static check: the SDK source contains zero references to the
@@ -417,4 +583,191 @@ class TestCanonicalGatewayPaths:
         )
         assert '"/v1/set"' not in src and "'/v1/set'" not in src, (
             "cloud.py contains legacy '/v1/set' — gateway exposes /v1/cache/set"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# v0.6.0 — Cache.get / Cache.set route through cloud transport without local embed
+# (sulci-oss #62, umbrella #63)
+#
+# Cache detects the cloud transport via duck-typed `hasattr(backend, "remote_get")`
+# at __init__ time (`self._is_remote_transport`). When set, Cache.get bypasses
+# `self._embedder.embed()` and `self._backend.search()` entirely, calling
+# `self._backend.remote_get(query, ...)` instead. Symmetric for Cache.set.
+#
+# These tests use a fake-transport-shaped backend + fake embedder so they run
+# offline (no MiniLM download), like TestInstanceInjection in test_core.py.
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class _FakeRemoteTransport:
+    """Minimal transport-shaped fake — has remote_get + remote_set, no search/store."""
+    def __init__(self):
+        self.remote_get_calls = []
+        self.remote_set_calls = []
+        self._stored: dict = {}
+
+    def remote_get(self, query, threshold, *, user_id=None, session_id=None):
+        self.remote_get_calls.append({
+            "query": query, "threshold": threshold,
+            "user_id": user_id, "session_id": session_id,
+        })
+        if query in self._stored:
+            return self._stored[query], 1.0, 0
+        return None, 0.0, 0
+
+    def remote_set(self, query, response, *, user_id=None, session_id=None,
+                   ttl_seconds=None):
+        self.remote_set_calls.append({
+            "query": query, "response": response,
+            "user_id": user_id, "session_id": session_id,
+            "ttl_seconds": ttl_seconds,
+        })
+        self._stored[query] = response
+
+
+class _FakeEmbedderForTransportTests:
+    """Embedder fake — should NEVER be called when Cache routes via transport."""
+    dimension = 4
+    def __init__(self):
+        self.embed_calls = []
+    def embed(self, text):
+        self.embed_calls.append(text)
+        return [0.0] * 4
+    def embed_batch(self, texts):
+        return [[0.0] * 4 for _ in texts]
+
+
+class TestCloudTransportShortCircuit:
+    """v0.6.0 (sulci-oss #62) — Cache.get / Cache.set bypass local embedding
+    when the backend is a cloud transport."""
+
+    def test_is_remote_transport_flag_set_for_cloud(self):
+        """Cache constructed with a transport-shaped backend has
+        _is_remote_transport=True."""
+        from sulci import Cache
+        c = Cache(
+            backend         = _FakeRemoteTransport(),
+            embedding_model = _FakeEmbedderForTransportTests(),
+            db_path         = "/nonexistent",
+        )
+        assert c._is_remote_transport is True
+
+    def test_is_remote_transport_flag_false_for_vector_backend(self):
+        """Cache constructed with a Backend-protocol-shaped backend (search,
+        store) has _is_remote_transport=False."""
+        from sulci import Cache
+
+        class _FakeVectorBackend:
+            ENFORCES_TENANT_ISOLATION = False
+            def search(self, **k): return (None, 0.0)
+            def store(self, **k):  pass
+            def clear(self): pass
+
+        c = Cache(
+            backend         = _FakeVectorBackend(),
+            embedding_model = _FakeEmbedderForTransportTests(),
+            db_path         = "/nonexistent",
+        )
+        assert c._is_remote_transport is False
+
+    def test_get_routes_to_remote_get_skips_local_embed(self):
+        """Cache.get with cloud transport must call backend.remote_get and
+        NEVER call embedder.embed() — the gateway-side library handles it."""
+        from sulci import Cache
+        emb = _FakeEmbedderForTransportTests()
+        be  = _FakeRemoteTransport()
+        c = Cache(backend=be, embedding_model=emb, db_path="/nonexistent")
+        result = c.get("test query")
+        # Routed to transport
+        assert len(be.remote_get_calls) == 1
+        assert be.remote_get_calls[0]["query"] == "test query"
+        # Local embedding skipped — this is the whole point
+        assert emb.embed_calls == [], (
+            "Cache.get must NOT call embedder.embed() when backend is cloud "
+            "transport — that would duplicate the work the gateway-side "
+            "library does (Issue #62)."
+        )
+        # Return shape is (response, similarity, context_depth)
+        assert result == (None, 0.0, 0)
+
+    def test_set_routes_to_remote_set_skips_local_embed(self):
+        """Cache.set with cloud transport must call backend.remote_set and
+        NEVER call embedder.embed()."""
+        from sulci import Cache
+        emb = _FakeEmbedderForTransportTests()
+        be  = _FakeRemoteTransport()
+        c = Cache(backend=be, embedding_model=emb, db_path="/nonexistent")
+        c.set("hello", "world")
+        # Routed to transport
+        assert len(be.remote_set_calls) == 1
+        assert be.remote_set_calls[0]["query"]    == "hello"
+        assert be.remote_set_calls[0]["response"] == "world"
+        # Local embedding skipped
+        assert emb.embed_calls == []
+
+    def test_get_then_set_then_get_round_trips_via_transport(self):
+        """Happy-path: set then get via transport returns the stored response."""
+        from sulci import Cache
+        emb = _FakeEmbedderForTransportTests()
+        be  = _FakeRemoteTransport()
+        c = Cache(backend=be, embedding_model=emb, db_path="/nonexistent")
+
+        miss, sim_miss, depth_miss = c.get("unknown query")
+        assert miss is None and sim_miss == 0.0
+
+        c.set("known query", "stored answer")
+        hit, sim_hit, depth_hit = c.get("known query")
+        assert hit       == "stored answer"
+        assert sim_hit   == 1.0
+        # Embedder STILL never called across all three calls
+        assert emb.embed_calls == []
+
+    def test_get_forwards_session_id_to_transport(self):
+        """session_id flows from Cache.get(session_id=...) through to the
+        wire — the gateway-side library tracks the session context window."""
+        from sulci import Cache
+        be = _FakeRemoteTransport()
+        c = Cache(
+            backend         = be,
+            embedding_model = _FakeEmbedderForTransportTests(),
+            db_path         = "/nonexistent",
+        )
+        c.get("test", session_id="sess-42")
+        assert be.remote_get_calls[0]["session_id"] == "sess-42"
+
+    def test_set_forwards_session_id_to_transport(self):
+        """Symmetric for set."""
+        from sulci import Cache
+        be = _FakeRemoteTransport()
+        c = Cache(
+            backend         = be,
+            embedding_model = _FakeEmbedderForTransportTests(),
+            db_path         = "/nonexistent",
+        )
+        c.set("test", "answer", session_id="sess-42")
+        assert be.remote_set_calls[0]["session_id"] == "sess-42"
+
+    def test_set_skips_local_session_window_recording(self):
+        """Cache.set with cloud transport must NOT touch self._sessions —
+        the gateway-side library tracks the session window. Recording
+        locally would create stale state since this Cache instance has
+        no engine."""
+        from sulci import Cache
+        c = Cache(
+            backend         = _FakeRemoteTransport(),
+            embedding_model = _FakeEmbedderForTransportTests(),
+            db_path         = "/nonexistent",
+            context_window  = 4,        # would enable local _sessions
+        )
+        # _sessions exists (context_window > 0)
+        assert c._sessions is not None
+        # But .set with session_id doesn't update it because raw_vec is None
+        c.set("query", "answer", session_id="sess-1")
+        # If local session recording had happened, the window would have a turn
+        window = c._sessions.get("sess-1")
+        assert window.depth == 0, (
+            "Cache.set must not record turns into the local session window "
+            "when routing through the cloud transport — the gateway-side "
+            "library owns the session context."
         )


### PR DESCRIPTION
Closes sulci-oss #62 (`SulciCloudBackend` violates ADR 0008). PR 2 of three coordinated PRs under v0.6.0 umbrella #63.

## The bug

`SulciCloudBackend` was a parallel embedding path that ADR 0008 explicitly retired (archive: `archive/parallel-impl-final`, tag `parallel-impl-final-v0.5.5`, commit `a4e4ad0`). `Cache.get/set` embedded queries locally via `self._embedder.embed(query)`, then `SulciCloudBackend.search` POSTed `{embedding, threshold, tenant_id, user_id}` to the gateway — which 422-rejected because `CacheGetRequest` (sulci-platform `shared/models.py`) expects `{query, threshold, user_id, session_id}`. The SDK's outer `except Exception:` swallowed the 422, returning `(None, 0.0)`.

**The cloud backend has never worked end-to-end against the live gateway since v0.3.0** — pre-v0.5.7 silently 404'd (wrong URL), post-v0.5.7 silently 422's (wrong payload). Both surfaces returned silent misses to the caller; nothing in customer logs to investigate.

## The fix

`SulciCloudBackend` is a **transport** for the entire `Cache.get/set` call, not a `Backend` protocol implementer in the vector-search sense. The gateway-side library (`LibraryBackedCache` at `sulci-platform:gateway/app/services/sulci_cache.py`) does the engine work: embedding via `EmbedServiceEmbedder`, ANN search in managed Qdrant, `cache.set` billing emit.

- **`sulci/backends/cloud.py`**: remove `search()`, `store()`, `upsert()`; add `remote_get(query, threshold, *, user_id, session_id)` and `remote_set(query, response, *, user_id, session_id, ttl_seconds)` with canonical payloads matching `CacheGetRequest` / `CacheSetRequest` exactly. `delete_user()` and `clear()` left as silent no-ops — they hit nonexistent gateway routes (sulci-platform #103 territory).

- **`sulci/core.py`**: `Cache.__init__` sets `self._is_remote_transport = hasattr(backend, "remote_get") and hasattr(backend, "remote_set")`. `Cache.get` / `Cache.set` branch on the flag — cloud path forwards the raw query string and reads `context_depth` from the gateway response; self-hosted path is byte-for-byte unchanged.

- **`tests/compat/conftest.py`**: remove `SulciCloudBackend` from `BACKEND_CLASSES`. The conformance suite tests Backend protocol shape (`search`, `store`, `clear`) — after this PR, the cloud transport has `remote_get`/`remote_set` instead, so it doesn't belong in the protocol list. Transport surface is covered by the four classes in `tests/test_cloud_backend.py`.

## Behavior change for `Cache(backend="sulci")` customers

**Silent miss → real hits, for the first time since v0.3.0.** Self-hosted backends (chroma, qdrant, faiss, redis, sqlite, milvus) are unaffected.

## Three architectural points worth flagging

**1. Duck-typing over `isinstance` for transport detection.** No `from sulci.backends.cloud import SulciCloudBackend` in `core.py`. Capability-shape detection (`hasattr(backend, "remote_get")`) preserves the lazy-httpx-import property issue #60 will eventually fix at install level — `core.py` stays httpx-free, and any future alternative transport (internal forks, custom impls) automatically works without touching core.

**2. Pydantic round-trip as the regression guard.** `TestCanonicalGatewayPaths` no longer asserts "did the SDK send a string starting with `/v1/cache/`" — it asserts "would the gateway's pydantic model accept this payload." Vendored copies of `CacheGetRequest` / `CacheGetResponse` / `CacheSetRequest` live at `_GatewayContractModels` in the test file, pinned to `sulci-platform:shared/models.py` via a sync-comment. Every SDK payload is `model_validate()`-checked against these copies, so future field drift fails CI loudly rather than silently 422'ing in production — exactly how Issue #62 stayed live for ~14 months. Extends the v0.5.7 URL-pinning lesson from URLs to JSON payloads.

**3. `session_id` forwarded; client-supplied `tenant_id` removed from the wire — feature behavior unchanged.** Worth a careful read since the tenant_id story has several layers:

- **On the wire (SDK→gateway):** Pre-v0.6.0 the SDK sent `tenant_id` in the JSON body. The gateway **already ignored** that value and derived tenant identity from the api_key auth context anyway (see `gateway/app/middleware/auth.py::get_tenant` and the call site at `gateway/app/routes/cache.py:108`). Removing it from the wire just makes the auth-context derivation the only source of truth — a small attack-surface reduction.

- **Inside the gateway:** Unchanged. `tenant = await get_tenant(raw_key, redis, get_pool())` still produces a full tenant row, and `cache.get(req.query, tenant_id=str(tenant["tenant_id"]), ...)` still passes the gateway-derived `tenant_id` into the library call.

- **Every tenant-keyed feature works exactly as before:**
  - Qdrant data isolation (`QdrantBackend.ENFORCES_TENANT_ISOLATION = True`, payload-filter on `tenant_id` field)
  - Backend selection (`tenant["backend_id"]` from migration 004 drives `TenantAwareCachePool.get_or_create(backend_id, embedder_id)`)
  - Embedder selection (`tenant["embedding_model"]` from migration 003)
  - Per-tenant threshold (`tenant["threshold"]` from migration 006)
  - Plan-based gating (`tenant["plan"]` → `check_and_increment`, `CacheEvent.plan`)

- **Library API unchanged:** `Cache.get(query, tenant_id=...)` still accepts the kwarg — self-hosted users running multi-tenant code in their own process still need it. Only on the cloud transport branch is `tenant_id` dropped (the customer's api_key IS their tenant identity; they can't override it).

- **`session_id` newly forwarded:** Wires up the existing `session_id` kwarg on `Cache.get/set` that previously stopped at the SDK boundary. The gateway-side library now sees it and can do session-aware context lookups.

## Verification

| Step | Result |
|---|---|
| Full unit suite (`pytest tests/`) against real MiniLM | ✅ **469 passed, 30 skipped, 0 failed** in 17m30s |
| `tests/compat/` (Backend + Embedder protocol conformance) | ✅ all green after `SulciCloudBackend` exclusion from `BACKEND_CLASSES` |
| `tests/test_cloud_backend.py` (45 tests: TestRemoteGet/Set, TestCanonicalGatewayPaths, TestCloudTransportShortCircuit) | ✅ all pass |
| `make checkin` (smoke + per-file runner + examples + benchmark verifier) | ✅ all green |
| Benchmark vs baseline (5,000-query corpus + context-aware) | ✅ all metrics within tolerance, **no regression** — hit rate 85.9%, context-aware accuracy +20.8pp |

## Out of scope (deliberately)

- `SulciCloudBackend.delete_user()` / `.clear()` — hit nonexistent gateway routes; tracked as sulci-platform #103
- Platform-side `LibraryBackedCache` subclass retirement — follow-up enabled by PR 1 (#34 C1c+C1d, merged in #64)
- v0.6.0 docs cleanup (drifts #3, #4, #5 from the canonical-architecture audit) — PR 3
- Warning when a cloud user passes `tenant_id` to `Cache.get` — adjacent follow-up; current PR silently drops the kwarg on the cloud branch, which is correct behavior (matches the pre-v0.6.0 "gateway ignored it anyway" semantics) but could be louder

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
