### PR TITLE
release: v0.6.1 — fix cloud-only install path (sulci-oss #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,72 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.1] — 2026-05-11 — Fix cloud-only install path (sulci-oss #60)
+
+> Patch release. Closes a v0.6.0 install-path gotcha discovered during the
+> v0.6.0 release smoke test: `pip install "sulci[cloud]==0.6.0"` followed by
+> `Cache(backend="sulci", api_key=...)` crashed at construction with
+> `ImportError: sentence-transformers not found`. The cloud extra correctly
+> declares only `httpx>=0.27` (no sentence-transformers, since the cloud
+> transport doesn't do local embedding), but `Cache.__init__` eagerly
+> loaded a local `MiniLMEmbedder` regardless of which backend was selected.
+>
+> After this patch, `pip install "sulci[cloud]"` is enough to use
+> `Cache(backend="sulci", ...)` end-to-end. Self-hosted backends are
+> unaffected — they continue to load their embedder eagerly at construction
+> time, identical to v0.6.0 behavior.
+
+### Fixed
+
+- `Cache.__init__` defers the local `Embedder` load when the backend is a
+  cloud transport. Construction order is now: (1) load backend, (2) detect
+  remote transport via `hasattr(backend, "remote_get")`, (3) skip embedder
+  load when the flag is set. `self._embedder` stays `None` on the cloud
+  path; every read of it (in `_context_vec`, the self-hosted branches of
+  `Cache.get` / `Cache.set`, and the `cached_call` hit-record path) is
+  already gated by `self._is_remote_transport` or sits inside the
+  self-hosted `else:` branch. Closes sulci-oss
+  [#60](https://github.com/sulci-io/sulci-oss/issues/60).
+
+- `cached_call` hit-record session-tracking path now skips when
+  `_is_remote_transport` is True. Mirrors the same-pattern guard
+  (`raw_vec is not None`) already present in `Cache.set`. Without this
+  guard, a cache hit on a session-aware cloud `Cache` (`backend="sulci"` +
+  `context_window > 0`) would crash on `None.embed(query)`. Surfaced by
+  code-path audit during the #60 fix; no customer report (the combination
+  is unusual since cloud-tier session tracking happens on the gateway side).
+
+- Friendlier error when constructing a cloud `Cache` without `httpx`
+  installed: `_load_backend("sulci", ...)` now catches the
+  `ModuleNotFoundError` from `import httpx` inside
+  `sulci/backends/cloud.py` and re-raises with guidance to
+  `pip install "sulci[cloud]"`. Pre-v0.6.1 surfaced as a bare
+  `ModuleNotFoundError: No module named 'httpx'` — accurate but unhelpful.
+
+### Tests
+
+- New `TestCloudTransportNoLocalEmbedder` class in `tests/test_core.py` —
+  4 tests covering: (a) constructing `Cache` with a fake remote-transport
+  backend (object with `remote_get` + `remote_set` methods) leaves
+  `self._embedder` as `None`; (b) `Cache.get` round-trips through
+  `remote_get` without touching the embedder; (c) `Cache.set` round-trips
+  through `remote_set` without touching the embedder; (d) `cached_call`
+  hit-record session path skips embed call on remote transport. Uses the
+  same offline `_FakeBackend` injection pattern as `TestInstanceInjection`
+  (added in v0.6.0 PR #64) — no live gateway, no sentence-transformers
+  import required.
+
+### Behavior preserved (regression guard)
+
+- Self-hosted `Cache(backend="sqlite", ...)`, `Cache(backend="chroma", ...)`,
+  etc. still load `MiniLMEmbedder` eagerly at construction time — no
+  behavior change. The pre-existing test suite (469 tests, all green on
+  v0.6.0) continues to pass identically — the conditional only fires
+  when the backend exposes the `remote_get` / `remote_set` duck-type
+  protocol that v0.6.0 introduced.
+
+---
+
 ## [0.6.0] — 2026-05-11 — Cloud transport finally works (umbrella #63)
 
 > Brings the cloud backend end-to-end alive for the first time since v0.3.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.6.0"
+version = "0.6.1"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -220,7 +220,7 @@ class Cache:
         self.embedding_model = embedding_model
         self._stats          = {"hits": 0, "misses": 0, "saved_cost": 0.0}
 
-        self._embedder = self._load_embedder(embedding_model)
+        self._embedder = None  # set conditionally below — see v0.6.1 note
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
         # v0.6.0 (sulci-oss #62, umbrella #63) — cloud-transport detection.
@@ -240,6 +240,21 @@ class Cache:
             hasattr(self._backend, "remote_get") and
             hasattr(self._backend, "remote_set")
         )
+
+        # v0.6.1 (sulci-oss #60) — defer the local Embedder load when the
+        # backend is a remote transport. The gateway-side library does the
+        # embedding via EmbedServiceEmbedder, so the SDK's local embedder
+        # is never read on the cloud path (every call site is gated by
+        # `if self._is_remote_transport` — see Cache.get/Cache.set/cached_call).
+        # Loading it eagerly forced cloud-only users to install
+        # sentence-transformers (~80MB pulled by `sulci[chroma]`, `sulci[qdrant]`,
+        # etc.) even though `sulci[cloud]` correctly declares only `httpx>=0.27`.
+        # Pre-v0.6.1 manifestation: `pip install "sulci[cloud]==0.6.0"` +
+        # `Cache(backend="sulci", ...)` → ImportError on `sentence_transformers`
+        # from `MiniLMEmbedder.__init__`. After this change, _embedder stays at
+        # its placeholder None and the cloud-only install path works end-to-end.
+        if not self._is_remote_transport:
+            self._embedder = self._load_embedder(embedding_model)
 
         # ── v0.5.2 nudge counter (D15) ──
         # Tracks queries observed by THIS instance, used by .stats() to
@@ -314,7 +329,22 @@ class Cache:
                 or os.environ.get("SULCI_API_KEY")
                 or _module_key
             )
-            from sulci.backends.cloud import SulciCloudBackend
+            # v0.6.1 (sulci-oss #60) — catch the bare ModuleNotFoundError that
+            # `import httpx` raises at the top of sulci/backends/cloud.py when
+            # the cloud extra wasn't installed, and re-raise with install
+            # guidance. Pre-v0.6.1 the user saw a raw "No module named 'httpx'"
+            # which is accurate but unhelpful — no pointer to the fix.
+            try:
+                from sulci.backends.cloud import SulciCloudBackend
+            except ModuleNotFoundError as exc:
+                if exc.name == "httpx":
+                    raise ImportError(
+                        "Cloud backend (Cache(backend=\"sulci\", ...)) requires "
+                        "httpx. Install with:\n"
+                        "    pip install \"sulci[cloud]\"\n"
+                        f"(Original error: {exc})"
+                    ) from exc
+                raise  # any other ModuleNotFoundError is genuinely unexpected
             return SulciCloudBackend(
                 api_key     = resolved_key,
                 gateway_url = gateway_url,
@@ -630,8 +660,13 @@ class Cache:
             # cached_call() owns saved_cost since it's the only path that knows
             # cost_per_call.
             self._stats["saved_cost"] += cost_per_call
-            # Record turn even on hits so future queries see this exchange
-            if session_id and self._sessions:
+            # Record turn even on hits so future queries see this exchange.
+            # v0.6.1 (sulci-oss #60) — skip on remote transport: self._embedder
+            # is None there (gateway-side library tracks session state for the
+            # cloud path); without this gate, a session-aware cloud Cache would
+            # crash here on None.embed(). Mirrors the `raw_vec is not None`
+            # guard already present in Cache.set's session-record path.
+            if session_id and self._sessions and not self._is_remote_transport:
                 raw_vec = self._embedder.embed(query)
                 self._record_turn(session_id, query, hit, raw_vec)
             return {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -699,3 +699,137 @@ class TestInstanceInjection:
         # search() was reached
         assert len(be.search_calls) == 1
 
+
+# ─────────────────────────────────────────────────────────────────────────
+# v0.6.1 (sulci-oss #60) — cloud-transport construction without a local
+# embedder. Constructing Cache with a remote-transport backend should NOT
+# trigger a local Embedder load (and therefore must not require
+# sentence-transformers to be installed). These tests use a minimal fake
+# remote-transport backend — duck-typed via remote_get/remote_set, the
+# same protocol that v0.6.0 #65 introduced for SulciCloudBackend.
+# ─────────────────────────────────────────────────────────────────────────
+
+class _FakeRemoteTransport:
+    """Minimal remote-transport-shaped fake.
+
+    Duck-types the cloud-transport protocol: exposes remote_get + remote_set.
+    Cache.__init__'s capability check (hasattr) treats any object with both
+    methods as a transport, which is exactly the v0.6.0 #65 contract.
+
+    Records every call so tests can assert that Cache.get/Cache.set routed
+    through the transport rather than the self-hosted self._embedder /
+    self._backend.search path.
+    """
+
+    def __init__(self, get_returns=("hit-response", 0.95, 0)):
+        self.remote_get_calls  = []
+        self.remote_set_calls  = []
+        self._get_returns      = get_returns  # (response, similarity, context_depth)
+
+    def remote_get(self, *, query, threshold, user_id=None, session_id=None):
+        self.remote_get_calls.append({
+            "query":      query,
+            "threshold":  threshold,
+            "user_id":    user_id,
+            "session_id": session_id,
+        })
+        return self._get_returns
+
+    def remote_set(self, *, query, response, user_id=None, session_id=None,
+                   ttl_seconds=None):
+        self.remote_set_calls.append({
+            "query":       query,
+            "response":    response,
+            "user_id":     user_id,
+            "session_id":  session_id,
+            "ttl_seconds": ttl_seconds,
+        })
+
+
+class TestCloudTransportNoLocalEmbedder:
+    """v0.6.1 — Cache(remote_transport_backend) skips local Embedder load."""
+
+    def test_construction_skips_embedder_load(self):
+        """Cache with a remote-transport backend keeps self._embedder as None.
+
+        This is the headline fix: cloud-only users (`pip install sulci[cloud]`)
+        do not need sentence-transformers installed. The eager embedder load
+        in v0.6.0 caused a hard ImportError at Cache.__init__ on the cloud
+        path; v0.6.1 defers it.
+        """
+        transport = _FakeRemoteTransport()
+        cache = Cache(backend=transport)
+
+        assert cache._is_remote_transport is True
+        assert cache._embedder is None, (
+            "Cloud transport should NOT trigger a local embedder load. "
+            "If this fires after a code change, audit Cache.__init__ for "
+            "an unconditional _load_embedder() call."
+        )
+
+    def test_get_routes_through_transport_without_embedder(self):
+        """Cache.get forwards the raw query string to remote_get; never
+        touches self._embedder (which is None).
+        """
+        transport = _FakeRemoteTransport(
+            get_returns=("Python is great.", 0.92, 0),
+        )
+        cache = Cache(backend=transport, threshold=0.85)
+
+        resp, sim, depth = cache.get("What is Python?")
+
+        assert resp  == "Python is great."
+        assert sim   == 0.92
+        assert depth == 0
+        # Transport was called once with the raw query, threshold passed through
+        assert len(transport.remote_get_calls) == 1
+        call = transport.remote_get_calls[0]
+        assert call["query"]     == "What is Python?"
+        assert call["threshold"] == 0.85
+        # Sanity: no embedder ever materialized
+        assert cache._embedder is None
+
+    def test_set_routes_through_transport_without_embedder(self):
+        """Cache.set forwards (query, response) to remote_set; never touches
+        self._embedder.
+        """
+        transport = _FakeRemoteTransport()
+        cache = Cache(backend=transport, ttl_seconds=600)
+
+        cache.set("What is Python?", "A programming language.")
+
+        assert len(transport.remote_set_calls) == 1
+        call = transport.remote_set_calls[0]
+        assert call["query"]       == "What is Python?"
+        assert call["response"]    == "A programming language."
+        assert call["ttl_seconds"] == 600
+        # Sanity: no embedder ever materialized
+        assert cache._embedder is None
+
+    def test_cached_call_hit_with_session_skips_local_embed(self):
+        """cached_call() hit-record path must not call self._embedder.embed()
+        on a remote-transport Cache, even when session_id + context_window
+        are set. Without the v0.6.1 gate this would crash on None.embed().
+        """
+        transport = _FakeRemoteTransport(
+            get_returns=("cached answer", 0.99, 0),
+        )
+        cache = Cache(
+            backend        = transport,
+            context_window = 4,   # session-tracking enabled
+        )
+
+        result = cache.cached_call(
+            query      = "What is Python?",
+            llm_fn     = lambda q, **kw: "should not be called",
+            session_id = "test-session-001",
+        )
+
+        # cached_call should have returned the cached hit without invoking
+        # llm_fn and without crashing on None.embed()
+        assert result["cache_hit"] is True
+        assert result["response"]  == "cached answer"
+        assert result["source"]    == "cache"
+        # And confirm the embedder really is None (i.e. the test
+        # demonstrates the gate, not a side-channel)
+        assert cache._embedder is None


### PR DESCRIPTION
Patch release closing the install-path gotcha discovered during the
v0.6.0 release smoke test. pip install "sulci[cloud]==0.6.0" +
Cache(backend="sulci", api_key=...) crashed at construction with
ImportError: sentence-transformers not found.

The sulci[cloud] extra correctly declares only httpx (no
sentence-transformers, since the cloud transport doesn't do local
embedding), but Cache.__init__ eagerly loaded MiniLMEmbedder
regardless of which backend was selected. After this patch, the
cloud-only install path works end-to-end.

Three fixes in sulci/core.py:

- Cache.__init__ defers local Embedder load when the backend is a
  remote transport. Construction order is now (1) load backend,
  (2) detect remote transport via hasattr(backend, "remote_get"),
  (3) skip embedder load if the flag is set. self._embedder stays
  at its placeholder None on the cloud path; every read of it
  (in _context_vec, the self-hosted branches of Cache.get/Cache.set,
  and the cached_call hit-record path) is already gated behind
  self._is_remote_transport or sits inside the self-hosted else:
  branch. Closes sulci-oss #60.

- cached_call hit-record session-tracking path now skips when
  _is_remote_transport is True. Mirrors the raw_vec is not None
  guard already present in Cache.set's session-record line. Without
  this gate, a cache hit on a session-aware cloud Cache
  (backend="sulci" + context_window > 0) would crash on None.embed().

- _load_backend("sulci", ...) wraps the cloud module import in a
  try/except that catches ModuleNotFoundError for httpx and re-raises
  with guidance to pip install "sulci[cloud]". Pre-v0.6.1 surfaced
  as a bare ModuleNotFoundError: No module named 'httpx'.

Tests: new TestCloudTransportNoLocalEmbedder class in
tests/test_core.py (4 tests) covers (a) construction skips embedder
load on remote transport, (b) Cache.get round-trips through
remote_get without touching the embedder, (c) Cache.set round-trips
through remote_set without touching the embedder, (d) cached_call
hit-record session path skips embed call on remote transport. Uses
the same offline _FakeBackend pattern as TestInstanceInjection (v0.6.0
PR #64) — no live gateway, no sentence-transformers required.

Full make checkin verified locally:
- 473 passed / 30 skipped / 0 failed across 18 test files (+4 from
  v0.6.0's 469, exactly the new TestCloudTransportNoLocalEmbedder)
- All 4 smoke-test suites green (core, LangChain, LlamaIndex,
  AsyncCache) — 12/12 examples pass with mocked LLMs
- Benchmark byte-identical to pre-v0.4.0 baseline (commit 35a0c86):
  hit_rate 0.8588, saved_cost $21.47, accuracy_delta +20.80pp, all
  per-domain deltas within tolerance — no regression on the
  customer-facing performance numbers.

After merge, tag v0.6.1 to trigger publish.yml → PyPI ships
sulci==0.6.1.
