### PR TITLE
fix: preserve AsyncCache cost_per_call default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`AsyncCache.cached_call()` and `AsyncCache.acached_call()` now preserve
+  `AsyncCache(cost_per_call=...)` by default (closes #92).** The async wrapper
+  methods now pass `None` through to `Cache.cached_call()` unless callers
+  explicitly override the per-call cost, matching the sync cache sentinel
+  behavior and preventing the old hard-coded `$0.005` default from replacing
+  the constructor value.
+
 - **`Cache.stats()['saved_cost']` now populates for users of the raw
   `get()`/`set()` API (closes #88).** Previously `saved_cost` only
   incremented inside `cached_call()`, which left LangChain integrations —

--- a/sulci/async_cache.py
+++ b/sulci/async_cache.py
@@ -63,7 +63,7 @@ class AsyncCache:
         **kwargs: All arguments accepted by sulci.Cache — backend,
                   threshold, embedding_model, ttl_seconds, personalized,
                   db_path, context_window, query_weight, context_decay,
-                  session_ttl, api_key, telemetry.
+                  session_ttl, cost_per_call, api_key, telemetry.
 
     Examples
     --------
@@ -141,7 +141,7 @@ class AsyncCache:
         llm_fn:        Callable[[str], str],
         session_id:    Optional[str]   = None,
         user_id:       Optional[str]   = None,
-        cost_per_call: float           = 0.005,
+        cost_per_call: Optional[float] = None,
     ) -> dict:
         """
         Async drop-in LLM wrapper — checks cache first, calls llm_fn on miss.
@@ -221,7 +221,7 @@ class AsyncCache:
         llm_fn:        Callable[[str], str],
         session_id:    Optional[str] = None,
         user_id:       Optional[str] = None,
-        cost_per_call: float         = 0.005,
+        cost_per_call: Optional[float] = None,
     ) -> dict:
         """Sync passthrough — cache.cached_call()."""
         return self._cache.cached_call(

--- a/tests/test_async_cache.py
+++ b/tests/test_async_cache.py
@@ -14,11 +14,11 @@ Test classes
 TestConstruction        ( 4) — constructor passthrough, repr, invalid backend
 TestAget                ( 5) — hit, miss, session_id, user_id, 3-tuple return
 TestAset                ( 3) — stores entry, advances context window, session_id
-TestAcachedCall         ( 4) — hit, miss, dict shape, cost_per_call
+TestAcachedCall         ( 5) — hit, miss, dict shape, cost_per_call
 TestContextMethods      ( 4) — aget_context, aclear_context, acontext_summary,
                                session isolation
 TestStats               ( 3) — astats dict shape, aclear resets stats, repr
-TestSyncPassthrough     ( 2) — sync get/set still work on AsyncCache instance
+TestSyncPassthrough     ( 3) — sync get/set still work on AsyncCache instance
 """
 
 import os
@@ -26,6 +26,18 @@ import tempfile
 import pytest
 
 from sulci import AsyncCache
+
+
+class _FakeEmbedder:
+    @property
+    def dimension(self):
+        return 2
+
+    def embed(self, text):
+        return [1.0, 0.0]
+
+    def embed_batch(self, texts):
+        return [self.embed(text) for text in texts]
 
 
 # ── Shared fixture ────────────────────────────────────────────────────────────
@@ -202,6 +214,23 @@ class TestAcachedCall:
         s = await tmp_cache.astats()
         assert s["saved_cost"] >= 0.0
 
+    @pytest.mark.asyncio
+    async def test_respects_constructor_cost_per_call(self, tmp_path):
+        cache = AsyncCache(
+            backend="sqlite",
+            db_path=str(tmp_path / "async_cost_db"),
+            embedding_model=_FakeEmbedder(),
+            threshold=0.85,
+            cost_per_call=0.003,
+        )
+        await cache.aset("What is pgvector?", "pgvector adds vector search to Postgres.")
+
+        result = await cache.acached_call("What is pgvector?", lambda _: "unused")
+
+        assert result["source"] == "cache"
+        s = await cache.astats()
+        assert s["saved_cost"] == pytest.approx(0.003)
+
 
 # ── TestContextMethods ───────────────────────────────────────────────────────
 
@@ -286,3 +315,18 @@ class TestSyncPassthrough:
         s = tmp_cache.stats()
         assert isinstance(s, dict)
         assert "hits" in s
+
+    def test_sync_cached_call_respects_constructor_cost_per_call(self, tmp_path):
+        cache = AsyncCache(
+            backend="sqlite",
+            db_path=str(tmp_path / "sync_cost_db"),
+            embedding_model=_FakeEmbedder(),
+            threshold=0.85,
+            cost_per_call=0.003,
+        )
+        cache.set("What is pgvector?", "pgvector adds vector search to Postgres.")
+
+        result = cache.cached_call("What is pgvector?", lambda _: "unused")
+
+        assert result["source"] == "cache"
+        assert cache.stats()["saved_cost"] == pytest.approx(0.003)


### PR DESCRIPTION
Fixes #92

## Summary

- change `AsyncCache.acached_call()` and the sync passthrough `AsyncCache.cached_call()` to default `cost_per_call` to `None`, matching `Cache.cached_call()`
- add regression coverage for both wrapper paths so `AsyncCache(cost_per_call=...)` is preserved on cache hits
- document the fix in the unreleased changelog

## Validation

- `git diff --check`
- `.venv/bin/python -m py_compile sulci/async_cache.py tests/test_async_cache.py`
- `.venv/bin/python -m pytest tests/test_async_cache.py::TestAcachedCall::test_respects_constructor_cost_per_call tests/test_async_cache.py::TestSyncPassthrough::test_sync_cached_call_respects_constructor_cost_per_call -q`

I also tried the full `tests/test_async_cache.py` file in the lightweight local venv, but the pre-existing tests require `sentence-transformers` for the `minilm` fixture. The two new regression tests inject a small fake embedder so they can run without that heavier dependency.
