### PR TITLE
fix: populate saved_cost from get() + suppress sentence-transformers FutureWarning (closes #88, #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Cache.stats()['saved_cost']` now populates for users of the raw
+  `get()`/`set()` API (closes #88).** Previously `saved_cost` only
+  incremented inside `cached_call()`, which left LangChain integrations —
+  the most common high-traffic path, via `set_llm_cache(SulciCache(...))`
+  — reporting $0 saved indefinitely. `Cache.__init__` now accepts
+  `cost_per_call: float = 0.005`; `get()` contributes that amount to
+  `saved_cost` on every hit. `cached_call()` continues to support a
+  per-call override (signature changed: default now `None` instead of
+  `0.005`, meaning "use the Cache's setting"); explicit overrides apply
+  as a delta to preserve identical numeric output for the existing
+  `cached_call(cost_per_call=X)` pattern.
+
+  Behavior change worth noting: pre-v0.7.1, `Cache().get()` alone left
+  `saved_cost` at $0; now it adds $0.005 per hit (using the default).
+  Opt out with `Cache(cost_per_call=0)` to preserve old semantics.
+  All other paths produce identical numeric output to v0.7.0.
+
+- **No more `FutureWarning` from sentence-transformers v3+ (closes #89).**
+  `sulci/embeddings/minilm.py` now uses `get_embedding_dimension()` when
+  available, falling back to the deprecated `get_sentence_embedding_dimension()`
+  on sentence-transformers v2.x. The warning was harmless but appeared on
+  every smoke run since the v3 upgrade earlier this year, polluting the
+  examples output.
+
 ### Added
 
 - **`examples/agent_example_crewai.py`** — CrewAI + Sulci agent demo with

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -210,6 +210,8 @@ class Cache:
         # ── v0.5.0 additions (ADR 0004 + ADR 0007) ──
         session_store:   Optional[SessionStoreProtocol] = None,
         event_sink:      Optional[EventSink]            = None,
+        # ── v0.7.1 — issue #88 ──────────────────────────────────────────────
+        cost_per_call:   float         = 0.005,
     ):
         self._telemetry     = telemetry
         self.backend        = backend
@@ -219,6 +221,14 @@ class Cache:
         self.context_window  = context_window
         self.embedding_model = embedding_model
         self._stats          = {"hits": 0, "misses": 0, "saved_cost": 0.0}
+
+        # v0.7.1 (issue #88) — Cache-instance default for the per-call cost
+        # used to populate _stats["saved_cost"]. Previously saved_cost only
+        # incremented inside cached_call(), which left users of the raw
+        # get()/set() API (notably LangChain via set_llm_cache) reporting $0
+        # saved indefinitely. Now get() also contributes to saved_cost using
+        # this value; opt out with cost_per_call=0.
+        self._cost_per_call = cost_per_call
 
         self._embedder = None  # set conditionally below — see v0.6.1 note
         self._backend  = self._load_backend(backend, db_path, api_key, gateway_url)
@@ -537,8 +547,14 @@ class Cache:
         # seeing {"hits": 0, "misses": 0} regardless of activity. cached_call()
         # no longer increments these itself — it goes through .get() like
         # everyone else, so there's no double-counting.
+        #
+        # #88 (v0.7.1) — saved_cost also now contributes here using the
+        # instance default self._cost_per_call (set on Cache.__init__).
+        # cached_call() still applies a delta when called with an explicit
+        # per-call override; see comment block at the cached_call() hit site.
         if resp is not None:
-            self._stats["hits"]   += 1
+            self._stats["hits"]       += 1
+            self._stats["saved_cost"] += self._cost_per_call
         else:
             self._stats["misses"] += 1
 
@@ -679,11 +695,11 @@ class Cache:
         query:         str,
         llm_fn:        Callable,
         *,
-        tenant_id:     Optional[str] = None,
-        user_id:       Optional[str] = None,
-        session_id:    Optional[str] = None,
-        cost_per_call: float         = 0.005,
-        plan:          Optional[str] = None,
+        tenant_id:     Optional[str]   = None,
+        user_id:       Optional[str]   = None,
+        session_id:    Optional[str]   = None,
+        cost_per_call: Optional[float] = None,
+        plan:          Optional[str]   = None,
         **llm_kwargs:  Any,
     ) -> dict:
         """
@@ -700,6 +716,10 @@ class Cache:
             user_id:       For personalized per-user caching.
             session_id:    Conversation ID — enables context-aware lookup.
             cost_per_call: Estimated LLM cost per call (for savings stats).
+                           If None (default), uses ``Cache.cost_per_call``
+                           (set on construction, default $0.005). Pass an
+                           explicit value to override for this call only —
+                           the delta is reflected in ``stats()['saved_cost']``.
             plan:          Optional customer plan tier; forwarded onto
                            the underlying .get/.set calls and thence onto
                            emitted CacheEvent.plan. v0.5.6 (sulci-oss #36).
@@ -720,10 +740,13 @@ class Cache:
         ms              = (time.perf_counter() - t0) * 1000
 
         if hit is not None:
-            # _stats["hits"] is incremented inside .get() — see #42 note there.
-            # cached_call() owns saved_cost since it's the only path that knows
-            # cost_per_call.
-            self._stats["saved_cost"] += cost_per_call
+            # _stats["hits"] AND _stats["saved_cost"] are both incremented
+            # inside .get() — see #42 / #88 notes there. cached_call() applies
+            # only the *delta* when an explicit per-call cost_per_call override
+            # was passed, so per-call accounting still works for users who
+            # mix instance-default and per-call costs.
+            if cost_per_call is not None and cost_per_call != self._cost_per_call:
+                self._stats["saved_cost"] += (cost_per_call - self._cost_per_call)
             # Record turn even on hits so future queries see this exchange.
             # v0.6.1 (sulci-oss #60) — skip on remote transport: self._embedder
             # is None there (gateway-side library tracks session state for the

--- a/sulci/embeddings/minilm.py
+++ b/sulci/embeddings/minilm.py
@@ -33,7 +33,14 @@ class MiniLMEmbedder:
             )
         model_id    = self.MODELS.get(model_name, model_name)
         self._model = SentenceTransformer(model_id)
-        self._dim   = self._model.get_sentence_embedding_dimension()
+        # sentence-transformers v3+ renamed get_sentence_embedding_dimension →
+        # get_embedding_dimension (the old name still works but emits a
+        # FutureWarning). hasattr guard preserves v2.x compatibility.
+        self._dim   = (
+            self._model.get_embedding_dimension()
+            if hasattr(self._model, "get_embedding_dimension")
+            else self._model.get_sentence_embedding_dimension()
+        )
 
     @property
     def dimension(self) -> int:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -245,17 +245,38 @@ class TestStats:
         # If either path double-counted, total would be 3 or 4.
         assert s["total_queries"] == 2
 
-    def test_saved_cost_only_from_cached_call(self, tmp_path):
-        """saved_cost stays a cached_call()-only metric (issue #42).
+    def test_saved_cost_from_raw_get_when_cost_per_call_set(self, tmp_path):
+        """v0.7.1 (#88) — raw .get() populates saved_cost using Cache's
+        cost_per_call (default $0.005, overridable on construction).
 
-        Raw .get() doesn't know what an LLM call would have cost, so
-        it must not contribute to saved_cost. Only cached_call() does.
+        Previously raw .get() left saved_cost at $0, which made the metric
+        meaningless for LangChain users (set_llm_cache routes through .get(),
+        not cached_call). With cost_per_call resolvable from Cache.__init__,
+        .get() now contributes — using the instance default — on every hit.
         """
         cache = Cache(backend="sqlite", threshold=0.85,
+                      cost_per_call=0.003,
                       db_path=str(tmp_path / "raw_savings_db"))
         cache.set("a question", "an answer")
-        cache.get("a question")  # exact hit, but raw — no saved_cost
+        cache.get("a question")           # exact hit
+        cache.get("a question")           # exact hit (identical query — guaranteed)
+        assert cache.stats()["saved_cost"] == pytest.approx(0.006)
+
+    def test_saved_cost_zero_when_cost_per_call_zero(self, tmp_path):
+        """v0.7.1 (#88) — Cache(cost_per_call=0) opts out of saved_cost
+        accounting on raw .get(), preserving the pre-v0.7.1 semantics for
+        users who want only cached_call() to contribute.
+        """
+        cache = Cache(backend="sqlite", threshold=0.85,
+                      cost_per_call=0.0,
+                      db_path=str(tmp_path / "raw_savings_off_db"))
+        cache.set("a question", "an answer")
+        cache.get("a question")            # raw hit, no contribution
         assert cache.stats()["saved_cost"] == 0.0
+        # cached_call with explicit override still works
+        cache.cached_call("a question", lambda q: "irrelevant",
+                          cost_per_call=0.01)
+        assert cache.stats()["saved_cost"] == pytest.approx(0.01)
 
 
 # ── Threshold behaviour ───────────────────────────────────────


### PR DESCRIPTION
Closes #88, closes #89.

## #88 — saved_cost stays at $0 for LangChain users

Pre-v0.7.1 saved_cost was only incremented inside cached_call(), which made the metric meaningless for the most common high-traffic path: LangChain's set_llm_cache(SulciCache(...)) routes through .get(), not cached_call. Users saw $0 saved indefinitely even with thousands of hits.

The fix:
  - Cache.__init__ adds cost_per_call: float = 0.005 (matches the pre-existing cached_call default; stored as self._cost_per_call)
  - get() increments saved_cost by self._cost_per_call on hit
  - cached_call.cost_per_call signature changes from `float = 0.005` to `Optional[float] = None` (sentinel meaning "use instance")
  - cached_call removes its direct saved_cost increment; when called with an explicit per-call override, it applies only the delta so per-call accounting still produces identical numbers

Behavior change for raw .get() users:
  - Pre-v0.7.1:  Cache().get() on hit → saved_cost unchanged (stays at $0)
  - v0.7.1:      Cache().get() on hit → saved_cost += $0.005 per hit
  - Opt out:     Cache(cost_per_call=0) preserves pre-v0.7.1 semantics

cached_call() paths produce IDENTICAL numeric output to v0.7.0 across every {default, explicit-override, mixed} combination — sandbox walkthrough confirmed 13/13 cases match expected values, TestStats 10/10 green under make checkin.

## #89 — FutureWarning on every smoke run

sentence-transformers v3+ renamed get_sentence_embedding_dimension → get_embedding_dimension. The old name still works but emits a FutureWarning that polluted every Sulci-using script's output since the v3 upgrade. Replaced with a hasattr guard so v2.x still works and v3+ uses the canonical name without warnings.

## Tests

  - Deleted test_saved_cost_only_from_cached_call (its premise — "raw .get() doesn't know cost so saved_cost stays at 0" — was the bug, codified)
  - Added test_saved_cost_from_raw_get_when_cost_per_call_set (new positive contract: raw get() contributes saved_cost)
  - Added test_saved_cost_zero_when_cost_per_call_zero (opt-out path preserves old semantics for users who want it)
  - All other existing TestStats tests pass unchanged

## Visible impact

  examples/agent_example_langgraph.py — cache.stats() summary
  examples/agent_example_crewai.py    — cache.stats() summary
  examples/anthropic_example.py       — cache.stats() summary
  benchmark/run.py                    — top-of-output during stateless run

All now print without the FutureWarning at the top, and the agent examples' final cache.stats() lines report non-zero saved_cost values matching the cache hit count × instance default.