### PR TITLE
release: v0.6.4 — drain telemetry buffer on process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.4] — 2026-05-12 — Drain telemetry buffer on process exit
+
+> Patch release. Closes the "I ran the snippet, nothing appeared on
+> app.sulci.io" failure mode: short-lived processes (CLI commands,
+> demo scripts, serverless invocations, test runs) now flush their
+> telemetry buffer before exit instead of silently dropping it.
+
+### Changed
+
+- `_start_flush_thread()` now registers an `atexit` hook that drains
+  the event buffer on process exit. Previously, the daemon flush
+  thread was killed when the main thread exited, losing any events
+  buffered since the last 30s tick — which for any process shorter
+  than 30 seconds meant *all* events.
+
+### Why this matters
+
+Before v0.6.4: running the /why-connect demo snippet (or any script
+shorter than 30 seconds) showed no telemetry on app.sulci.io. The
+script exited before the first 30-second flush tick fired, and the
+daemon thread died with the buffer intact. Workaround required adding
+`time.sleep(35)` to scripts — fine for development, broken for
+serverless/CLI use cases where it's not feasible.
+
+After v0.6.4: the same script flushes its buffer at process exit
+(typically within a few hundred milliseconds), then exits cleanly.
+Telemetry appears on the dashboard within ~1-2 seconds of script
+completion.
+
+### Verification
+
+A new behavioral test `tests/test_telemetry_lifecycle.py::
+TestAtexitFlush::test_flush_on_exit_drains_buffer` mocks the HTTP
+layer, emits an event, runs `atexit._run_exitfuncs()`, and asserts
+the POST to `/v1/telemetry` was made. Catches future regressions
+where someone removes the atexit hook or changes the flush thread
+to non-daemon (which would block process exit instead).
+
+### Backward compatibility
+
+- No API surface changes. Same `sulci.connect(...)` signature.
+- Long-running services (web servers, batch jobs, the benchmark
+  suite) are unaffected — the existing 30-second flush loop continues
+  to run identically. The atexit hook only fires once, at process
+  exit, and is a no-op if telemetry is disabled.
+- The atexit handler is wrapped in try/except to preserve the
+  "telemetry never raises" contract. A stalled gateway at exit will
+  delay process termination by httpx's default timeout but won't
+  crash the process.
+
+---
+
 ## [0.6.3] — 2026-05-12 — Promote `httpx` to mandatory dependency (closes B1)
 
 > Patch release. Closes a packaging gap that was open since the first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.6.3"
+version = "0.6.4"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -63,6 +63,7 @@ LlamaIndex async agents, and any asyncio-based application:
 All constructor parameters are identical to Cache.
 """
 
+import atexit
 import os
 import threading
 import time
@@ -471,6 +472,12 @@ def _start_flush_thread() -> None:
 
     Uses a module-level flag rather than checking thread.is_alive() to
     avoid the overhead of thread object lookup on every connect() call.
+
+    Also registers an :mod:`atexit` hook to drain the buffer on process
+    exit — the daemon flush thread dies the moment the main thread
+    exits, so without this hook any events buffered since the last 30s
+    tick would be silently lost. Affects every short-lived process:
+    CLI commands, serverless invocations, test runs, demo scripts.
     """
     global _flush_thread_started
     if _flush_thread_started:
@@ -478,6 +485,28 @@ def _start_flush_thread() -> None:
     _flush_thread_started = True
     t = threading.Thread(target=_flush_loop, daemon=True, name="sulci-telemetry-flush")
     t.start()
+
+    # v0.6.4: drain buffer on process exit. Wrapped in try/except so
+    # it preserves the "telemetry never raises" contract; a stalled
+    # gateway at exit delays termination by httpx's default timeout
+    # but won't crash the process or break the user's code.
+    atexit.register(_flush_on_exit)
+
+
+def _flush_on_exit() -> None:
+    """atexit handler — drain any remaining buffered events.
+
+    Called automatically by the Python interpreter at normal process
+    exit. No-op if telemetry was disabled (or never enabled) since
+    last :func:`connect`."""
+    try:
+        if _telemetry_enabled:
+            _flush()
+    except Exception:
+        # The telemetry contract is "never raise" — an exception here
+        # would be reported by the atexit machinery as a warning. We
+        # swallow silently to match the contract everywhere else.
+        pass
 
 
 # ── Core library imports (lazy) ───────────────────────────────────────────────

--- a/tests/test_telemetry_lifecycle.py
+++ b/tests/test_telemetry_lifecycle.py
@@ -1,0 +1,128 @@
+"""
+Lifecycle tests for the telemetry pipe (v0.6.4+).
+
+Pre-v0.6.4, the flush thread was a daemon with NO atexit hook, so
+short-lived processes (demo scripts, CLI invocations, serverless,
+test runs) silently lost every event buffered since the last 30s
+flush tick. v0.6.4 added `atexit.register(_flush_on_exit)` inside
+`_start_flush_thread()` to drain the buffer on process exit.
+
+These tests pin that invariant. If a future PR removes the atexit
+hook, changes the flush thread to non-daemon (which would block
+process exit), or breaks the "never raise" contract on exit, these
+tests fail loudly.
+"""
+from __future__ import annotations
+
+import atexit
+from unittest import mock
+
+import pytest
+
+import sulci
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    """Reset module-level state so tests don\'t pollute each other."""
+    yield
+    sulci._api_key = None
+    sulci._telemetry_enabled = False
+    sulci._event_buffer.clear()
+    sulci._flush_thread_started = False
+
+
+class TestAtexitFlush:
+    """v0.6.4 regression: short-lived processes must drain buffer on exit."""
+
+    def test_flush_on_exit_drains_buffer(self, monkeypatch):
+        """The headline guarantee — a script that exits before the 30s
+        flush tick still gets its events to the gateway."""
+        posts = []
+
+        def fake_post(url, json=None, **kwargs):
+            posts.append({"url": url, "body": json})
+            response = mock.MagicMock()
+            response.status_code = 200
+            response.raise_for_status = mock.MagicMock()
+            return response
+
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        sulci.connect(api_key="sk-sulci-test-key", telemetry=True)
+        sulci._emit(
+            event="cache.get",
+            data={"backend": "sqlite", "hit": True, "latency_ms": 0.5},
+        )
+
+        # Buffer has the event (plus the \'startup\' event from connect()),
+        # no POST yet (would have happened on the 30s tick).
+        assert len(sulci._event_buffer) >= 1
+        assert posts == [], "no POST should have happened before exit"
+
+        # Simulate process exit
+        atexit._run_exitfuncs()
+
+        assert len(posts) >= 1, (
+            "v0.6.4 regression: telemetry buffer not drained at process exit. "
+            "Was atexit.register(_flush_on_exit) removed from _start_flush_thread()? "
+            "Was the daemon flush thread changed to non-daemon (which would "
+            "block process exit instead)?"
+        )
+        assert "/v1/telemetry" in posts[0]["url"]
+
+    def test_flush_on_exit_never_raises(self, monkeypatch):
+        """The flush-on-exit hook must preserve the "telemetry never
+        raises" contract even when the gateway returns an error."""
+        def explosive_post(*args, **kwargs):
+            raise RuntimeError("simulated gateway failure")
+
+        monkeypatch.setattr("httpx.post", explosive_post)
+
+        sulci.connect(api_key="sk-sulci-test-key", telemetry=True)
+        sulci._emit(
+            event="cache.get",
+            data={"backend": "sqlite", "hit": True, "latency_ms": 0.5},
+        )
+
+        try:
+            atexit._run_exitfuncs()
+        except RuntimeError:
+            pytest.fail(
+                "flush-on-exit must not propagate exceptions — the "
+                "\'telemetry never raises\' contract was violated."
+            )
+
+    def test_flush_on_exit_no_op_when_telemetry_disabled(self, monkeypatch):
+        """If telemetry was disabled (or never enabled), the hook
+        should make no HTTP calls."""
+        posts = []
+
+        def fake_post(url, json=None, **kwargs):
+            posts.append({"url": url})
+            return mock.MagicMock(status_code=200, raise_for_status=mock.MagicMock())
+
+        monkeypatch.setattr("httpx.post", fake_post)
+
+        sulci._flush_on_exit()  # without connect()
+
+        assert posts == [], (
+            "flush-on-exit must be a no-op when telemetry is disabled "
+            "(prevents stray POSTs from libraries that don\'t opt in)"
+        )
+
+    def test_flush_thread_is_daemon(self):
+        """The flush thread must stay daemon — non-daemon threads
+        block process exit, which would create a different bug:
+        scripts hanging for 30s on exit instead of losing telemetry."""
+        import threading
+        sulci.connect(api_key="sk-sulci-test-key", telemetry=True)
+
+        flush_threads = [t for t in threading.enumerate()
+                         if t.name == "sulci-telemetry-flush"]
+        assert flush_threads, "flush thread should be running after connect()"
+        assert all(t.daemon for t in flush_threads), (
+            "flush thread must be daemon — non-daemon would block process "
+            "exit indefinitely, replacing the v0.6.4 \'lost events\' bug "
+            "with a \'hung process\' bug."
+        )


### PR DESCRIPTION
Patch release. Closes the 'demo snippet runs, dashboard shows nothing' failure mode by registering an atexit hook to drain the telemetry buffer on process exit.

**Verification:** new tests/test_telemetry_lifecycle.py with 4 behavioral tests. Existing flow contract suite + unit tests still pass.

**Backward compat:** no API changes. Long-running services unaffected — existing 30s flush loop continues; atexit only fires only once, at exit.

**End-to-end verified:** new dashboard fingerprint appeared on app.sulci.io within ~2 seconds of a sub-5-second demo snippet run, confirming the atexit hook drains the buffer correctly. Pre-v0.6.4 the same run produced nothing on the dashboard.

See CHANGELOG.md for full breakdown.