### PR TITLE
release: v0.6.0 — cloud transport works end-to-end (umbrella #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [0.6.0] — 2026-05-11 — Cloud transport finally works (umbrella #63)
 
-> v0.6.0 work-in-progress. Three coordinated PRs under sulci-oss umbrella
-> [#63](https://github.com/sulci-io/sulci-oss/issues/63) — bringing
-> sulci-oss into compliance with canonical architecture v3. Each PR
-> appends to this section; the release PR consolidates and renames it
-> to `## [0.6.0]`.
+> Brings the cloud backend end-to-end alive for the first time since v0.3.0.
+> Three coordinated PRs under sulci-oss umbrella
+> [#63](https://github.com/sulci-io/sulci-oss/issues/63):
+> [#64](https://github.com/sulci-io/sulci-oss/pull/64) (Embedder + Backend
+> instance injection in `Cache.__init__`),
+> [#65](https://github.com/sulci-io/sulci-oss/pull/65) (cloud transport
+> short-circuits local embedding, sends canonical payload),
+> sulci-platform [#106](https://github.com/sulci-io/sulci-platform/pull/106)
+> (canonical-architecture-v3 diagram aligned with embedder layer reality).
+>
+> **Customer-visible:** `Cache(backend="sulci")` now returns real cache hits
+> instead of the silent `(None, 0.0)` it had been returning for ~14 months.
+> Pre-v0.6.0 the SDK sent a payload the gateway 422-rejected (post-v0.5.7;
+> 404'd pre-v0.5.7) and the SDK's outer `except Exception:` swallowed the
+> error. v0.6.0 sends the canonical wire payload, the gateway accepts it,
+> and the platform-side library does the embedding via `EmbedServiceEmbedder`.
+> Self-hosted backends (chroma, qdrant, faiss, redis, sqlite, milvus) are
+> completely unaffected.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.5.7"
+version = "0.6.0"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }


### PR DESCRIPTION
Release PR for v0.6.0 — completes the sulci-oss umbrella [#63](https://github.com/sulci-io/sulci-oss/issues/63).

## What ships in v0.6.0

| PR | Merge commit | Customer impact |
|---|---|---|
| [#64](https://github.com/sulci-io/sulci-oss/pull/64) — Cache instance injection | `6158cfe` | API surface: `Cache(embedding_model=<instance>, backend=<instance>)` now works natively. No subclassing needed. Existing string-based callers unchanged. |
| [#65](https://github.com/sulci-io/sulci-oss/pull/65) — Cloud transport short-circuit | `db7764b` | **`Cache(backend="sulci")` works end-to-end for the first time since v0.3.0.** Silent `(None, 0.0)` misses → real hits. |
| sulci-platform [#106](https://github.com/sulci-io/sulci-platform/pull/106) — diagram alignment | `fe71300` | Docs accuracy. No code impact. |

## The headline

**Cloud-tier customers see actual cache hits for the first time since v0.3.0.** Pre-v0.6.0, every `Cache(backend="sulci").get(...)` call returned a silent miss because the SDK was sending a payload shape the gateway rejected — pre-v0.5.7 it was a wrong URL (404), post-v0.5.7 it was the right URL but wrong payload (422). Both were swallowed by the SDK's outer `except Exception:` and surfaced as `(None, 0.0)` — appearing in customer apps as "sulci isn't caching anything."

v0.6.0 SDK sends the canonical `{query, threshold, user_id, session_id}` payload that the gateway's `CacheGetRequest` pydantic model expects, and the gateway-side library does the embedding via `EmbedServiceEmbedder`. Self-hosted backends (chroma, qdrant, faiss, redis, sqlite, milvus) are completely unaffected.

## API additions

- `Cache.__init__` accepts `Union[str, Embedder]` for `embedding_model=` and `Union[str, Backend]` for `backend=`. Strings still dispatch through the registry; instances pass through directly.
- `SulciCloudBackend.remote_get(query, threshold, *, user_id, session_id) -> (response, similarity, context_depth)`
- `SulciCloudBackend.remote_set(query, response, *, user_id, session_id, ttl_seconds) -> None`

## Breaking changes

- `SulciCloudBackend.search()`, `.store()`, and `.upsert()` removed. These were broken in production (silently 404'd or 422'd) so no caller could be using them successfully — but if you had code referencing these methods directly, it now raises `AttributeError` instead of silently failing.

## What follows v0.6.0

Two follow-up issues filed during umbrella closeout:

- sulci-platform [#107](https://github.com/sulci-io/sulci-platform/issues/107) — ER diagram drift cleanup
- sulci-platform [#108](https://github.com/sulci-io/sulci-platform/issues/108) — `LibraryBackedCache` retirement (enabled by #64)

## Release verification (sandbox)

| Check | Result |
|---|---|
| `pyproject.toml` parses cleanly | ✅ version = 0.6.0 |
| `CHANGELOG.md` Markdown structure | ✅ `## [0.6.0]` is now top heading; `## [0.5.7]` second |
| `## [Unreleased]` section removed | ✅ Zero occurrences |
| All PR 1 + PR 2 bullets preserved | ✅ Added/Changed/Removed/Tests sections unchanged |
| Patch dry-run vs `main` | ✅ Clean apply |

## After merge

1. Tag `v0.6.0` from `main`: `git tag -a v0.6.0 -m "Release v0.6.0 — cloud transport works end-to-end"`
2. Push the tag: `git push origin v0.6.0`
3. `publish.yml` workflow triggers → PyPI ships `sulci==0.6.0`
4. Verify on PyPI: https://pypi.org/project/sulci/0.6.0/

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
