### PR TITLE
feat(v0.7.0): Cache() auto-connects telemetry when an api_key is resolvable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,119 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.6.5] — 2026-05-13 — `sulci.connect()` resolution-path observability + config staleness guard
+## [0.7.0] — 2026-05-26 — Cache() auto-connects telemetry when an api_key is resolvable
+
+> Minor release closing a long-running footgun across **all tiers**
+> (OSS-Connect, Pro, Business): pre-0.7.0, constructing
+> `Cache(backend="sulci", api_key=...)` registered the key for cache backend
+> auth but did **not** enable the telemetry flush path. The four
+> telemetry-backed dashboard panels — TrendChart, AuditEventsTable,
+> DeploymentsTable, the Active-SDKs counter — stayed empty until the user
+> separately called `sulci.connect()`. The aggregate stat cards (Cost Saved,
+> Hit Rate, Requests, Quota) populated normally via the cache event pipeline,
+> producing a half-broken dashboard that looked like a product bug.
+>
+> The footgun was identical for paid managed-tier customers: a $29/mo Pro
+> tenant following the documented `Cache(backend="sulci", api_key=...)`
+> quickstart would land on `ProOverview` with a blank trend chart and empty
+> audit feed immediately after upgrade.
+>
+> v0.7.0 unifies the opt-in rule per §5.2 trust-boundary spec and
+> sulci-oss ADR 0001 (mirror: sulci-platform ADR 0021):
+>
+>     If api_key is resolvable AND telemetry=True (default) → telemetry flows.
+>
+> One sentence. Three personas covered (paid managed, OSS-Connect, pure
+> self-hosted). One canonical quickstart shape everywhere.
+
+### Changed — Cache() auto-connects telemetry
+
+- `Cache.__init__` now auto-calls `sulci.connect()` when **all three** hold:
+  1. `self._telemetry` is `True` (the constructor default; explicit
+     `telemetry=False` opt-out remains and wins),
+  2. an api_key is resolvable from any of `{kwarg, SULCI_API_KEY env,
+     module-level _api_key set by a prior connect()}`,
+  3. `sulci._telemetry_enabled` is still `False` (no prior `connect()` has
+     run — the user's earlier explicit `telemetry=False` choice survives).
+- Auto-connect runs with `prompt=False` so it never blocks Cache
+  construction on a 15-minute device-code timeout. Users who want the
+  device-code flow continue to call `sulci.connect(prompt=True)` explicitly
+  before constructing a Cache; the "already connected" short-circuit
+  preserves that ordering.
+- Auto-connect failures **never crash Cache construction**. The cache
+  itself stays fully functional; only telemetry stays disabled, and a
+  WARNING is logged on the `sulci` logger naming the exception type +
+  message and pointing the operator at `sulci.connect()` to retry.
+
+### Why this is not a breaking change
+
+- The semantic contract — *passing an api_key is explicit opt-in to
+  telemetry* — was already documented in §5.2 trust-boundary spec via the
+  "or set SULCI_API_KEY" clause. v0.7.0 makes the kwarg path behave
+  identically to the env-var path that was already an authorized opt-in
+  signal.
+- Users who want the prior "cache without telemetry" shape have a clean,
+  documented opt-out: `Cache(backend="sulci", api_key=..., telemetry=False)`.
+  That kwarg has existed since the cloud backend shipped (v0.6.x); v0.7.0
+  doesn't change its semantics, only makes it more useful as an explicit
+  opt-out anchor.
+- Existing `sulci.connect()` callsites are unchanged. The short-circuit
+  at `_telemetry_enabled is False` (rung 3 above) means any prior
+  `connect()` invocation wins — including `connect(telemetry=False)`.
+
+### Canonical one-line quickstart (new)
+
+The pattern that now works for every tier and every backend:
+
+```python
+from sulci import Cache
+
+cache = Cache(
+    backend = "sulci",                # or "sqlite"/"chroma"/etc. for OSS-Connect
+    api_key = "sk-sulci-...",         # or set SULCI_API_KEY env var
+)
+
+cache.get("hello")  # populates the entire dashboard
+```
+
+`sulci.connect()` remains as the canonical entry point for two advanced
+flows: the OSS-Connect device-code browser onboarding
+(`sulci.connect(prompt=True)`), and the "register key without constructing
+a Cache yet" boot pattern (`sulci.connect()` at module load, Cache instances
+spawn later in worker threads).
+
+### Added — Tests
+
+- `tests/test_connect.py::TestCacheAutoConnect` — 8 new tests covering:
+  kwarg trigger, env-var trigger with local backend, no-api-key short-circuit,
+  `telemetry=False` opt-out, prior-connect-with-telemetry-False respect,
+  prior-connect-no-re-call, connect-failure-does-not-crash-Cache, and the
+  default-backend-no-key regression guard.
+- Total test count: 488 → 496 passed (8 new), 30 skipped (unchanged).
+
+### Added — Documentation
+
+- `docs/architecture/adrs/0001-cache-auto-connect-telemetry.md` —
+  decision capture, mirroring sulci-platform ADR 0021. First ADR in the
+  sulci-oss repo; `docs/architecture/adrs/README.md` introduces the registry
+  with the same conventions used in sulci-platform (sequential, never
+  renumbered, ISO date-stamped going forward).
+- `README.md` § "Sulci Cloud — zero infrastructure option" rewritten to
+  show the auto-connect quickstart as primary. Advanced `sulci.connect()`
+  patterns moved into a clearly-flagged subsection. Key resolution order
+  table updated to reflect three equivalent opt-in signals (kwarg, env,
+  prior `connect()`).
+
+### Coordinated release
+
+`sulci-cache==0.7.0` ships alongside `sulci-gateway==0.7.0` in the
+sulci-platform repo. The gateway version bump is purely operational —
+no behavioral change on the gateway side, since the auto-connect logic
+lives entirely in the SDK. Bumping both to the same `0.7.0` marker
+keeps the canonical version cross-reference clean in docs and support
+conversations.
+
+
 
 > Patch release closing the two sulci-oss follow-up issues filed during
 > the v0.6.x close-out (#79, #80). Both target the same surface — the

--- a/README.md
+++ b/README.md
@@ -212,24 +212,75 @@ cache = Cache(backend="sulci", threshold=0.85)
 
 **Free tier:** 50,000 requests/month. No credit card required.
 
-### sulci.connect()
+### One-line setup — telemetry just works (v0.7.0+)
 
-For apps that want to set the key once at startup and enable optional telemetry:
+As of v0.7.0, passing `api_key` to `Cache()` enables the Sulci Cloud
+dashboard automatically. **One line is enough** — no separate `sulci.connect()`
+call required for the dashboard panels (TrendChart, AuditEventsTable,
+DeploymentsTable, Active SDKs) to populate.
+
+```python
+from sulci import Cache
+
+cache = Cache(
+    backend = "sulci",                # or "sqlite"/"chroma"/etc. — see below
+    api_key = "sk-sulci-...",         # or set SULCI_API_KEY env var
+)
+
+cache.get("hello")                    # populates the entire dashboard
+```
+
+This works for every tier and every backend choice:
+
+| Persona | Backend | api_key role |
+|---|---|---|
+| **Pro / Business (paid managed)** | `"sulci"` | cache auth + telemetry |
+| **OSS-Connect (free, self-host + dashboard)** | `"sqlite"` / `"chroma"` / `"qdrant"` / etc. | **telemetry only** — cache lives locally |
+| **Pure self-hosted (no Sulci account)** | local backend | omit `api_key` — no telemetry, no cloud |
+
+**One rule covers all three:**
+
+> If `api_key` is present anywhere (kwarg, `SULCI_API_KEY` env, or prior
+> `sulci.connect()`) AND `telemetry=True` (the default), telemetry flows
+> to Sulci. Backend choice is independent.
+
+**Telemetry remains strictly opt-in.** No api_key anywhere → no telemetry,
+ever. Pass `telemetry=False` to override: `Cache(backend="sulci",
+api_key="sk-sulci-...", telemetry=False)` uses the managed cache without
+emitting telemetry (useful in compliance-restricted environments or
+internal staging where dev traffic should not pollute production
+dashboards).
+
+### sulci.connect() — advanced flows
+
+`sulci.connect()` is still the canonical entry point for two patterns that
+benefit from explicit ordering:
+
+**1. OSS-Connect device-code onboarding (browser-based auth)**
 
 ```python
 import sulci
 
-sulci.connect(
-    api_key   = "sk-sulci-...",   # or set SULCI_API_KEY env var
-    telemetry = True,             # default True — set False to disable reporting
-)
-
-cache = Cache(backend="sulci")    # picks up key from connect() automatically
+sulci.connect(prompt=True)            # opens browser, registers key in ~/.sulci/config
+cache = Cache(backend="sqlite")       # cache lives locally; telemetry already wired
 ```
 
-**Telemetry is strictly opt-in.** Nothing is sent unless `sulci.connect()` is called.
-`_telemetry_enabled = False` until you explicitly connect. Disable per-instance with
-`Cache(backend="sulci", telemetry=False)`.
+**2. Register key at boot, construct Cache later (multi-worker apps)**
+
+```python
+# At app startup, before workers spawn:
+import sulci
+sulci.connect(api_key="sk-sulci-...")
+
+# Later, in a worker thread / lazy init:
+from sulci import Cache
+cache = Cache(backend="sulci")        # picks up the already-registered key
+```
+
+Both flows short-circuit the v0.7.0 auto-connect logic by setting
+`sulci._telemetry_enabled` to its intended state before `Cache()` runs.
+The auto-connect block respects that and does nothing — your explicit
+`connect()` choice (including `telemetry=False` if you passed it) survives.
 
 **Key resolution order** (first match wins):
 
@@ -240,6 +291,11 @@ cache = Cache(backend="sulci")    # picks up key from connect() automatically
 4. Browser-based OSS-Connect device-code flow — only if prompt=True
 ```
 
+All four are equivalent opt-in signals per the §5.2 trust-boundary spec.
+Pre-v0.7.0 only paths (1) via `connect()`, (2), and (3) flipped the
+telemetry flag; v0.7.0 makes path (1) via `Cache(api_key=...)` equivalent
+to the others, which is what eliminates the historic footgun.
+
 Step 3 (config persistence) ships in **v0.5.3**. After your first successful
 `sulci.connect(api_key="sk-sulci-...")`, the key is persisted to
 `~/.sulci/config` (mode 0600) and subsequent `sulci.connect()` calls with
@@ -248,12 +304,12 @@ no arguments will pick it up automatically.
 Step 4 (device-code flow) ships **latent** in v0.5.3. The SDK code is in
 place, but the gateway endpoints and dashboard page need to deploy
 end-to-end before it's usable. The `prompt` parameter defaults to `False`
-in v0.5.3:
+in v0.5.3+:
 
 ```python
-# v0.5.3 default — safe everywhere:
+# v0.5.3+ default — safe everywhere:
 sulci.connect()
-# - Step 1-3 work normally
+# - Steps 1-3 work normally
 # - Step 4 is skipped (prompt=False default)
 # - If no key found, connect() returns silently (no telemetry enabled)
 
@@ -269,9 +325,9 @@ sulci.connect(prompt=True)
 OSS-Connect chain (gateway endpoints + dashboard page) is announced as
 publicly available. v0.6.0 was originally pencilled in for this flip; it
 shipped (2026-05-11) focused on the cloud transport rewrite instead, so
-`prompt` is still `False`-by-default in v0.6.x. **Setting `prompt=True`
-against an environment that hasn't announced OSS-Connect availability is
-user error** — wait for the release announcement.
+`prompt` is still `False`-by-default in v0.6.x and v0.7.0. **Setting
+`prompt=True` against an environment that hasn't announced OSS-Connect
+availability is user error** — wait for the release announcement.
 
 ---
 

--- a/docs/architecture/adrs/0001-cache-auto-connect-telemetry.md
+++ b/docs/architecture/adrs/0001-cache-auto-connect-telemetry.md
@@ -1,0 +1,229 @@
+# ADR 0001 — `Cache()` auto-connects telemetry when an `api_key` is resolvable
+
+- **Status:** Accepted
+- **Date:** 2026-05-26
+- **Shipped:** `sulci-cache==0.7.0`
+- **Companion:** `sulci-platform` ADR-0021 (the gateway-side mirror)
+- **Closes:** the dashboard-population footgun first surfaced in `sulci-platform` PR #249 close-out
+
+---
+
+## Context
+
+The `Sulci_UI_Design_and_Dev_Tracker` §5.2 *Trust boundaries* spec lists
+three equivalent opt-in signals for telemetry:
+
+1. Explicit `sulci.connect()` call,
+2. `SULCI_API_KEY` environment variable,
+3. (implicit via (2)) any documented surface where the user hands their
+   key to the SDK.
+
+The spec calls this constraint "non-negotiable" — telemetry is opt-in
+forever, never silent. Through v0.6.x, only path (1) actually enabled
+the telemetry flush. Paths (2) and (3) registered the key for cache
+backend auth but left `sulci._telemetry_enabled = False`. Consequence:
+
+- `Cache(backend="sulci", api_key="sk-sulci-...")` worked for the cache
+  ops (vectors flowed to `/v1/cache/*`, hit rates and cost-saved counters
+  populated via the billing-worker rollup pipeline),
+- BUT the four telemetry-backed dashboard panels — `TrendChart`,
+  `AuditEventsTable`, `DeploymentsTable`, the Active-SDKs counter — stayed
+  empty until the user separately called `sulci.connect()`.
+
+This shipped in every quickstart, blog example, and customer onboarding
+flow. The symptom (half-broken dashboard) was indistinguishable from a
+product bug to the casual user. It affected every tier identically:
+OSS-Connect users got an empty `ConnectedOssOverview` for deployments,
+Pro/Business users got an empty `ProOverview` for trend chart and audit
+feed. The latter is especially damaging — a paid customer's first
+post-upgrade dashboard view was empty for the panels they were paying for.
+
+The constraint was originally spec'd this way to keep the privacy
+guarantee strict. But the way it shipped didn't match what the spec
+*said* the three signals were — it was strictly stricter, requiring
+signal (1) for telemetry but accepting (2) and (3) for cache auth. That
+asymmetry was a bug, not an intended design.
+
+---
+
+## Decision
+
+**`Cache.__init__` auto-calls `sulci.connect()`** when the following three
+predicates all hold:
+
+| Predicate | Source of truth |
+|---|---|
+| `self._telemetry` is `True` | the `telemetry=True` default kwarg on `Cache.__init__` |
+| an api_key is resolvable | `{api_key kwarg, SULCI_API_KEY env, sulci._api_key set by a prior connect()}` |
+| `sulci._telemetry_enabled` is `False` | the module-level flag — short-circuit when any prior `connect()` has run |
+
+The resolved key is passed to `sulci.connect(api_key=resolved_key,
+telemetry=True, prompt=False)`. The `prompt=False` is critical — the
+auto-connect path must never block `Cache()` construction on a 15-minute
+device-code timeout. Users who want the browser device-code flow continue
+to call `sulci.connect(prompt=True)` explicitly *before* constructing a
+`Cache`; the "already connected" short-circuit ensures their ordering
+choice survives.
+
+Auto-connect failures **never crash Cache construction**. Wrapped in
+`try/except Exception`, falls through to a logged `WARNING` on the `sulci`
+logger naming the exception type + message and pointing the operator at
+`sulci.connect()` for retry. The cache itself stays fully functional —
+only telemetry remains off.
+
+The implementation lives at the end of `Cache.__init__`, after backend
+loading. About 25 lines including comments. See `sulci/core.py` for the
+canonical text.
+
+---
+
+## Consequences
+
+### What gets better
+
+**One canonical quickstart shape works for all three personas.** No
+"did you remember to call `sulci.connect()`?" anywhere. The minimum
+viable user code is:
+
+```python
+from sulci import Cache
+
+cache = Cache(backend="sulci", api_key="sk-sulci-...")   # or env var
+cache.get("hello")  # populates the entire dashboard
+```
+
+…and that same shape covers `Cache(backend="sqlite", api_key=...)` for the
+OSS-Connect self-host-plus-telemetry persona. Backend choice is now
+genuinely orthogonal to telemetry choice, which matches user mental
+model.
+
+**The privacy invariant is preserved.** Presence of api_key in any of the
+three signal sources is explicit opt-in per the spec. v0.7.0 makes the
+kwarg-to-Cache path consistent with the env-var path that the spec
+already authorized — it doesn't add any new opt-in surface, it just
+unifies behavior across surfaces the spec already accepted.
+
+**`telemetry=False` remains a clean explicit opt-out anchor.**
+Compliance-restricted environments, internal staging that shouldn't
+pollute production dashboards, customers with legal restrictions on
+non-essential outbound — all of them have a clear, documented escape.
+
+**Advanced flows are unbroken.** `sulci.connect(prompt=True)` for
+device-code, `sulci.connect()` at boot before workers spawn `Cache`
+instances — both work identically because the `_telemetry_enabled`
+short-circuit looks for "any prior connect() ran" rather than for a
+specific argument shape.
+
+### What gets worse
+
+**One layer of "magic."** `Cache(api_key=...)` now has a side effect
+beyond constructing a cache object. Documented in CHANGELOG, README, and
+this ADR; signposted in source via a multi-line comment block. The
+warning-on-failure path provides a recovery affordance: if the auto-call
+fails, the operator sees the WARNING and knows to call `sulci.connect()`
+manually.
+
+**A subtle behavior change for users who pass api_key but didn't want
+telemetry.** Pre-0.7.0 they got cache without telemetry by accident.
+Post-0.7.0 the same code emits telemetry. Mitigation: the
+`telemetry=False` kwarg makes the explicit opt-out trivial, and the
+CHANGELOG entry calls out the change. Risk-assessed as low — most users
+who pass api_key *want* the dashboard to populate; the silent-no-telemetry
+state was almost always unintended.
+
+---
+
+## Alternatives considered
+
+### Force telemetry on with no off-switch for paid tiers
+
+**Rejected.** Two reasons:
+
+1. Violates the §5.2 invariant ("Telemetry is opt-in forever") which had
+   no exception for paid tiers in the original spec.
+2. Multiple legitimate use cases for paid tenants to disable telemetry
+   exist:
+   - Enterprise on-prem deployments (per ADR §9.1 — VPC callhome for
+     billing only, not full telemetry),
+   - Compliance contexts requiring minimal non-essential outbound,
+   - Internal staging environments where dev traffic shouldn't pollute
+     production dashboards,
+   - Customers running their own dashboard via the gateway API directly.
+
+The brand cost of "we say it's opt-in but if you pay we force it on"
+outweighs the marginal implementation gain.
+
+### Worker-side write to `telemetry_events` for managed-cache traffic
+
+**Considered as complementary, not alternative; deferred.** The dashboard
+correctness today depends on the SDK behaving — older SDK forks or
+out-of-date pins would still hit the footgun. A platform-side fix where
+the billing worker writes minimal per-event rows to `telemetry_events`
+from the Redis stream would decouple dashboard correctness from SDK
+behavior entirely. This is the proper long-term shape but is meatier
+work: gateway needs to emit more fields, worker needs a new write path,
+the `telemetry_events` schema needs to flex, and a privacy review must
+confirm none of the new fields violate ADR 0010 (managed-cache stream
+events carry different metadata than `/v1/telemetry` payloads, which
+are shape-locked).
+
+Tracked separately. Does not block v0.7.0.
+
+### Runtime warning only — no auto-connect
+
+**Rejected as the only fix.** A warning when `Cache(api_key=...)` is
+constructed without a prior `connect()` would help discoverability but
+miss the larger population of users who don't read logs in development.
+The footgun remains for every casual user, every quickstart-copier,
+every blog example. The fix has to be behavioral, not advisory.
+
+### Make `sulci.connect()` mandatory; remove `api_key=` from `Cache()`
+
+**Rejected.** Breaking change. Every existing snippet in the
+ecosystem breaks. The "drop-in library" positioning takes a hit
+that auto-connect doesn't require us to take.
+
+---
+
+## Implementation notes
+
+- Lives entirely in `sulci/core.py`. No protocol changes, no
+  cross-repo coordination beyond the version bump.
+- Test coverage in `tests/test_connect.py::TestCacheAutoConnect`,
+  eight tests covering the matrix of `(api_key source, telemetry kwarg,
+  prior-connect state, connect-failure)`.
+- The `connect()` call is wrapped in `try/except Exception` to honor the
+  pre-existing "telemetry never crashes the caller" contract (see
+  `__init__.py::_emit` docstring for the same pattern at the emit layer).
+- The `WARNING` log message format is stable and includes "auto-connect
+  from Cache() failed" as a grep-friendly anchor for support tooling.
+
+---
+
+## Verification
+
+```python
+import logging, sulci
+from sulci import Cache
+
+# Demonstrates the v0.7.0 contract.
+logging.basicConfig(level=logging.INFO)
+
+# Pre-0.7.0 footgun, now fixed:
+cache = Cache(backend="sulci", api_key="sk-sulci-...")
+assert sulci._telemetry_enabled is True
+
+# Explicit opt-out path remains:
+sulci._telemetry_enabled = False  # simulate a fresh process
+cache = Cache(backend="sulci", api_key="sk-sulci-...", telemetry=False)
+assert sulci._telemetry_enabled is False
+
+# OSS-Connect canonical flow (local cache + telemetry):
+import os
+os.environ["SULCI_API_KEY"] = "sk-sulci-env-test"
+sulci._telemetry_enabled = False
+cache = Cache(backend="sqlite")
+assert sulci._telemetry_enabled is True
+```
+
+End of ADR 0001.

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -1,0 +1,67 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds the decision log for the `sulci-oss` library —
+one file per decision, numbered sequentially, never renumbered.
+
+An ADR captures **why** a technical choice was made, the **alternatives
+considered**, and the **consequences accepted**. It is not a tutorial,
+a how-to guide, or a status update. It is a point-in-time artifact of
+a decision.
+
+ADRs are the antidote to "why is it built this way?" three years from now
+when everyone who was in the room has moved on.
+
+The companion ADR registry for the platform side lives at
+`sulci-platform/docs/architecture/adrs/`. Cross-references between the
+two are explicit: a sulci-oss ADR that has a platform-side mirror names
+the sulci-platform ADR number in its header, and vice versa.
+
+---
+
+## When to write an ADR
+
+**Write one when:**
+
+- A choice has long-term consequences for the public API or library
+  contract (telemetry behavior, backend protocol, embedding interface)
+- Reasonable engineers could disagree, and the choice will be questioned
+  again
+- The decision reverses, supersedes, or deviates from a prior one
+- An external constraint (privacy, compliance, customer requirement)
+  drove the choice
+
+**Skip it when:**
+
+- The choice is obvious or enforced by the stack
+- It's a local implementation detail with no cross-cutting impact
+- It's a bug fix or routine refactor
+
+When in doubt, write one. Cheap to produce, expensive to wish you had.
+
+---
+
+## Numbering
+
+- Sequential, zero-padded to 4 digits: `0001`, `0002`, ..., `9999`
+- Never reused. Never renumbered. Superseded ADRs keep their number.
+- Filename format: `NNNN-kebab-case-title.md`
+
+---
+
+## Status lifecycle
+
+```
+Proposed ──▶ Accepted ──▶ Superseded by ADR-NNNN
+```
+
+---
+
+## Index
+
+| # | Title | Status | Date |
+|---|---|---|---|
+| [0001](0001-cache-auto-connect-telemetry.md) | `Cache()` auto-connects telemetry when an `api_key` is resolvable | Accepted | 2026-05-26 |
+
+> **Cross-repo note:** sulci-oss ADR-0001 has a sulci-platform mirror at
+> ADR-0021. Both ship as part of the coordinated v0.7.0 release
+> (`sulci-cache==0.7.0` + `sulci-gateway==0.7.0`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.6.5"
+version = "0.7.0"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -223,6 +223,70 @@ class Cache:
         self._embedder = None  # set conditionally below — see v0.6.1 note
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
 
+        # ── v0.7.0 — auto-connect to the telemetry path ──────────────────────
+        # ADR 0001 (sulci-oss) / ADR 0021 (sulci-platform): when an api_key is
+        # resolvable from {kwarg, SULCI_API_KEY env, module-level _api_key} and
+        # telemetry is left at its default (True), Cache() implicitly calls
+        # sulci.connect() so the four telemetry-backed dashboard panels
+        # (TrendChart, AuditEventsTable, DeploymentsTable, Active-SDKs counter)
+        # populate without a second SDK call.
+        #
+        # Privacy invariant preserved: per Sulci_UI_Design_and_Dev_Tracker §5.2
+        # trust boundaries, presence of api_key (kwarg or SULCI_API_KEY env) is
+        # explicit user opt-in. This block makes the kwarg path behave
+        # identically to the env path (which was already an authorized opt-in
+        # signal per the spec). Pre-0.7.0 the kwarg path silently failed to
+        # enable telemetry — a footgun documented in sulci-platform PR #249
+        # session notes.
+        #
+        # Short-circuited when ANY of:
+        #   - self._telemetry is False (explicit instance-level opt-out wins)
+        #   - sulci._api_key is already set (any prior connect() call ran —
+        #     including connect(telemetry=False); the user's explicit choice
+        #     survives whether they opted in OR out)
+        #   - no api_key resolvable from any of the three sources (pure
+        #     self-hosted: no Sulci account, no dashboard, no telemetry)
+        #
+        # Rationale for the `_api_key is set` short-circuit: module-level
+        # `_api_key` is None at import time and is ONLY set non-None by
+        # sulci.connect(). So `_api_key is not None` is a reliable proxy for
+        # "the user has explicitly invoked connect() and chose some posture."
+        # That posture — whether telemetry=True (enabled) or telemetry=False
+        # (deliberate opt-out) — is preserved by this check; auto-connect will
+        # not second-guess it.
+        #
+        # Auto-connect failures NEVER crash Cache construction. The cache
+        # still serves get/set normally; only the telemetry side stays off,
+        # and a WARNING is logged identifying the failure mode.
+        if self._telemetry:
+            import os, sys
+            _sulci_mod = sys.modules.get("sulci")
+            if _sulci_mod is not None:
+                _user_already_connected = (
+                    getattr(_sulci_mod, "_telemetry_enabled", False)
+                    or getattr(_sulci_mod, "_api_key", None) is not None
+                )
+                if not _user_already_connected:
+                    resolved_key = (
+                        api_key
+                        or os.environ.get("SULCI_API_KEY")
+                    )
+                    if resolved_key:
+                        try:
+                            _sulci_mod.connect(
+                                api_key   = resolved_key,
+                                telemetry = True,
+                                prompt    = False,
+                            )
+                        except Exception as exc:
+                            import logging
+                            logging.getLogger("sulci").warning(
+                                "auto-connect from Cache() failed; telemetry "
+                                "disabled. Call sulci.connect() explicitly to "
+                                "retry. (%s: %s)",
+                                type(exc).__name__, exc,
+                            )
+
         # v0.6.0 (sulci-oss #62, umbrella #63) — cloud-transport detection.
         # When self._backend is the cloud transport (SulciCloudBackend), the
         # gateway-side library does ALL engine work (embed + search + emit);

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -811,3 +811,161 @@ class TestDeviceCodeFlow:
 
         assert sulci._api_key == "sk-sulci-from-flow"
         assert sulci._telemetry_enabled is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# v0.7.0 — Cache() auto-connect from api_key (ADR 0001 / sulci-platform ADR 0021)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCacheAutoConnect:
+    """Cache.__init__ implicitly calls sulci.connect() when an api_key is
+    resolvable (kwarg, SULCI_API_KEY env, or module-level _api_key) AND
+    telemetry is left at the default True.
+
+    Unified opt-in rule (v0.7.0):
+        api_key present (any source) + telemetry=True  →  telemetry flows
+        api_key absent everywhere   OR  telemetry=False →  no telemetry
+
+    Pre-0.7.0 the kwarg path silently failed to enable telemetry — a footgun
+    that left TrendChart / AuditEventsTable / DeploymentsTable empty for both
+    OSS-Connect and paid (Pro/Business) tenants. The env-var path was always
+    a valid opt-in signal per §5.2 trust-boundary spec, so the kwarg path
+    matches it.
+    """
+
+    def setup_method(self):
+        _reset_module()
+        # Clear env in case prior test left SULCI_API_KEY set.
+        os.environ.pop("SULCI_API_KEY", None)
+
+    def teardown_method(self):
+        _reset_module()
+        os.environ.pop("SULCI_API_KEY", None)
+
+    def test_kwarg_api_key_triggers_auto_connect(self):
+        """Cache(backend='sulci', api_key=...) enables telemetry per v0.7.0."""
+        import sulci
+        assert sulci._telemetry_enabled is False  # baseline
+
+        from sulci import Cache
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"):
+            Cache(backend="sulci", api_key="sk-sulci-kwarg-test")
+
+        assert sulci._telemetry_enabled is True
+        assert sulci._api_key == "sk-sulci-kwarg-test"
+
+    def test_env_var_api_key_triggers_auto_connect_with_local_backend(self):
+        """Setting SULCI_API_KEY + local backend triggers auto-connect.
+
+        Canonical OSS-Connect shape: self-hosted cache, telemetry to Sulci.
+        Mocks the local embedder load to keep this an isolated unit test
+        (no sentence-transformers requirement); the equivalent integration
+        test lives in tests/integration/.
+        """
+        import sulci
+        os.environ["SULCI_API_KEY"] = "sk-sulci-env-test"
+        from sulci import Cache
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"), \
+             patch.object(Cache, "_load_embedder", return_value=None):
+            Cache(backend="sqlite")          # no api_key kwarg, local backend
+
+        assert sulci._telemetry_enabled is True
+        assert sulci._api_key == "sk-sulci-env-test"
+
+    def test_no_api_key_anywhere_does_not_auto_connect(self):
+        """Pure self-hosted (no Sulci account at all) → no telemetry.
+
+        Embedder loader patched out — see test_env_var_... for rationale.
+        """
+        import sulci
+        from sulci import Cache
+        with patch.object(Cache, "_load_embedder", return_value=None):
+            Cache(backend="sqlite")
+
+        assert sulci._telemetry_enabled is False
+        assert sulci._api_key is None
+
+    def test_explicit_telemetry_false_blocks_auto_connect(self):
+        """telemetry=False is the documented opt-out — honored even with api_key."""
+        import sulci
+        from sulci import Cache
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"):
+            Cache(backend="sulci",
+                  api_key="sk-sulci-optout-test",
+                  telemetry=False)
+
+        assert sulci._telemetry_enabled is False
+
+    def test_does_not_override_prior_explicit_connect_with_telemetry_false(self):
+        """If user called sulci.connect(telemetry=False) first, Cache respects that.
+
+        Uses backend='sulci' to avoid the local embedder load; the value
+        being tested is the short-circuit logic in __init__, which is
+        backend-agnostic.
+        """
+        import sulci
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"):
+            sulci.connect(api_key="sk-sulci-prior", telemetry=False)
+        assert sulci._telemetry_enabled is False
+
+        from sulci import Cache
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"):
+            Cache(backend="sulci", api_key="sk-sulci-prior")
+
+        # The user's explicit telemetry=False survives — auto-connect's
+        # short-circuit looks at _telemetry_enabled, which the prior
+        # explicit connect() with telemetry=False left at False. _api_key
+        # was set by that prior connect() though, so resolved_key is
+        # non-None; the short-circuit is the only thing preventing a
+        # second connect() call with telemetry=True from overriding the
+        # user's earlier explicit choice.
+        assert sulci._telemetry_enabled is False
+
+    def test_does_not_re_call_connect_when_already_enabled(self):
+        """Prior connect() with telemetry on → Cache() does not re-call connect."""
+        import sulci
+        with patch("sulci._start_flush_thread"), patch("sulci._emit"):
+            sulci.connect(api_key="sk-sulci-prior")
+        assert sulci._telemetry_enabled is True
+
+        # Now construct Cache and verify connect() is not called again.
+        from sulci import Cache
+        with patch("sulci.connect") as mock_connect:
+            Cache(backend="sulci", api_key="sk-sulci-different")
+            assert not mock_connect.called
+
+    def test_auto_connect_failure_does_not_crash_cache(self, caplog):
+        """If connect() raises, Cache still constructs; warning is logged.
+
+        Uses backend='sulci' so Cache construction reaches the auto-connect
+        block without loading the local embedder.
+        """
+        import sulci
+        from sulci import Cache
+
+        def _raising_connect(**kwargs):
+            raise RuntimeError("simulated connect failure")
+
+        with patch("sulci.connect", side_effect=_raising_connect):
+            with caplog.at_level(logging.WARNING, logger="sulci"):
+                # Must NOT raise.
+                cache = Cache(backend="sulci", api_key="sk-sulci-fail-test")
+
+        # Cache itself is usable.
+        assert cache is not None
+        # A warning was logged identifying the failure mode.
+        assert any("auto-connect from Cache() failed" in rec.message
+                   for rec in caplog.records)
+
+    def test_default_backend_no_api_key_no_auto_connect(self):
+        """No api_key anywhere → no telemetry, regardless of backend.
+
+        Embedder loader patched out — see test_env_var_... for rationale.
+        Regression guard for the most common 'just install and try it' path.
+        """
+        import sulci
+        from sulci import Cache
+        with patch.object(Cache, "_load_embedder", return_value=None):
+            Cache(backend="sqlite")
+
+        assert sulci._telemetry_enabled is False


### PR DESCRIPTION

Closes the dashboard-population footgun first surfaced in sulci-platform PR #249 close-out: pre-0.7.0, constructing Cache(backend="sulci", api_key=...) registered the key for cache backend auth but did NOT enable the telemetry flush path. The four telemetry-backed dashboard panels — TrendChart, AuditEventsTable, DeploymentsTable, the Active-SDKs counter — stayed empty until the user separately called sulci.connect().

The footgun was identical across tiers:
  - Pro/Business: ProOverview's TrendChart + AuditEventsTable empty.
  - OSS-Connect: ConnectedOssOverview's TrendChart + DeploymentsTable + Active-SDKs counter empty.

v0.7.0 unifies the three opt-in signals already documented in §5.2 trust-boundary spec (kwarg, SULCI_API_KEY env, explicit sulci.connect()) so the kwarg-to-Cache path behaves equivalently to the env path.

Short-circuit predicate looks at sulci._api_key (set by ANY prior connect() call regardless of telemetry choice) to ensure auto-connect never overrides an explicit user posture — including connect(telemetry= False) opt-outs. The telemetry=False kwarg on Cache() remains the documented instance-level opt-out anchor.

Auto-connect failures are caught and logged at WARNING; Cache construction never raises from the auto-connect path.

Test coverage: 8 new tests in tests/test_connect.py::TestCacheAutoConnect covering the matrix of (api_key source, telemetry kwarg, prior-connect state, connect-failure).

Coordinated release with sulci-gateway==0.7.0 in the sulci-platform repo. See:
  - docs/architecture/adrs/0001-cache-auto-connect-telemetry.md (this repo)
  - sulci-platform/docs/architecture/adrs/0021-cache-auto-connect-telemetry.md