### PR TITLE
fix(sdk): age-out stale ~/.sulci/config keys with WARNING (closes #80)

### DIFF
--- a/sulci/__init__.py
+++ b/sulci/__init__.py
@@ -326,18 +326,85 @@ def _config_file_mtime() -> Optional[str]:
     return None
 
 
+# ── Config staleness threshold ───────────────────────────────────────────────
+# Persisted ~/.sulci/config keys older than this are skipped during
+# resolution (treated as stale). 90 days is generous enough that
+# legitimate persisted keys from regular users do not hit it but tight
+# enough that stale keys from old account-cycling sessions get caught.
+# See sulci-oss #80 for context.
+_CONFIG_MAX_AGE_DAYS = 90
+
+
 def _read_key_from_config() -> Optional[str]:
-    """Read api_key from ~/.sulci/config. Tolerant of any failure mode —
-    missing file, malformed JSON, permission denied — all return None
-    so the next resolution step (the device-code flow) can proceed.
+    """Read api_key from ~/.sulci/config, with staleness guard.
+
+    Returns ``None`` (skipping the config rung in resolution) when:
+
+      - ``written_at`` field is missing (config predates v0.6.5 — treated
+        as stale because we cannot verify the age)
+      - ``written_at`` is older than ``_CONFIG_MAX_AGE_DAYS``
+      - ``written_at`` is unparseable (corrupt or future-incompatible)
+      - any other failure mode (file missing, malformed JSON, permission
+        denied) — these are silent per the config module design rules
+
+    On each stale-skip path, emits a WARNING log line telling the user
+    how to refresh the key (re-run with ``prompt=True`` or pass
+    ``api_key=`` explicitly).
 
     The config module is dependency-free + corruption-tolerant by its
     own design rules (see sulci/config.py module docstring), but we
     still wrap with try/except as defense-in-depth.
+
+    Closes sulci-oss #80. Added 2026-05-13.
     """
     try:
+        import datetime
         from sulci import config
-        return config.load().get("api_key")
+        data = config.load()
+        api_key = data.get("api_key")
+        if not api_key:
+            return None
+
+        # Staleness guard.
+        written_at_str = data.get("written_at")
+        if not written_at_str:
+            log.warning(
+                "sulci.connect: ~/.sulci/config has no written_at timestamp "
+                "(predates v0.6.5) — treating as stale and skipping. "
+                "Re-run with sulci.connect(prompt=True) to refresh the "
+                "persisted key, or pass api_key=... explicitly."
+            )
+            return None
+
+        try:
+            written_at = datetime.datetime.fromisoformat(written_at_str)
+            # Defensive: a tz-naive value (shouldn't happen with our writer,
+            # but a hand-edited config might) is assumed UTC so the
+            # subtraction below is well-defined.
+            if written_at.tzinfo is None:
+                written_at = written_at.replace(tzinfo=datetime.timezone.utc)
+        except (ValueError, TypeError):
+            log.warning(
+                "sulci.connect: ~/.sulci/config has unparseable written_at "
+                "value (%r) — treating as stale and skipping. "
+                "Re-run with sulci.connect(prompt=True) to refresh, or pass "
+                "api_key=... explicitly.",
+                written_at_str,
+            )
+            return None
+
+        age = datetime.datetime.now(tz=datetime.timezone.utc) - written_at
+        if age.days > _CONFIG_MAX_AGE_DAYS:
+            log.warning(
+                "sulci.connect: ~/.sulci/config is %d days old "
+                "(written %s; threshold %d days) — treating as stale and "
+                "skipping. Re-run with sulci.connect(prompt=True) to "
+                "refresh, or pass api_key=... explicitly.",
+                age.days, written_at_str, _CONFIG_MAX_AGE_DAYS,
+            )
+            return None
+
+        return api_key
     except Exception:
         return None
 

--- a/sulci/config.py
+++ b/sulci/config.py
@@ -130,9 +130,22 @@ def update(**fields: Any) -> bool:
 
     A corrupt or missing file is treated as ``{}`` (so ``update`` can be
     called as a first-write). Returns ``True`` on a successful save.
+
+    When ``api_key`` is among the fields being written, auto-stamps a
+    ``written_at`` UTC ISO-8601 timestamp on the saved dict. This lets
+    :func:`sulci.connect` detect stale persisted keys and refuse to
+    use a config that's older than the staleness threshold (90 days).
+    Added 2026-05-13 (sulci-oss #80). Other field writes (e.g.
+    ``machine_id``-only via :func:`get_machine_id`) do not stamp,
+    because they don't represent a fresh authentication event.
     """
+    import datetime
     data = load()
     data.update(fields)
+    if "api_key" in fields:
+        data["written_at"] = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        ).isoformat(timespec="seconds")
     return save(data)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,3 +174,65 @@ class TestGetMachineId:
         """If config already has a machine_id, return it verbatim."""
         cfg.save({"machine_id": "preexisting"})
         assert cfg.get_machine_id() == "preexisting"
+
+
+class TestWrittenAtStamping:
+    """update() auto-stamps written_at when api_key is among the fields.
+
+    Added 2026-05-13 for sulci-oss #80 — the config staleness guard. The
+    api_key/written_at pair must always travel together so the resolution
+    chain in sulci.connect() can detect stale persisted keys.
+
+    Other field writes (machine_id-only, etc.) must NOT trip the stamp,
+    because they don't represent a fresh authentication event.
+    """
+
+    def test_update_with_api_key_stamps_written_at(self, tmp_path, monkeypatch):
+        """A config.update(api_key=...) call must persist a written_at
+        timestamp alongside the key."""
+        from sulci import config
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config.update(api_key="sk-sulci-fresh-aaaaaaaaaaaaaaaaaaaa")
+        data = config.load()
+        assert data["api_key"] == "sk-sulci-fresh-aaaaaaaaaaaaaaaaaaaa"
+        assert "written_at" in data
+        assert "T" in data["written_at"]
+        assert data["written_at"].endswith("+00:00")
+
+    def test_update_without_api_key_does_not_stamp(self, tmp_path, monkeypatch):
+        """A config.update(machine_id=...) call (the get_machine_id() path)
+        must NOT stamp written_at."""
+        from sulci import config
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config.update(machine_id="abc123")
+        data = config.load()
+        assert data["machine_id"] == "abc123"
+        assert "written_at" not in data
+
+    def test_update_with_both_api_key_and_other_fields_stamps(
+        self, tmp_path, monkeypatch
+    ):
+        """Mixed-field update — api_key plus extras — still stamps written_at."""
+        from sulci import config
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config.update(api_key="sk-sulci-bbbbbbbbbbbbbbbbbbbbbbbbb",
+                      machine_id="def456")
+        data = config.load()
+        assert data["api_key"] == "sk-sulci-bbbbbbbbbbbbbbbbbbbbbbbbb"
+        assert data["machine_id"] == "def456"
+        assert "written_at" in data
+
+    def test_update_with_api_key_refreshes_existing_written_at(
+        self, tmp_path, monkeypatch
+    ):
+        """When a config already has a written_at from a previous write,
+        the next api_key write must REFRESH it (not keep the old one)."""
+        from sulci import config
+        import time
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config.update(api_key="sk-sulci-first-aaaaaaaaaaaaaaaaaaaa")
+        first = config.load()["written_at"]
+        time.sleep(1.1)
+        config.update(api_key="sk-sulci-second-aaaaaaaaaaaaaaaaaaaa")
+        second = config.load()["written_at"]
+        assert second > first  # ISO timestamps sort lexically

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -302,6 +302,104 @@ class TestResolutionPathLogging:
         assert "using explicit api_key argument" not in caplog.text
 
 
+class TestConfigAgeOut:
+    """~/.sulci/config staleness guard (sulci-oss #80).
+
+    Pre-#80, a persisted config file from months ago would silently
+    win the resolution-chain race and route telemetry to whatever
+    account that key was issued under, with no signal to the caller.
+    #80 adds an age-out: configs without a ``written_at`` field
+    (anything pre-v0.6.5) or older than 90 days are skipped, and a
+    WARNING line tells the user how to refresh.
+
+    These tests pin the invariant from each direction:
+      - fresh config still used (no false-stale rejection)
+      - stale config skipped + WARNING emitted
+      - missing written_at treated as stale (legacy pre-#80 files)
+      - unparseable written_at treated as stale (corrupt files)
+      - WARNING text tells the user how to fix it
+    """
+
+    def _build_config_dict(self, days_ago: int):
+        """Construct a config payload with written_at days_ago in the past."""
+        import datetime
+        ts = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=days_ago)
+        return {
+            "api_key":    "sk-sulci-fresh-key-aaaaaaaaaaaaaaaaaaaa",
+            "written_at": ts.isoformat(timespec="seconds"),
+        }
+
+    def test_fresh_config_returns_api_key(self, caplog, monkeypatch):
+        """A config 1 day old is well within threshold — returned normally,
+        no WARNING emitted."""
+        import sulci
+        monkeypatch.delenv("SULCI_API_KEY", raising=False)
+        with patch("sulci.config.load",
+                   return_value=self._build_config_dict(days_ago=1)):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                result = sulci._read_key_from_config()
+        assert result == "sk-sulci-fresh-key-aaaaaaaaaaaaaaaaaaaa"
+        assert "stale" not in caplog.text.lower()
+
+    def test_config_at_threshold_boundary_returned(self, caplog, monkeypatch):
+        """A config exactly at the 90-day boundary is still considered fresh
+        (the check uses ``>``, not ``>=``). Documents the boundary semantics
+        so future tweaks notice if it changes."""
+        import sulci
+        monkeypatch.delenv("SULCI_API_KEY", raising=False)
+        with patch("sulci.config.load",
+                   return_value=self._build_config_dict(days_ago=90)):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                result = sulci._read_key_from_config()
+        assert result == "sk-sulci-fresh-key-aaaaaaaaaaaaaaaaaaaa"
+        assert "stale" not in caplog.text.lower()
+
+    def test_stale_config_skipped_with_warning(self, caplog, monkeypatch):
+        """A config 91 days old is over the threshold — skipped (returns None)
+        and emits WARNING describing the situation and the fix."""
+        import sulci
+        monkeypatch.delenv("SULCI_API_KEY", raising=False)
+        with patch("sulci.config.load",
+                   return_value=self._build_config_dict(days_ago=91)):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                result = sulci._read_key_from_config()
+        assert result is None
+        assert "stale" in caplog.text.lower()
+        assert "91 days old" in caplog.text or "91 days" in caplog.text
+        assert "prompt=True" in caplog.text
+        assert "api_key=" in caplog.text
+
+    def test_missing_written_at_treated_as_stale(self, caplog, monkeypatch):
+        """A legacy config (pre-v0.6.5) has no ``written_at`` field. Treated
+        as stale because we cannot verify the age."""
+        import sulci
+        monkeypatch.delenv("SULCI_API_KEY", raising=False)
+        legacy_config = {"api_key": "sk-sulci-legacy-aaaaaaaaaaaaaaaaaaaa"}
+        with patch("sulci.config.load", return_value=legacy_config):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                result = sulci._read_key_from_config()
+        assert result is None
+        assert "no written_at timestamp" in caplog.text
+        assert "predates v0.6.5" in caplog.text
+        assert "prompt=True" in caplog.text
+
+    def test_unparseable_written_at_treated_as_stale(self, caplog, monkeypatch):
+        """A corrupt or non-ISO ``written_at`` value is treated as stale
+        rather than crashing the resolution chain."""
+        import sulci
+        monkeypatch.delenv("SULCI_API_KEY", raising=False)
+        corrupt_config = {
+            "api_key":    "sk-sulci-corrupt-aaaaaaaaaaaaaaaaaaaa",
+            "written_at": "not-a-valid-iso-timestamp",
+        }
+        with patch("sulci.config.load", return_value=corrupt_config):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                result = sulci._read_key_from_config()
+        assert result is None
+        assert "unparseable written_at" in caplog.text
+        assert "prompt=True" in caplog.text
+
+
 class TestEmit:
     def setup_method(self):
         _reset_module()


### PR DESCRIPTION
Closes #80. Companion to #79 (PR #82, merged).

## What

`sulci/__init__.py::_read_key_from_config()` now refuses to use `~/.sulci/config` entries that are stale. `sulci/config.py::update()` auto-stamps `written_at` whenever `api_key` is being written.

## Behavior

Three reject paths, all returning `None` and emitting WARNING:

1. **Missing `written_at`** — config predates v0.6.5, can't verify age, treat as stale
2. **Older than 90 days** — over threshold
3. **Unparseable `written_at`** — corrupt or future-incompatible

WARNING example:

```
sulci.connect: ~/.sulci/config is 127 days old (written
2026-01-06T10:30:00+00:00; threshold 90 days) — treating as stale
and skipping. Re-run with sulci.connect(prompt=True) to refresh,
or pass api_key=... explicitly.
```

## Upgrade path note

The 'missing `written_at`' rule is strict by design: existing pre-v0.6.5 configs will all get skipped on first connect() call after upgrade. This forces one fresh re-auth, giving us a known-fresh key with a known timestamp going forward. Users who don't want to re-auth pass `api_key=` explicitly to bypass.

## Acceptance criteria (from #80)

- [x] `~/.sulci/config` writes include a `written_at` ISO timestamp
- [x] `sulci.connect()` rejects (or warns + skips) config older than 90 days
- [x] WARNING log line tells the user what to do (re-run with `prompt=True` or pass `api_key=`)
- [x] Test coverage for: fresh config used, stale config skipped, missing `written_at` treated as stale

## Verification

- All 9 new tests pass (5 in TestConfigAgeOut + 4 in TestWrittenAtStamping)
- `make checkin` clean: 496 passed, 0 failed, 0 errors, 30 skipped
- Benchmark verification: all metrics within tolerance (Δ=+0.0000 across the board) vs pre-v0.4.0 baseline
- Telemetry lifecycle suite + #82's TestResolutionPathLogging: still pass — no cross-contamination