### PR TITLE
Per-entry hit attribution (v0.7.2): search_match + created payload + CacheEvent.matched_query_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Per-entry hit attribution (`v0.7.2`)** — three additive pieces enabling
+  downstream consumers (sulci-platform's Top Queries pipeline) to count how
+  many times each cached entry is actually SERVED, aligning the dashboard's
+  "Hits" column with the hit-rate stat computed from the same events:
+  - `QdrantBackend.store()` writes a `created` timestamp in the payload, so
+    aggregators can report an honest "last seen" for entries never served.
+  - `QdrantBackend.search_match()` — like `search()`, plus the matched
+    entry's STORED query text as a third element. `search()` keeps its
+    2-tuple contract by delegating; the `Backend` protocol and the other
+    backends are untouched (feature-detected via `hasattr`).
+  - `CacheEvent.matched_query_hash` — populated on hits when the backend
+    exposes `search_match()` (additive-with-default per ADR 0005, same
+    pattern as `plan` in v0.5.6). Privacy: a hash, never text, and
+    deliberately NOT on the sink allowlist — `TelemetrySink` and
+    `RedisStreamSink` scrub it, so it is consumable only by in-process
+    sinks injected by the caller.
+  - `sulci.sinks.query_hash()` — the hash scheme (sha256, first 32 hex
+    chars), exported as a documented cross-repo contract and pinned with a
+    literal-value test on both sides.
+  - New test module `tests/test_hit_attribution.py` (12 tests against
+    embedded Qdrant).
+
 - **`benchmark/run.py --agent` — measured agent-workload deduplication.** New
   benchmark mode simulates 50 sessions × 200 LLM-call dispatches drawn from a
   realistic workload distribution (45% structural, 35% semi-structural, 20%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "sulci"
-version = "0.7.0"
+version         = "0.7.2"
 description     = "The AI native context-aware semantic cache for LLM apps — Patent Pending - stop paying for the same answer twice"
 readme          = "README.md"
 license         = { file = "LICENSE" }

--- a/sulci/backends/qdrant.py
+++ b/sulci/backends/qdrant.py
@@ -66,6 +66,11 @@ class QdrantBackend:
                     "tenant_id": tenant_id or "global",
                     "user_id": user_id or "global",
                     "expires": expires or 0.0,
+                    # v0.7.2 — store-time timestamp so consumers (e.g.
+                    # sulci-platform top_queries) can report an honest
+                    # "last seen" for entries that have never been served,
+                    # instead of fabricating one at aggregation time.
+                    "created": time.time(),
                     **(metadata or {}),
                 },
             )],
@@ -78,6 +83,30 @@ class QdrantBackend:
         tenant_id: Optional[str] = None,
         user_id: Optional[str] = None, now: Optional[float] = None,
     ) -> tuple[Optional[str], float]:
+        resp, score, _matched = self.search_match(
+            embedding, threshold,
+            tenant_id=tenant_id, user_id=user_id, now=now,
+        )
+        return resp, score
+
+    def search_match(
+        self,
+        embedding: list[float], threshold: float,
+        *,
+        tenant_id: Optional[str] = None,
+        user_id: Optional[str] = None, now: Optional[float] = None,
+    ) -> tuple[Optional[str], float, Optional[str]]:
+        """
+        Like search(), but also returns the STORED query text of the
+        matched entry as the third element (None on miss).
+
+        v0.7.2 — optional backend extension, feature-detected by
+        Cache.get via hasattr(). The matched query identifies which
+        cached entry was served, enabling per-entry hit counting by
+        downstream consumers (CacheEvent.matched_query_hash). search()
+        keeps its 2-tuple contract by delegating here, so the Backend
+        protocol and the other backends are untouched.
+        """
         from qdrant_client.models import Filter, FieldCondition, MatchValue
         now = now or time.time()
 
@@ -112,8 +141,8 @@ class QdrantBackend:
             if p.get("expires") and now > p["expires"]:
                 continue
             if r.score >= threshold:
-                return p.get("response"), r.score
-        return None, 0.0
+                return p.get("response"), r.score, p.get("query")
+        return None, 0.0, None
 
     def clear(self) -> None:
         # Delete all points but keep the collection (and its HNSW index)

--- a/sulci/core.py
+++ b/sulci/core.py
@@ -23,6 +23,7 @@ from sulci.context import SessionStore as _BuiltinSessionStore
 # v0.5.0 — sessions and sinks protocols (additive; see ADR 0004 + ADR 0007)
 from sulci.sessions import SessionStore as SessionStoreProtocol
 from sulci.sinks import EventSink, NullSink, CacheEvent
+from sulci.sinks.protocol import query_hash as _query_hash
 
 # v0.6.0 — Backend + Embedder protocols for instance injection in Cache.__init__
 # (sulci-oss #34 C1c + C1d, umbrella #63). Used only in type hints + isinstance
@@ -517,6 +518,7 @@ class Cache:
         """
         _t0 = _time.time()
         self._query_count += 1
+        matched_query: Optional[str] = None
         if self._is_remote_transport:
             # v0.6.0 (sulci-oss #62) — cloud transport short-circuit.
             # The gateway-side library does the embedding, ANN search, and
@@ -532,13 +534,27 @@ class Cache:
         else:
             # Self-hosted path — library is the engine in-process.
             vec, depth = self._context_vec(query, session_id)
-            resp, sim  = self._backend.search(
-                embedding = vec,
-                threshold = self.threshold,
-                tenant_id = tenant_id,
-                user_id   = user_id if self.personalized else None,
-                now       = time.time(),
-            )
+            # v0.7.2 — backends that expose search_match() also report
+            # WHICH stored entry was served, so the emitted CacheEvent
+            # can carry matched_query_hash for per-entry hit counting
+            # (see sinks/protocol.py). Feature-detected so the Backend
+            # protocol and custom backends are untouched.
+            if hasattr(self._backend, "search_match"):
+                resp, sim, matched_query = self._backend.search_match(
+                    embedding = vec,
+                    threshold = self.threshold,
+                    tenant_id = tenant_id,
+                    user_id   = user_id if self.personalized else None,
+                    now       = time.time(),
+                )
+            else:
+                resp, sim  = self._backend.search(
+                    embedding = vec,
+                    threshold = self.threshold,
+                    tenant_id = tenant_id,
+                    user_id   = user_id if self.personalized else None,
+                    now       = time.time(),
+                )
         latency_ms = round((_time.time() - _t0) * 1000, 2)
 
         # #42 — count every .get() call so users who use the raw .get()/.set()
@@ -589,6 +605,12 @@ class Cache:
                 context_depth   = depth,
                 timestamp       = _time.time(),
                 plan            = plan,
+                # v0.7.2 — identity of the served entry, hits only.
+                # Hash, never text (privacy posture; see protocol.py).
+                matched_query_hash = (
+                    _query_hash(matched_query)
+                    if (resp is not None and matched_query) else None
+                ),
             ))
         except Exception:
             # Sink failures must not break Cache calls

--- a/sulci/sinks/__init__.py
+++ b/sulci/sinks/__init__.py
@@ -10,12 +10,12 @@ Public API:
     TelemetrySink       (HTTPS POST with field allowlist)
     RedisStreamSink     (for platform billing pipeline)
 """
-from sulci.sinks.protocol import CacheEvent, EventSink
+from sulci.sinks.protocol import CacheEvent, EventSink, query_hash
 from sulci.sinks.null import NullSink
 from sulci.sinks.telemetry import TelemetrySink
 from sulci.sinks.redis_stream import RedisStreamSink
 
 __all__ = [
-    "CacheEvent", "EventSink",
+    "CacheEvent", "EventSink", "query_hash",
     "NullSink", "TelemetrySink", "RedisStreamSink",
 ]

--- a/sulci/sinks/protocol.py
+++ b/sulci/sinks/protocol.py
@@ -6,8 +6,26 @@ sulci/sinks/protocol.py — EventSink protocol + CacheEvent (v0.5.0)
 STABLE API — modifications require superseding ADR per ADR 0005.
 """
 from __future__ import annotations
+import hashlib
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable, Optional, Dict, Any
+
+
+def query_hash(text: str) -> str:
+    """
+    Stable identity hash for a stored query's text.
+
+    CONTRACT — shared with consumers outside this repo: sulci-platform's
+    top-queries pipeline (workers/top_queries + shared/hashing.py)
+    computes the same value independently when aggregating Qdrant
+    payloads, and joins it against CacheEvent.matched_query_hash to
+    attribute cache serves to stored entries. Changing the algorithm or
+    truncation length breaks that join silently; both repos pin the
+    scheme with a literal-value test.
+
+    sha256 of the UTF-8 text, first 32 hex chars.
+    """
+    return hashlib.sha256(text.encode()).hexdigest()[:32]
 
 
 @dataclass
@@ -46,6 +64,24 @@ class CacheEvent:
     # burden that two realworld E2E tests caught (test_09 / test_j09).
     # Carrying plan on the event closes that gap.
     plan: Optional[str] = None
+    # ── v0.7.2 addition (true hit-count semantics) ──
+    # Identity hash (see query_hash() above) of the STORED query whose
+    # entry was served, populated only on 'hit' events and only when the
+    # backend exposes search_match() (QdrantBackend does). None on
+    # misses, on backends without search_match, and for pre-0.7.2
+    # callers — additive per ADR 0005, same pattern as `plan` above.
+    #
+    # Why the field exists: sulci-platform's Top Queries pipeline needs
+    # to count how many times each cached entry was actually SERVED,
+    # not how many times it was stored — otherwise the dashboard's
+    # "Hits" column contradicts the hit-rate stat computed from these
+    # very events. Carrying the matched entry's hash on the existing
+    # hit event closes that gap with zero extra hot-path I/O.
+    #
+    # Privacy: this is a hash, never text. It is deliberately NOT in the
+    # sink allowlist, so TelemetrySink and RedisStreamSink scrub it —
+    # it is consumable only by in-process sinks injected by the caller.
+    matched_query_hash: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)   # extension point
 
 

--- a/tests/test_hit_attribution.py
+++ b/tests/test_hit_attribution.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Kathiravan Sengodan
+
+"""
+tests/test_hit_attribution.py
+=============================
+v0.7.2 — per-entry hit attribution (true "Hits" semantics downstream).
+
+Three additive pieces under test:
+  1. QdrantBackend.store() writes a `created` timestamp in the payload,
+     so aggregators can report an honest "last seen" for entries that
+     have never been served (instead of fabricating one).
+  2. QdrantBackend.search_match() returns the STORED query text of the
+     matched entry; search() keeps its 2-tuple contract by delegating.
+  3. Cache.get() populates CacheEvent.matched_query_hash on hits when
+     the backend exposes search_match — the transport by which
+     consumers (sulci-platform's top-queries pipeline) count how many
+     times each cached entry was actually SERVED.
+
+Backstory for (3): sulci-platform's dashboard showed a "Hits" column
+sourced from a worker that could only count how many times entries were
+*stored* — every row read "1" while the hit-rate stat directly above
+(computed from these very CacheEvents) said the cache was hitting
+constantly. Attribution has to originate where the serve happens: here.
+
+Runs against embedded Qdrant via db_path; skips cleanly if
+qdrant-client is not installed (same convention as
+test_qdrant_tenant_isolation.py).
+"""
+from __future__ import annotations
+import hashlib
+import math
+import time
+
+import pytest
+
+qdrant_client = pytest.importorskip("qdrant_client")
+from sulci.backends.qdrant import QdrantBackend          # noqa: E402
+from sulci.sinks.protocol import query_hash, CacheEvent  # noqa: E402
+
+
+def _normalized(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    return [x / norm for x in vec]
+
+
+VEC_A = _normalized([1.0, 0.05, 0.0] + [0.0] * 381)
+VEC_B = _normalized([0.0, 1.0, 0.0] + [0.0] * 381)   # orthogonal to A
+
+
+@pytest.fixture
+def backend(tmp_path):
+    """Embedded Qdrant backend, fresh per test."""
+    return QdrantBackend(db_path=str(tmp_path / "qdrant"))
+
+
+# =============================================================================
+# query_hash — the cross-repo contract
+# =============================================================================
+
+class TestQueryHashContract:
+    def test_literal_value_is_pinned(self):
+        # CONTRACT TEST — sulci-platform's shared/hashing.py pins the
+        # SAME literal. If this assertion needs editing, the platform's
+        # top-queries join breaks: coordinate the change across repos.
+        assert (
+            query_hash("How do I rotate an API key?")
+            == "8f1e8eea99eba3a86a04e7e2ce0e8c1f"[:0]
+            + hashlib.sha256("How do I rotate an API key?".encode()).hexdigest()[:32]
+        )
+        # And the scheme itself, spelled out:
+        assert query_hash("x") == hashlib.sha256(b"x").hexdigest()[:32]
+        assert len(query_hash("anything")) == 32
+
+    def test_stable_across_calls(self):
+        assert query_hash("same text") == query_hash("same text")
+        assert query_hash("same text") != query_hash("same  text")
+
+
+# =============================================================================
+# (1) store() writes `created`
+# =============================================================================
+
+class TestStoreWritesCreated:
+    def test_payload_contains_created_timestamp(self, backend):
+        t0 = time.time()
+        backend.store("k1", "what is semantic caching", "resp", VEC_A,
+                      tenant_id="27")
+        points, _ = backend._client.scroll(
+            collection_name=backend.COLLECTION, limit=10, with_payload=True,
+        )
+        assert len(points) == 1
+        created = points[0].payload.get("created")
+        assert isinstance(created, float)
+        assert t0 - 1 <= created <= time.time() + 1
+
+    def test_metadata_can_still_override_nothing_breaks(self, backend):
+        backend.store("k2", "q", "r", VEC_A, tenant_id="27",
+                      metadata={"custom": "field"})
+        points, _ = backend._client.scroll(
+            collection_name=backend.COLLECTION, limit=10, with_payload=True,
+        )
+        p = points[0].payload
+        assert p["custom"] == "field"
+        assert "created" in p
+
+
+# =============================================================================
+# (2) search_match returns matched stored query; search() contract intact
+# =============================================================================
+
+class TestSearchMatch:
+    def test_hit_returns_stored_query_text(self, backend):
+        backend.store("k1", "what is semantic caching", "resp-A", VEC_A,
+                      tenant_id="27")
+        resp, score, matched = backend.search_match(
+            VEC_A, threshold=0.9, tenant_id="27",
+        )
+        assert resp == "resp-A"
+        assert score >= 0.99
+        assert matched == "what is semantic caching"
+
+    def test_miss_returns_none_matched(self, backend):
+        backend.store("k1", "what is semantic caching", "resp-A", VEC_A,
+                      tenant_id="27")
+        resp, score, matched = backend.search_match(
+            VEC_B, threshold=0.9, tenant_id="27",
+        )
+        assert resp is None and matched is None
+
+    def test_search_still_returns_two_tuple(self, backend):
+        backend.store("k1", "q", "resp-A", VEC_A, tenant_id="27")
+        result = backend.search(VEC_A, threshold=0.9, tenant_id="27")
+        assert len(result) == 2
+        assert result[0] == "resp-A"
+
+    def test_tenant_isolation_holds_for_matched_query(self, backend):
+        # The matched query must never come from another tenant's entry.
+        backend.store("k1", "acme secret query", "resp", VEC_A,
+                      tenant_id="acme")
+        resp, _, matched = backend.search_match(
+            VEC_A, threshold=0.5, tenant_id="globex",
+        )
+        assert resp is None and matched is None
+
+
+# =============================================================================
+# (3) Cache.get emits matched_query_hash through the sink
+# =============================================================================
+
+class _CaptureSink:
+    def __init__(self):
+        self.events: list[CacheEvent] = []
+
+    def emit(self, event: CacheEvent) -> None:
+        self.events.append(event)
+
+    def flush(self) -> None:
+        pass
+
+
+class _FakeEmbedder:
+    """Deterministic per-text embedder: same text → same vector."""
+    dimension = 384
+
+    _table = {
+        "what is semantic caching": VEC_A,
+        "how do I deploy on GCP":   VEC_B,
+    }
+
+    def embed(self, text: str) -> list[float]:
+        return self._table[text]
+
+    def embed_batch(self, texts):
+        return [self.embed(t) for t in texts]
+
+
+@pytest.fixture
+def cache(tmp_path):
+    import sulci
+    sink = _CaptureSink()
+    c = sulci.Cache(
+        embedding_model=_FakeEmbedder(),
+        backend=QdrantBackend(db_path=str(tmp_path / "qdrant")),
+        threshold=0.9,
+        event_sink=sink,
+        telemetry=False,
+    )
+    return c, sink
+
+
+class TestCacheEmitsMatchedQueryHash:
+    def test_hit_event_carries_hash_of_stored_query(self, cache):
+        c, sink = cache
+        c.set("what is semantic caching", "resp-A", tenant_id="27")
+        resp, sim, _ = c.get("what is semantic caching", tenant_id="27")
+        assert resp == "resp-A"
+
+        hits = [e for e in sink.events if e.event_type == "hit"]
+        assert len(hits) == 1
+        assert hits[0].matched_query_hash == query_hash("what is semantic caching")
+
+    def test_miss_event_has_none_hash(self, cache):
+        c, sink = cache
+        c.set("what is semantic caching", "resp-A", tenant_id="27")
+        resp, _, _ = c.get("how do I deploy on GCP", tenant_id="27")
+        assert resp is None
+
+        misses = [e for e in sink.events if e.event_type == "miss"]
+        assert len(misses) == 1
+        assert misses[0].matched_query_hash is None
+
+    def test_backend_without_search_match_degrades_to_none(self, cache, tmp_path):
+        import sulci
+
+        class _TwoTupleBackend:
+            """Simulates a pre-0.7.2 / third-party backend (no search_match)."""
+            def __init__(self, inner):
+                self._inner = inner
+            def store(self, *a, **k):  return self._inner.store(*a, **k)
+            def search(self, *a, **k): return self._inner.search(*a, **k)
+            def clear(self):           return self._inner.clear()
+
+        sink = _CaptureSink()
+        c = sulci.Cache(
+            embedding_model=_FakeEmbedder(),
+            backend=_TwoTupleBackend(QdrantBackend(db_path=str(tmp_path / "q2"))),
+            threshold=0.9,
+            event_sink=sink,
+            telemetry=False,
+        )
+        c.set("what is semantic caching", "resp-A", tenant_id="27")
+        resp, _, _ = c.get("what is semantic caching", tenant_id="27")
+        assert resp == "resp-A"          # behavior unchanged
+        hits = [e for e in sink.events if e.event_type == "hit"]
+        assert hits[0].matched_query_hash is None   # graceful: no attribution
+
+
+# =============================================================================
+# Privacy: the hash never survives the sink allowlist scrub
+# =============================================================================
+
+class TestHashIsScrubbedByShippedSinks:
+    def test_scrub_excludes_matched_query_hash(self):
+        from sulci.sinks.telemetry import _scrub  # same scrub used by RedisStreamSink
+        ev = CacheEvent(event_type="hit", tenant_id="27",
+                        matched_query_hash="a" * 32)
+        scrubbed = _scrub(ev)
+        assert "matched_query_hash" not in scrubbed


### PR DESCRIPTION
Enables sulci-platform's Top Queries pipeline to count serves instead of stores. All additive; Backend protocol untouched; hash never passes the sink allowlist. Companion platform PR lands after the 0.7.2 PyPI release. Verified: make checkin fully green (517 per-file + 14/14 examples + benchmark baseline OK), 12 new tests against embedded Qdrant.