### PR TITLE
Part 12: rename customer dashboard host app.sulci.io → dashboard.sulci.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,7 +332,7 @@ forcing a fresh resolution that picks the actually-current key.
 ## [0.6.4] — 2026-05-12 — Drain telemetry buffer on process exit
 
 > Patch release. Closes the "I ran the snippet, nothing appeared on
-> app.sulci.io" failure mode: short-lived processes (CLI commands,
+> dashboard.sulci.io" failure mode: short-lived processes (CLI commands,
 > demo scripts, serverless invocations, test runs) now flush their
 > telemetry buffer before exit instead of silently dropping it.
 
@@ -347,7 +347,7 @@ forcing a fresh resolution that picks the actually-current key.
 ### Why this matters
 
 Before v0.6.4: running the /why-connect demo snippet (or any script
-shorter than 30 seconds) showed no telemetry on app.sulci.io. The
+shorter than 30 seconds) showed no telemetry on dashboard.sulci.io. The
 script exited before the first 30-second flush tick fired, and the
 daemon thread died with the buffer intact. Workaround required adding
 `time.sleep(35)` to scripts — fine for development, broken for
@@ -405,7 +405,7 @@ asymmetric outcomes depending on which code path the user hit first:
 |---|---|
 | `Cache(backend="sqlite")`                  | Loud `ImportError` with helpful "install `sulci[sqlite]`" message (via the existing `sulci/embeddings/minilm.py` try/except wrapping). |
 | `Cache(backend="sulci", api_key=…)`        | Loud but unhelpful `ModuleNotFoundError: No module named 'httpx'` from the top-of-module import in `sulci/backends/cloud.py`. |
-| `sulci.connect(api_key=…)`                 | **Silent** failure: the telemetry path is contractually "never raise"; the missing-httpx ImportError is swallowed by the flush thread. User sees no error, but their deployment never appears on `app.sulci.io`. |
+| `sulci.connect(api_key=…)`                 | **Silent** failure: the telemetry path is contractually "never raise"; the missing-httpx ImportError is swallowed by the flush thread. User sees no error, but their deployment never appears on `dashboard.sulci.io`. |
 
 The third outcome is the worst — it looks like everything works but the
 user gets zero signal that anything's wrong. Promoting `httpx` to

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -551,7 +551,7 @@ sulci.connect()
 # To opt into the browser-based onboarding flow:
 sulci.connect(prompt=True)
 # → if no key found through the first three steps:
-#     [sulci] Visit https://app.sulci.io/oss-connect and enter code: WXYZ-2345
+#     [sulci] Visit https://dashboard.sulci.io/oss-connect and enter code: WXYZ-2345
 #     [sulci] Waiting for authorization (Ctrl+C to cancel)...
 #   On success: SDK gets the api_key, writes to ~/.sulci/config (mode 0600)
 #   On user-deny / 15-min timeout: raises RuntimeError

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ sulci.connect()
 # Once your environment has OSS-Connect end-to-end deployed
 # (gateway + dashboard), opt in:
 sulci.connect(prompt=True)
-# - First-run: prints "Visit https://app.sulci.io/oss-connect and enter code: WXYZ-2345"
+# - First-run: prints "Visit https://dashboard.sulci.io/oss-connect and enter code: WXYZ-2345"
 # - User authorizes via browser → SDK gets api_key and persists to ~/.sulci/config
 # - Subsequent runs: step 3 short-circuits, no browser needed
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ this guard, a developer with ``SULCI_API_KEY`` exported in their shell
 (common while iterating on the SDK) would have every test call to
 ``sulci.connect()`` that doesn\'t pass an explicit ``api_key=`` argument
 silently emit telemetry to the production gateway — polluting that
-account\'s request count and showing up on ``app.sulci.io`` as
+account\'s request count and showing up on ``dashboard.sulci.io`` as
 "deployment" rows that are really test runs.
 
 Tests that explicitly want telemetry enabled — e.g. the

--- a/tests/integration/flows/flow_1.py
+++ b/tests/integration/flows/flow_1.py
@@ -11,7 +11,7 @@ locally:
     sulci.connect(api_key="sk-sulci-…")          # one-time, per machine
     cache = Cache(backend="sqlite", ...)           # any local backend
     cache.get(...)                                 # operations stay LOCAL
-    # background thread POSTs 8-WIRE-FIELD telemetry to app.sulci.io
+    # background thread POSTs 8-WIRE-FIELD telemetry to dashboard.sulci.io
 
 This script asserts the SDK side of that contract:
 - explicit-arg api_key resolves through precedence rung 1
@@ -30,7 +30,7 @@ Current-state caveat
 Flow 1's telemetry POST depends on `httpx`, which is in the [cloud]
 extra (bug B1, see flows.md). On a bare `pip install sulci`, the
 telemetry thread silently fails — user sees no error but no deployment
-appears on app.sulci.io. This script doesn't exercise that failure mode
+appears on dashboard.sulci.io. This script doesn't exercise that failure mode
 (we test the contract, not the missing-dep failure).
 """
 from __future__ import annotations

--- a/tests/integration/flows/flow_cli_devicecode.py
+++ b/tests/integration/flows/flow_cli_devicecode.py
@@ -26,7 +26,7 @@ real network, Clerk, or dashboard touched.
 
 Known platform-side gap (P2, was P0 before flow demotion)
 ---------------------------------------------------------
-The platform-side dashboard route (``app.sulci.io/oss-connect``) still
+The platform-side dashboard route (``dashboard.sulci.io/oss-connect``) still
 redirects to the paid-tier key-paste page after Clerk sign-up. This
 script does NOT exercise the dashboard surface, so it PASSes even while
 the dashboard is broken. When the CLI ships, the dashboard route bug
@@ -76,8 +76,8 @@ def _stub_httpx_post(url: str, json=None, timeout=None, **kwargs):
         resp.json = MagicMock(return_value={
             "device_code":              "x" * 43,
             "user_code":                "WXYZ-1234",
-            "verification_uri":         "https://app.sulci.io/oss-connect",
-            "verification_uri_complete":"https://app.sulci.io/oss-connect?code=WXYZ-1234",
+            "verification_uri":         "https://dashboard.sulci.io/oss-connect",
+            "verification_uri_complete":"https://dashboard.sulci.io/oss-connect?code=WXYZ-1234",
             # interval=0 so the SDK's time.sleep is a no-op and the test
             # runs in milliseconds rather than waiting 5s between polls.
             "expires_in":               900,

--- a/tests/test_oss_connect.py
+++ b/tests/test_oss_connect.py
@@ -36,8 +36,8 @@ import pytest
 _DEVICE_CODE_BODY = {
     "device_code":               "fake-device-code-43-chars-padded-pad-pad-padd",
     "user_code":                 "WXYZ-2345",
-    "verification_uri":          "https://app.sulci.io/oss-connect",
-    "verification_uri_complete": "https://app.sulci.io/oss-connect?code=WXYZ-2345",
+    "verification_uri":          "https://dashboard.sulci.io/oss-connect",
+    "verification_uri_complete": "https://dashboard.sulci.io/oss-connect?code=WXYZ-2345",
     "expires_in":                900,
     "interval":                  5,
 }


### PR DESCRIPTION
Renames `app.sulci.io` → `dashboard.sulci.io` (7 files: docs + tests). No engine or benchmark code touched.

## Scope
- Docs/tests only: `README.md`, `CHANGELOG.md`, `LOCAL_SETUP.md`, `tests/conftest.py`, two integration flow tests.
- Preserved: `api.sulci.io` and all sibling hosts.
- Verified `stray app.sulci.io = 0`, `dashboard.sulci.io = 14`, siblings preserved.

## Validation
- `make checkin` green: 505 tests passed, 14/14 examples passed, stateless + context-aware benchmarks on-baseline.
- Agent benchmark separately confirmed deterministic (seed=1729) and matching baseline (`cold_session=0.43`, `p95=31`).

## CI note
If `make checkin` runs in CI, ensure the pipeline clears `benchmark/results/` between runs — a stale `agent_summary.json` can trip a false benchmark drift (seen locally, root-caused to leftover artifacts).